### PR TITLE
fix(vulkan): harden BF16 runtime dispatch and fallbacks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -208,3 +208,7 @@ tests/             # C++ unit tests
 - For Vulkan Reference implementation read ./llama.cpp/ggml/src/ggml-vulkan/
 - ALWAYS check for existing shaders in ./mlx/backend/vulkan/kernels/ before introducing new onces
 - Shaders should be compiled automatically by CMake; check build output if shaders fail
+- NEVER edit source files outside of mlx/backends/vulkan !! (test files are allowed)
+
+## Github instructions
+- Every PR that you create, should contain the results of qwen3 benchmark by running it @benchmark_qwen3.sh against bf16 anf 8bit quants. either as pr desc or as comment 

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -628,10 +628,12 @@ layout(push_constant) uniform PushConstants {
       } else if (prim_name == "LogAddExp" && x.inputs().size() == 2) {
         auto lhs = get_input_expr(x.inputs()[0]);
         auto rhs = get_input_expr(x.inputs()[1]);
+        std::string type_str = dtype_to_glsl_compute(x.dtype());
         os += fmt::format(
-            "((min({0}, {1}) == -1.0 / 0.0 || max({0}, {1}) == 1.0 / 0.0) ? max({0}, {1}) : (max({0}, {1}) + log(1.0 + exp(min({0}, {1}) - max({0}, {1})))));\n",
+            "((min({0}, {1}) == {2}(-1.0 / 0.0) || max({0}, {1}) == {2}(1.0 / 0.0)) ? max({0}, {1}) : (max({0}, {1}) + log({2}(1.0) + exp(min({0}, {1}) - max({0}, {1})))));\n",
             lhs,
-            rhs);
+            rhs,
+            type_str);
       } else if (is_binary_op && x.inputs().size() == 2) {
         if (is_complex && op == "*") {
           os += fmt::format(
@@ -695,7 +697,8 @@ layout(push_constant) uniform PushConstants {
             x.inputs()[0].dtype() == complex64) {
           fn = "complex_conjugate";
         } else if (op == "sigmoid") {
-          fn = "(1.0 / (1.0 + exp(-";
+          std::string type_str = dtype_to_glsl_compute(x.dtype());
+          fn = fmt::format("({0}(1.0) / ({0}(1.0) + exp(-", type_str);
         }
 
         if ((prim_name == "Real" || prim_name == "Imag") &&

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -291,8 +291,11 @@ bool try_host_vector_cast_copy(
     int64_t in_offset,
     int64_t out_offset,
     const mlx::core::Stream& s) {
-  auto* in_buf = static_cast<mlx::core::vulkan::VulkanBuffer*>(
-      const_cast<void*>(static_cast<const void*>(in.buffer().ptr())));
+  const bool in_is_vulkan = mlx::core::vulkan::is_vulkan_buffer(in.buffer());
+  auto* in_buf = in_is_vulkan
+      ? static_cast<mlx::core::vulkan::VulkanBuffer*>(
+            const_cast<void*>(static_cast<const void*>(in.buffer().ptr())))
+      : nullptr;
   auto* out_buf =
       static_cast<mlx::core::vulkan::VulkanBuffer*>(out.buffer().ptr());
 
@@ -318,6 +321,13 @@ bool try_host_vector_cast_copy(
     mlx::core::vulkan::retain_array_for_stream(s, in);
     mlx::core::vulkan::retain_array_for_stream(s, out);
   };
+
+  if (!in_is_vulkan) {
+    auto* src_ptr = static_cast<const char*>(in.data<void>()) +
+        in_offset * size_of(in.dtype());
+    convert_and_store(src_ptr);
+    return true;
+  }
 
   if (in_buf->mapped_ptr != nullptr) {
     auto* src_ptr = static_cast<const char*>(in_buf->mapped_ptr) +
@@ -727,6 +737,13 @@ void copy_gpu_inplace(
     materialized_in.emplace(in);
     materialized_in->eval();
     source = &*materialized_in;
+  } else {
+    auto data = in.data_shared_ptr();
+    if (data == nullptr || data->buffer.ptr() == nullptr) {
+      materialized_in.emplace(in);
+      materialized_in->wait();
+      source = &*materialized_in;
+    }
   }
 
   auto in_view = make_copy_view(
@@ -855,7 +872,30 @@ void copy_gpu_inplace(
     throw std::runtime_error(oss.str());
   }
 
-  const bool same_buffer = source->buffer().ptr() == out.buffer().ptr();
+  const bool source_is_vulkan = source->data_shared_ptr() != nullptr &&
+      mlx::core::vulkan::is_vulkan_buffer(source->buffer());
+  const bool out_is_vulkan = mlx::core::vulkan::is_vulkan_buffer(out.buffer());
+
+  if (!source_is_vulkan && out_is_vulkan && host_contiguous_copy &&
+      same_dtype) {
+    auto* out_buf = static_cast<vulkan::VulkanBuffer*>(out.buffer().ptr());
+    const auto* src_ptr =
+        static_cast<const char*>(source->data<void>()) + in_view.offset();
+    if (out_buf->mapped_ptr != nullptr) {
+      auto* dst_ptr =
+          static_cast<char*>(out_buf->mapped_ptr) + out_view.offset();
+      std::memcpy(dst_ptr, src_ptr, in_view.nbytes());
+    } else {
+      vulkan::enqueue_owned_staging_upload(
+          s, src_ptr, in_view.nbytes(), out_buf->buffer, out_view.offset());
+      vulkan::retain_array_for_stream(s, *source);
+      vulkan::retain_array_for_stream(s, out);
+    }
+    return;
+  }
+
+  const bool same_buffer = source_is_vulkan && out_is_vulkan &&
+      source->buffer().ptr() == out.buffer().ptr();
   if (segmented_buffer_copy && same_buffer) {
     array staged(out_view.shape(), out_view.dtype(), nullptr, {});
     staged.set_data(mlx::core::allocator::malloc(staged.nbytes()));

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -914,8 +914,11 @@ void copy_gpu_inplace(
     return;
   }
 
-  vk::CommandBuffer cmd_buffer =
-      vulkan::begin_transfer_command_recording(s.index);
+  const bool use_transfer_queue =
+      raw_buffer_copy || contiguous_large_rank_copy || segmented_buffer_copy;
+  vk::CommandBuffer cmd_buffer = use_transfer_queue
+      ? vulkan::begin_transfer_command_recording(s.index)
+      : vulkan::begin_command_recording(s.index);
 
   // Get buffer handles
   auto* in_buf = static_cast<vulkan::VulkanBuffer*>(
@@ -948,7 +951,11 @@ void copy_gpu_inplace(
   } else if (segmented_buffer_copy) {
     const auto copy_regions = make_strided_copy_regions(in_view, out_view);
     if (copy_regions.empty()) {
-      vulkan::end_transfer_command_recording(s.index);
+      if (use_transfer_queue) {
+        vulkan::end_transfer_command_recording(s.index);
+      } else {
+        vulkan::end_command_recording(s.index);
+      }
       throw std::runtime_error(
           "Copy operation failed on Vulkan: unsupported large-offset strided copy.");
     }
@@ -981,7 +988,11 @@ void copy_gpu_inplace(
 
       vulkan::dispatch_unary_op(in_view, out_view, *shader_id, cmd_buffer, s);
     } catch (const std::runtime_error& e) {
-      vulkan::end_transfer_command_recording(s.index);
+      if (use_transfer_queue) {
+        vulkan::end_transfer_command_recording(s.index);
+      } else {
+        vulkan::end_command_recording(s.index);
+      }
       throw std::runtime_error(
           std::string("Copy operation failed on Vulkan: ") + e.what());
     }
@@ -989,7 +1000,11 @@ void copy_gpu_inplace(
     throw std::runtime_error("Unsupported Vulkan copy type.");
   }
 
-  vulkan::end_transfer_command_recording(s.index);
+  if (use_transfer_queue) {
+    vulkan::end_transfer_command_recording(s.index);
+  } else {
+    vulkan::end_command_recording(s.index);
+  }
 }
 
 // Note: The simpler overload copy_gpu_inplace(in, out, ctype, s) is defined in

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -836,7 +836,7 @@ bool try_eval_flash_attention_vulkan(
       float32);
 
   try {
-    const bool use_causal_shader = do_causal && q_len > 1 && q_len != kv_len;
+    const bool use_causal_shader = do_causal && q_len > 1;
 
     if (!try_dispatch_flash_attention_native_vulkan(
             q,

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -784,8 +784,10 @@ bool try_eval_flash_attention_vulkan(
   const uint32_t kv_heads = checked_u32_size(k.shape(1), "flash_attn kv_heads");
   const uint32_t kv_len = checked_u32_size(k.shape(2), "flash_attn kv_len");
   const uint32_t hsv = checked_u32_size(v.shape(3), "flash_attn hsv");
-  const bool use_native_bf16_kv = do_causal && q_len > 1 && q_len == kv_len &&
-      k.dtype() == bfloat16 && v.dtype() == bfloat16;
+  const bool use_native_bf16_kv =
+      vulkan::VulkanContext::get().shader_bfloat16_supported() && do_causal &&
+      q_len > 1 && q_len == kv_len && k.dtype() == bfloat16 &&
+      v.dtype() == bfloat16;
 
   if (batch == 0 || q_heads == 0 || q_len == 0 || hsk == 0 || kv_heads == 0 ||
       kv_len == 0 || hsv == 0 || hsk % 4 != 0 || hsv % 4 != 0 ||

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -777,20 +777,14 @@ bool try_eval_flash_attention_vulkan(
     return x;
   };
 
-  auto debug_eval = [&](array& x, const char* label) {
-    trace_flash_attention_array(label, x);
-    eval(x);
-    trace_flash_attention_array(label, x);
-  };
-
   q = make_contiguous_zero_offset(q);
   k = make_contiguous_zero_offset(k);
   v = make_contiguous_zero_offset(v);
   k = cast_flash_attention_kv_to_f16(k, kFlashAttnKCastScratchLane, s);
   v = cast_flash_attention_kv_to_f16(v, kFlashAttnVCastScratchLane, s);
-  debug_eval(q, "q_ready");
-  debug_eval(k, "k_ready");
-  debug_eval(v, "v_ready");
+  trace_flash_attention_array("q_ready", q);
+  trace_flash_attention_array("k_ready", k);
+  trace_flash_attention_array("v_ready", v);
 
   if (q.dtype() != float32 || k.dtype() != float16 || v.dtype() != float16) {
     return false;
@@ -821,9 +815,15 @@ bool try_eval_flash_attention_vulkan(
     }
 
     array out_final = astype(out_transposed, out.dtype(), s);
-    debug_eval(out_final, "out_final");
+    trace_flash_attention_array("out_final", out_final);
     if (out.shape() == out_final.shape()) {
-      out.copy_shared_buffer(out_final);
+      auto data = out_final.data_shared_ptr();
+      if (data != nullptr && data->buffer.ptr() != nullptr) {
+        out.copy_shared_buffer(out_final);
+      } else {
+        copy_gpu(out_final, out, CopyType::General, s);
+        out.set_status(array::Status::evaluated);
+      }
     } else {
       copy_gpu(out_final, out, CopyType::General, s);
       out.set_status(array::Status::evaluated);

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -104,8 +104,10 @@ array cast_flash_attention_kv_to_f16(
 }
 
 array cast_flash_attention_q_to_f32(const array& x, Stream s) {
+  auto data = x.data_shared_ptr();
   if (x.dtype() == float32 && x.offset() == 0 && x.flags().row_contiguous &&
-      x.strides().back() == 1) {
+      x.strides().back() == 1 && data != nullptr &&
+      data->buffer.ptr() != nullptr) {
     return x;
   }
   array out = vulkan::acquire_scratch_array(
@@ -133,21 +135,38 @@ struct FlashAttentionTuningParams {
 };
 
 vulkan::StaticShaderId flash_attention_main_shader(
-    FlashAttentionTuningParams::Path path) {
+    FlashAttentionTuningParams::Path path,
+    bool use_native_bf16_kv) {
+  const bool kv_bf16 = use_native_bf16_kv;
   if (const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_SHADER");
       env != nullptr) {
     const std::string value(env);
     if (value == "cm1") {
+      if (kv_bf16) {
+        return vulkan::StaticShaderId::flash_attn_f32_f16_bf16;
+      }
       return vulkan::StaticShaderId::flash_attn_f32_f16_f16_cm1;
     }
     if (value == "fp32") {
+      if (kv_bf16) {
+        return vulkan::StaticShaderId::flash_attn_f32_f16_bf16_fp32;
+      }
       return vulkan::StaticShaderId::flash_attn_f32_f16_f16_fp32;
     }
     if (value == "f16acc") {
+      if (kv_bf16) {
+        return vulkan::StaticShaderId::flash_attn_f32_f16_bf16_f16acc;
+      }
       return path == FlashAttentionTuningParams::Path::CoopMat1
           ? vulkan::StaticShaderId::flash_attn_f32_f16_f16_f16acc_cm1
           : vulkan::StaticShaderId::flash_attn_f32_f16_f16_f16acc;
     }
+  }
+  if (kv_bf16) {
+    if (vulkan::VulkanContext::get().shader_float16_supported()) {
+      return vulkan::StaticShaderId::flash_attn_f32_f16_bf16;
+    }
+    return vulkan::StaticShaderId::flash_attn_f32_f16_bf16_fp32;
   }
   if (path == FlashAttentionTuningParams::Path::CoopMat1) {
     return vulkan::StaticShaderId::flash_attn_f32_f16_f16_cm1;
@@ -383,10 +402,13 @@ FlashAttentionExecutionPlan make_flash_attention_execution_plan(
     uint32_t batch,
     bool has_mask,
     bool do_causal,
+    bool use_native_bf16_kv,
     uint32_t q_stride,
     uint32_t k_stride,
     uint32_t v_stride) {
-  auto tuning = get_flash_attention_tuning_params(hsk, hsv, q_len, kv_len);
+  auto tuning = use_native_bf16_kv
+      ? get_flash_attention_tuning_params_scalar(hsk, hsv, q_len, kv_len)
+      : get_flash_attention_tuning_params(hsk, hsv, q_len, kv_len);
   const bool aligned = (kv_len % tuning.block_cols) == 0 &&
       (q_stride & 7u) == 0 && (k_stride & 7u) == 0 && (v_stride & 7u) == 0;
 
@@ -491,7 +513,8 @@ bool try_dispatch_flash_attention_native_vulkan(
     const array* mask,
     bool do_causal,
     array& out_storage,
-    Stream s) {
+    Stream s,
+    bool use_native_bf16_kv) {
   const uint32_t batch = checked_u32_size(q.shape(0), "flash_attn batch");
   const uint32_t q_heads = checked_u32_size(q.shape(1), "flash_attn q_heads");
   const uint32_t q_len = checked_u32_size(q.shape(2), "flash_attn q_len");
@@ -516,11 +539,13 @@ bool try_dispatch_flash_attention_native_vulkan(
       batch,
       has_mask,
       do_causal,
+      use_native_bf16_kv,
       q_stride,
       k_stride,
       v_stride);
   const auto& tuning = plan.tuning;
-  const auto shader_id = flash_attention_main_shader(tuning.path);
+  const auto shader_id =
+      flash_attention_main_shader(tuning.path, use_native_bf16_kv);
   if (tuning.d_split == 0 || tuning.block_rows == 0 || tuning.block_cols == 0 ||
       tuning.row_split == 0 || hsk % tuning.d_split != 0 ||
       hsv % tuning.d_split != 0 ||
@@ -759,6 +784,8 @@ bool try_eval_flash_attention_vulkan(
   const uint32_t kv_heads = checked_u32_size(k.shape(1), "flash_attn kv_heads");
   const uint32_t kv_len = checked_u32_size(k.shape(2), "flash_attn kv_len");
   const uint32_t hsv = checked_u32_size(v.shape(3), "flash_attn hsv");
+  const bool use_native_bf16_kv = do_causal && q_len > 1 && q_len == kv_len &&
+      k.dtype() == bfloat16 && v.dtype() == bfloat16;
 
   if (batch == 0 || q_heads == 0 || q_len == 0 || hsk == 0 || kv_heads == 0 ||
       kv_len == 0 || hsv == 0 || hsk % 4 != 0 || hsv % 4 != 0 ||
@@ -766,7 +793,8 @@ bool try_eval_flash_attention_vulkan(
     return false;
   }
 
-  q = multiply(array(scale, q.dtype()), q, s);
+  q = cast_flash_attention_q_to_f32(q, s);
+  q = multiply(array(scale, float32), q, s);
   q = cast_flash_attention_q_to_f32(q, s);
 
   auto make_contiguous_zero_offset = [&](array x) {
@@ -780,13 +808,22 @@ bool try_eval_flash_attention_vulkan(
   q = make_contiguous_zero_offset(q);
   k = make_contiguous_zero_offset(k);
   v = make_contiguous_zero_offset(v);
-  k = cast_flash_attention_kv_to_f16(k, kFlashAttnKCastScratchLane, s);
-  v = cast_flash_attention_kv_to_f16(v, kFlashAttnVCastScratchLane, s);
+  if (!use_native_bf16_kv) {
+    k = cast_flash_attention_kv_to_f16(k, kFlashAttnKCastScratchLane, s);
+    v = cast_flash_attention_kv_to_f16(v, kFlashAttnVCastScratchLane, s);
+  }
   trace_flash_attention_array("q_ready", q);
   trace_flash_attention_array("k_ready", k);
   trace_flash_attention_array("v_ready", v);
 
-  if (q.dtype() != float32 || k.dtype() != float16 || v.dtype() != float16) {
+  if (q.dtype() != float32) {
+    return false;
+  }
+  if (use_native_bf16_kv) {
+    if (k.dtype() != bfloat16 || v.dtype() != bfloat16) {
+      return false;
+    }
+  } else if (k.dtype() != float16 || v.dtype() != float16) {
     return false;
   }
 
@@ -797,10 +834,17 @@ bool try_eval_flash_attention_vulkan(
       float32);
 
   try {
-    const bool use_causal_shader = do_causal && q_len > 1;
+    const bool use_causal_shader = do_causal && q_len > 1 && q_len != kv_len;
 
     if (!try_dispatch_flash_attention_native_vulkan(
-            q, k, v, nullptr, use_causal_shader, out_storage, s)) {
+            q,
+            k,
+            v,
+            nullptr,
+            use_causal_shader,
+            out_storage,
+            s,
+            use_native_bf16_kv)) {
       return false;
     }
     vulkan::mark_scratch_array_written(s, kFlashAttnOutScratchLane);

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -862,10 +862,12 @@ bool try_eval_flash_attention_vulkan(
 
     array out_final = astype(out_transposed, out.dtype(), s);
     trace_flash_attention_array("out_final", out_final);
+    eval(out_final);
     if (out.shape() == out_final.shape()) {
       auto data = out_final.data_shared_ptr();
       if (data != nullptr && data->buffer.ptr() != nullptr) {
         out.copy_shared_buffer(out_final);
+        out.set_status(array::Status::evaluated);
       } else {
         copy_gpu(out_final, out, CopyType::General, s);
         out.set_status(array::Status::evaluated);

--- a/mlx/backend/vulkan/kernels/flash_attn.comp
+++ b/mlx/backend/vulkan/kernels/flash_attn.comp
@@ -151,17 +151,19 @@ void main() {
     uint32_t mask_opt = 0;
     uint32_t mask_opt_idx = ~0;
     uint32_t mask_opt_bits = 0;
-    const uint32_t n_past = KV - N;
+    const int n_past = int(KV) - int(N);
 
     [[dont_unroll]]
     for (uint32_t j = start_j; j < end_j; ++j) {
+
         if (CAUSAL_ONLY) {
             const uint32_t block_first_col = j * Bc;
             const uint32_t block_last_row = min(i * Br + Br - 1, N - 1);
-            if (block_first_col > n_past + block_last_row) {
+            if (int(block_first_col) > n_past + int(block_last_row)) {
                 continue;
             }
         }
+
         if (MASK_ENABLE) {
             if (USE_MASK_OPT && mask_opt_idx != j / 16) {
                 mask_opt_idx = j / 16;
@@ -326,8 +328,8 @@ void main() {
             [[unroll]] for (uint32_t c = 0; c < cols_per_thread; ++c) {
                 const uint32_t global_col = j * Bc + c * cols_per_iter + col_tid;
                 [[unroll]] for (uint32_t r = 0; r < rows_per_thread; ++r) {
-                    const uint32_t global_row = tile_row(r);
-                    if (global_col > n_past + global_row) {
+                    const uint32_t global_row = i * Br + tile_row(r);
+                    if (int(global_col) > n_past + int(global_row)) {
                         Sf[r][c] = ACC_TYPE(NEG_FLT_MAX_OVER_2);
                     }
                 }

--- a/mlx/backend/vulkan/kernels/flash_attn_cm1.comp
+++ b/mlx/backend/vulkan/kernels/flash_attn_cm1.comp
@@ -144,7 +144,7 @@ void main() {
     uint32_t mask_opt_idx = ~0;
     uint32_t mask_opt_bits = 0;
     f16vec4 mask_cache[Bc * Br / 4 / WorkGroupSize];
-    const uint32_t n_past = KV - N;
+    const int n_past = int(KV) - int(N);
 
     [[dont_unroll]]
     for (uint32_t j = start_j; j < end_j; ++j) {
@@ -152,7 +152,7 @@ void main() {
         if (CAUSAL_ONLY) {
             const uint32_t block_first_col = j * Bc;
             const uint32_t block_last_row = min(i * Br + Br - 1, N - 1);
-            if (block_first_col > n_past + block_last_row) {
+            if (int(block_first_col) > n_past + int(block_last_row)) {
                 continue;
             }
         }
@@ -351,18 +351,18 @@ void main() {
                 uint32_t r = (idx + tid) % (Br / 4);
                 if (idx + tid < Bc * Br / 4 || idx + gl_WorkGroupSize.x <= Bc * Br / 4) {
                     const uint32_t global_col = j * Bc + c;
-                    const uint32_t row0 = r * 4;
+                    const uint32_t row0 = i * Br + r * 4;
                     ACC_TYPEV4 causal = sfsh[c * sfshstride + r];
-                    if (global_col > n_past + row0) {
+                    if (int(global_col) > n_past + int(row0)) {
                         causal[0] = ACC_TYPE(NEG_FLT_MAX_OVER_2);
                     }
-                    if (global_col > n_past + row0 + 1) {
+                    if (int(global_col) > n_past + int(row0) + 1) {
                         causal[1] = ACC_TYPE(NEG_FLT_MAX_OVER_2);
                     }
-                    if (global_col > n_past + row0 + 2) {
+                    if (int(global_col) > n_past + int(row0) + 2) {
                         causal[2] = ACC_TYPE(NEG_FLT_MAX_OVER_2);
                     }
-                    if (global_col > n_past + row0 + 3) {
+                    if (int(global_col) > n_past + int(row0) + 3) {
                         causal[3] = ACC_TYPE(NEG_FLT_MAX_OVER_2);
                     }
                     sfsh[c * sfshstride + r] = causal;

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -211,7 +211,32 @@ bool is_row_contiguous_zero_offset(const array& arr) {
 }
 
 bool has_vulkan_buffer(const array& arr) {
-  return arr.buffer().ptr() != nullptr;
+  auto data = arr.data_shared_ptr();
+  return data != nullptr && data->buffer.ptr() != nullptr;
+}
+
+bool ensure_vulkan_buffer(array& arr, Stream s) {
+  if (has_vulkan_buffer(arr)) {
+    return true;
+  }
+
+  if (arr.has_primitive()) {
+    arr.eval();
+  } else {
+    arr.wait();
+  }
+
+  if (has_vulkan_buffer(arr)) {
+    return true;
+  }
+
+  auto data = arr.data_shared_ptr();
+  if (data == nullptr || data->buffer.ptr() == nullptr) {
+    return false;
+  }
+
+  arr = contiguous_copy_gpu(arr, s);
+  return has_vulkan_buffer(arr);
 }
 
 void zero_initialize_output(array& out, Stream s) {
@@ -411,12 +436,15 @@ bool try_eval_mul_mm_vulkan(
   array out_t = vulkan::acquire_scratch_array(
       s, kMulMmOutScratchLane, out_t_shape, float32);
 
-  if (!has_vulkan_buffer(a) || !has_vulkan_buffer(b_t) ||
-      !has_vulkan_buffer(out_t)) {
+  if (!ensure_vulkan_buffer(a, s) || !ensure_vulkan_buffer(b_t, s) ||
+      !ensure_vulkan_buffer(out_t, s)) {
     if (matmul_debug_enabled()) {
       std::cerr << "[vulkan::mul_mm] missing buffer"
-                << " a=" << has_vulkan_buffer(a)
+                << " a=" << has_vulkan_buffer(a) << " a_status=" << a.status()
+                << " a_has_primitive=" << a.has_primitive()
                 << " b_t=" << has_vulkan_buffer(b_t)
+                << " b_t_status=" << b_t.status()
+                << " b_t_has_primitive=" << b_t.has_primitive()
                 << " out_t=" << has_vulkan_buffer(out_t) << "\n";
     }
     return false;

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -24,8 +24,11 @@ namespace {
 constexpr uint32_t kMulMmTileM = 32;
 constexpr uint32_t kMulMmTileN = 32;
 constexpr uint32_t kMaxGridZ = 65535;
+constexpr char kMatvecMatrixCastScratchLane[] = "matvec.matrix_f16";
 constexpr char kMatvecVectorCastScratchLane[] = "matvec.vec_f16";
 constexpr char kMatvecOutScratchLane[] = "matvec.out_work";
+constexpr char kMulMmACastScratchLane[] = "mul_mm.a_f16";
+constexpr char kMulMmBCastScratchLane[] = "mul_mm.b_f16";
 constexpr char kMulMmOutScratchLane[] = "mul_mm.out_t";
 
 bool is_supported_matmul_dtype(Dtype dtype) {
@@ -119,6 +122,9 @@ std::optional<vulkan::StaticShaderId> matvec_shader_name(
     return vulkan::StaticShaderId::mul_mat_vec_f16_f32_f32;
   }
   if (matrix_dtype == bfloat16 && vec_dtype == float32) {
+    if (!vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+      return std::nullopt;
+    }
     return vulkan::StaticShaderId::mul_mat_vec_bf16_f32_f32;
   }
   if (matrix_dtype == float32 && vec_dtype == float16) {
@@ -128,6 +134,9 @@ std::optional<vulkan::StaticShaderId> matvec_shader_name(
     return vulkan::StaticShaderId::mul_mat_vec_f16_f16_f32;
   }
   if (matrix_dtype == bfloat16 && vec_dtype == float16) {
+    if (!vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+      return std::nullopt;
+    }
     return vulkan::StaticShaderId::mul_mat_vec_bf16_f16_f32;
   }
   return std::nullopt;
@@ -191,6 +200,9 @@ std::vector<vulkan::StaticShaderId> mul_mm_shader_candidates(Dtype dtype) {
           vulkan::StaticShaderId::matmul_f16_fp32,
       };
     case bfloat16:
+      if (!vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+        return {};
+      }
       return {
           vulkan::StaticShaderId::matmul_bf16,
           vulkan::StaticShaderId::matmul_bf16_fp32,
@@ -213,6 +225,13 @@ bool is_row_contiguous_zero_offset(const array& arr) {
 bool has_vulkan_buffer(const array& arr) {
   auto data = arr.data_shared_ptr();
   return data != nullptr && data->buffer.ptr() != nullptr;
+}
+
+array cast_to_float16_scratch(const array& arr, Stream s, const char* lane) {
+  array out = vulkan::acquire_scratch_array(s, lane, arr.shape(), float16);
+  copy_gpu(arr, out, CopyType::General, s);
+  vulkan::mark_scratch_array_written(s, lane);
+  return out;
 }
 
 bool ensure_vulkan_buffer(array& arr, Stream s) {
@@ -321,13 +340,14 @@ bool try_eval_matvec_vulkan(
     return false;
   }
 
+  if (matrix.dtype() == bfloat16 &&
+      !vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+    matrix = cast_to_float16_scratch(matrix, s, kMatvecMatrixCastScratchLane);
+  }
+
   Dtype vec_shader_dtype = vec.dtype();
   if (vec_shader_dtype == bfloat16) {
-    array vec_f16 = vulkan::acquire_scratch_array(
-        s, kMatvecVectorCastScratchLane, vec.shape(), float16);
-    copy_gpu(vec, vec_f16, CopyType::General, s);
-    vulkan::mark_scratch_array_written(s, kMatvecVectorCastScratchLane);
-    vec = vec_f16;
+    vec = cast_to_float16_scratch(vec, s, kMatvecVectorCastScratchLane);
     vec_shader_dtype = float16;
   }
 
@@ -410,6 +430,12 @@ bool try_eval_mul_mm_vulkan(
   if (a.shape(-1) == 0) {
     zero_initialize_output(out, s);
     return true;
+  }
+
+  if (a.dtype() == bfloat16 &&
+      !vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+    a = cast_to_float16_scratch(a, s, kMulMmACastScratchLane);
+    b = cast_to_float16_scratch(b, s, kMulMmBCastScratchLane);
   }
 
   // Keep BF16 inputs in BF16 and dispatch matmul_bf16* directly.

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -64,6 +64,19 @@ array ensure_float32_row_contiguous(const array& arr, Stream s) {
   return out;
 }
 
+array ensure_float16_row_contiguous(const array& arr, Stream s) {
+  if (arr.dtype() == float16 && is_row_contiguous_zero_offset(arr)) {
+    return arr;
+  }
+  array out(arr.shape(), float16, nullptr, {});
+  out.set_data(allocator::malloc(out.nbytes()));
+  copy_gpu(arr, out, CopyType::General, s);
+  if (!is_row_contiguous_zero_offset(out)) {
+    out = contiguous_copy_gpu(out, s);
+  }
+  return out;
+}
+
 Shape expanded_quantized_shape(const array& w, int bits) {
   auto out_shape = w.shape();
   out_shape.back() = w.shape(-1) * 32 / bits;
@@ -295,6 +308,11 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     x_mat = array(flat_shape, x.dtype(), nullptr, {});
     x_mat.copy_shared_buffer(
         x, make_contiguous_strides(flat_shape), x.flags(), x.size());
+  }
+
+  if (x_mat.dtype() == bfloat16 &&
+      !vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+    x_mat = ensure_float16_row_contiguous(x_mat, s);
   }
 
   auto fused_shader = fused_affine_matmul_shader_id(x_mat.dtype());

--- a/mlx/backend/vulkan/rope.cpp
+++ b/mlx/backend/vulkan/rope.cpp
@@ -14,6 +14,12 @@ namespace fast {
 
 namespace {
 
+array cast_to_float16_staging(const array& in, Stream s) {
+  array out(in.shape(), float16, nullptr, {});
+  copy_gpu(in, out, CopyType::General, s);
+  return out;
+}
+
 std::optional<vulkan::StaticShaderId> rope_shader_id(
     Dtype dtype,
     bool traditional) {
@@ -183,9 +189,17 @@ bool try_eval_rope_vulkan(
     x = contiguous_copy_gpu(x, s);
   }
 
+  const bool fallback_to_f16 = x.dtype() == bfloat16 &&
+      !vulkan::VulkanContext::get().shader_bfloat16_supported();
+  if (fallback_to_f16) {
+    x = cast_to_float16_staging(x, s);
+  }
+
   const auto shader_id = rope_shader_id(x.dtype(), traditional);
-  if (!shader_id.has_value() || x.dtype() != out.dtype() || dims <= 0 ||
-      (dims % 2) != 0 || dims > x.shape(-1) || x.offset() != 0) {
+  if (!shader_id.has_value() ||
+      (x.dtype() != out.dtype() &&
+       !(fallback_to_f16 && out.dtype() == bfloat16)) ||
+      dims <= 0 || (dims % 2) != 0 || dims > x.shape(-1) || x.offset() != 0) {
     return false;
   }
 
@@ -211,13 +225,18 @@ bool try_eval_rope_vulkan(
     return false;
   }
 
-  if (out.size() == 0) {
+  array out_target = out;
+  if (fallback_to_f16) {
+    out_target = array(out.shape(), float16, nullptr, {});
+  }
+
+  if (out_target.size() == 0) {
     out.set_data(allocator::malloc(0));
     return true;
   }
 
-  out.set_data(allocator::malloc(out.nbytes()));
-  array out_norm = normalize_rope_output(out, normalized_shape, s);
+  out_target.set_data(allocator::malloc(out_target.nbytes()));
+  array out_norm = normalize_rope_output(out_target, normalized_shape, s);
 
   array x_kernel = swapaxes_in_eval(x_norm, 1, 2);
   array out_kernel = swapaxes_in_eval(out_norm, 1, 2);
@@ -253,6 +272,10 @@ bool try_eval_rope_vulkan(
         pc,
         grid);
     vulkan::end_command_recording(s.index);
+    if (out_target.id() != out.id()) {
+      out.set_data(allocator::malloc(out.nbytes()));
+      copy_gpu(out_target, out, CopyType::General, s);
+    }
     return true;
   } catch (const std::runtime_error& e) {
     if (trace_fallback_enabled()) {

--- a/mlx/backend/vulkan/softmax.cpp
+++ b/mlx/backend/vulkan/softmax.cpp
@@ -222,10 +222,10 @@ bool try_eval_logsumexp_vulkan(
   }
 
   try {
-    const auto shader_id = out.dtype() == bfloat16
+    const auto shader_id = out_work.dtype() == bfloat16
         ? vulkan::StaticShaderId::logsumexp_bf16
-        : (out.dtype() == float16 ? vulkan::StaticShaderId::logsumexp_f16
-                                  : vulkan::StaticShaderId::logsumexp_f32);
+        : (out_work.dtype() == float16 ? vulkan::StaticShaderId::logsumexp_f16
+                                       : vulkan::StaticShaderId::logsumexp_f32);
     auto command_buffer = vulkan::begin_command_recording(s.index);
     vulkan::dispatch_sum_rows_op(in, out_work, shader_id, command_buffer, s);
     vulkan::end_command_recording(s.index);

--- a/mlx/backend/vulkan/softmax.cpp
+++ b/mlx/backend/vulkan/softmax.cpp
@@ -1,11 +1,18 @@
 // Copyright © 2024 Apple Inc.
 
 #include "mlx/backend/vulkan/primitives_utils.h"
+#include "mlx/backend/vulkan/vulkan.h"
 #include "mlx/dtype_utils.h"
 
 namespace mlx::core {
 
 namespace {
+
+array cast_to_float16_staging(const array& in, Stream s) {
+  array out(in.shape(), float16, nullptr, {});
+  copy_gpu(in, out, CopyType::General, s);
+  return out;
+}
 
 bool is_supported_softmax_layout(const array& arr) {
   return arr.flags().contiguous && arr.offset() == 0 && arr.ndim() > 0 &&
@@ -182,16 +189,24 @@ bool try_eval_logsumexp_vulkan(
     return false;
   }
 
+  array out_target = out;
+  if (in.dtype() == bfloat16 &&
+      !vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+    in = cast_to_float16_staging(in, s);
+    out_target = array(out.shape(), float16, nullptr, {});
+  }
+
   if (!in.flags().contiguous || in.offset() != 0 || in.strides().back() != 1 ||
       !is_supported_unary_layout(in)) {
     in = contiguous_copy_gpu(in, s);
   }
 
-  array out_work = out;
-  const bool staged_output = !out.flags().contiguous || out.offset() != 0 ||
-      out.strides().back() != 1 || !is_supported_unary_layout(out);
+  array out_work = out_target;
+  const bool staged_output = !out_target.flags().contiguous ||
+      out_target.offset() != 0 || out_target.strides().back() != 1 ||
+      !is_supported_unary_layout(out_target);
   if (staged_output) {
-    out_work = array(out.shape(), out.dtype(), nullptr, {});
+    out_work = array(out_target.shape(), out_target.dtype(), nullptr, {});
   }
 
   set_unary_output_data(in, out_work);
@@ -215,7 +230,10 @@ bool try_eval_logsumexp_vulkan(
     vulkan::dispatch_sum_rows_op(in, out_work, shader_id, command_buffer, s);
     vulkan::end_command_recording(s.index);
     if (staged_output) {
-      copy_gpu(out_work, out, CopyType::GeneralGeneral, s);
+      copy_gpu(out_work, out_target, CopyType::GeneralGeneral, s);
+    }
+    if (out_target.id() != out.id()) {
+      copy_gpu(out_target, out, CopyType::GeneralGeneral, s);
     }
     return true;
   } catch (const std::runtime_error& e) {

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -87,10 +87,9 @@ QueueFamilyIndices find_queue_families(vk::PhysicalDevice physical_device) {
   QueueFamilyIndices indices;
   indices.compute_family = compute_family;
   indices.transfer_family = transfer_family;
-  indices.has_separate_transfer = (compute_family != transfer_family) ||
-      (queue_families[compute_family].queueCount == 1 &&
-       (queue_families[transfer_family].queueFlags &
-        vk::QueueFlagBits::eTransfer) != vk::QueueFlagBits{});
+  indices.has_separate_transfer = (compute_family != transfer_family) &&
+      (queue_families[transfer_family].queueFlags &
+       vk::QueueFlagBits::eTransfer) != vk::QueueFlagBits{};
 
   return indices;
 }

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -2,8 +2,16 @@
 
 #include "mlx/backend/vulkan/vulkan.h"
 
+#include "mlx/backend/gpu/copy.h"
+#include "mlx/backend/vulkan/allocator.h"
+#include "mlx/backend/vulkan/device.h"
+#include "mlx/backend/vulkan/kernels.h"
+
 #include <algorithm>
+#include <cmath>
+#include <iostream>
 #include <mutex>
+#include <optional>
 #include <stdexcept>
 #include <string>
 #include <vector>
@@ -98,7 +106,63 @@ bool has_device_extension(
       });
 }
 
+bool bf16_capability_debug_enabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("MLX_VULKAN_DEBUG_CAPS");
+    return env != nullptr && std::string(env) != "0";
+  }();
+  return enabled;
+}
+
+std::optional<bool> forced_bf16_capability() {
+  static const std::optional<bool> enabled = []() -> std::optional<bool> {
+    const char* env = std::getenv("MLX_VULKAN_FORCE_BF16_CAPABILITY");
+    if (env == nullptr) {
+      return std::nullopt;
+    }
+
+    const std::string value(env);
+    if (value == "0") {
+      return false;
+    }
+    if (value == "1") {
+      return true;
+    }
+    return std::nullopt;
+  }();
+  return enabled;
+}
+
+bool nearly_equal(float a, float b, float atol = 1e-3f) {
+  return std::fabs(a - b) <= atol;
+}
+
 } // namespace
+
+bool VulkanContext::shader_bfloat16_supported() const {
+  std::call_once(shader_bfloat16_probe_once_, [this]() {
+    if (auto forced = forced_bf16_capability(); forced.has_value()) {
+      shader_bfloat16_supported_ = *forced;
+    } else {
+      shader_bfloat16_supported_ = probe_shader_bfloat16_support();
+    }
+
+    if (bf16_capability_debug_enabled() ||
+        shader_bfloat16_supported_ != shader_bfloat16_reported_supported_) {
+      std::cerr << "[vulkan::caps] shader_bfloat16 extension_present="
+                << shader_bfloat16_extension_present_
+                << " reported_supported=" << shader_bfloat16_reported_supported_
+                << " forced_override="
+                << (forced_bf16_capability().has_value()
+                        ? (*forced_bf16_capability() ? 1 : 0)
+                        : -1)
+                << " runtime_probe_supported=" << shader_bfloat16_supported_
+                << "\n";
+    }
+  });
+
+  return shader_bfloat16_supported_;
+}
 
 bool is_available() {
   try {
@@ -129,6 +193,95 @@ VulkanContext::VulkanContext() = default;
 
 VulkanContext::~VulkanContext() {
   cleanup();
+}
+
+bool VulkanContext::probe_shader_bfloat16_support() const {
+  try {
+    const Stream s{0, Device{Device::gpu, 0}};
+
+    auto make_array = [](Shape shape, Dtype dtype) {
+      array out(std::move(shape), dtype, nullptr, {});
+      out.set_data(allocator::malloc(out.nbytes()));
+      return out;
+    };
+
+    array a = make_array({2, 3}, bfloat16);
+    array b_t = make_array({2, 3}, bfloat16);
+    array out_t = make_array({2, 2}, float32);
+    array out = make_array({2, 2}, float32);
+
+    auto* a_ptr = a.data<bfloat16_t>();
+    a_ptr[0] = 1.0f;
+    a_ptr[1] = 2.0f;
+    a_ptr[2] = 3.0f;
+    a_ptr[3] = 4.0f;
+    a_ptr[4] = 5.0f;
+    a_ptr[5] = 6.0f;
+
+    auto* b_ptr = b_t.data<bfloat16_t>();
+    b_ptr[0] = 1.0f;
+    b_ptr[1] = 0.0f;
+    b_ptr[2] = 1.0f;
+    b_ptr[3] = 0.0f;
+    b_ptr[4] = 1.0f;
+    b_ptr[5] = -1.0f;
+
+    MatmulPushConstants push_constants{};
+    push_constants.M = 2;
+    push_constants.N = 2;
+    push_constants.K = 3;
+    push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
+    push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
+    push_constants.stride_d = static_cast<uint32_t>(out_t.strides(-2));
+    push_constants.batch_stride_a = 6;
+    push_constants.batch_stride_b = 6;
+    push_constants.batch_stride_d = 4;
+    push_constants.num_batches = 1;
+    push_constants.k_split = 3;
+    push_constants.ne02 = 1;
+    push_constants.ne12 = 1;
+    push_constants.broadcast2 = 1;
+    push_constants.broadcast3 = 1;
+    push_constants.padded_N = 2;
+    push_constants.base_work_group_z = 0;
+
+    bool dispatched = false;
+    for (auto shader_id : {
+             StaticShaderId::matmul_bf16,
+             StaticShaderId::matmul_bf16_fp32,
+         }) {
+      try {
+        auto command_buffer = begin_command_recording(s.index);
+        dispatch_mul_mm_op(
+            a,
+            b_t,
+            out_t,
+            shader_id,
+            command_buffer,
+            s,
+            push_constants,
+            {1u, 1u, 1u});
+        end_command_recording(s.index);
+        dispatched = true;
+        break;
+      } catch (const std::runtime_error&) {
+      }
+    }
+
+    if (!dispatched) {
+      synchronize_stream(s);
+      return false;
+    }
+
+    copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
+    synchronize_stream(s);
+
+    const auto* out_ptr = out.data<float>();
+    return nearly_equal(out_ptr[0], 4.0f) && nearly_equal(out_ptr[1], -1.0f) &&
+        nearly_equal(out_ptr[2], 10.0f) && nearly_equal(out_ptr[3], -1.0f);
+  } catch (const std::runtime_error&) {
+    return false;
+  }
 }
 
 void VulkanContext::init() {
@@ -510,7 +663,9 @@ void VulkanContext::init() {
     mem_properties_ = mem_properties;
     is_unified_memory_ = is_unified_memory;
     this->shader_float16_supported_ = shader_float16_supported;
-    this->shader_bfloat16_supported_ = shader_bfloat16_supported;
+    this->shader_bfloat16_extension_present_ = has_shader_bfloat16_ext;
+    this->shader_bfloat16_reported_supported_ = shader_bfloat16_supported;
+    this->shader_bfloat16_supported_ = false;
     this->subgroup_size_control_supported_ = subgroup_size_control_supported;
     this->subgroup_require_full_support_ = subgroup_require_full_support;
     this->subgroup_min_size_ = subgroup_min_size;
@@ -565,6 +720,8 @@ void VulkanContext::cleanup() {
   timeline_value_ = 0;
   is_unified_memory_ = false;
   shader_float16_supported_ = false;
+  shader_bfloat16_extension_present_ = false;
+  shader_bfloat16_reported_supported_ = false;
   shader_bfloat16_supported_ = false;
   subgroup_size_control_supported_ = false;
   subgroup_require_full_support_ = false;

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -147,6 +147,7 @@ void VulkanContext::init() {
   bool has_separate_transfer_queue = false;
   bool is_unified_memory = false;
   bool shader_float16_supported = false;
+  bool shader_bfloat16_supported = false;
   bool subgroup_size_control_supported = false;
   bool subgroup_require_full_support = false;
   uint32_t subgroup_min_size = 0;
@@ -215,6 +216,8 @@ void VulkanContext::init() {
         extensions, VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME);
     const bool has_cooperative_matrix_ext = has_device_extension(
         extensions, VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
+    const bool has_shader_bfloat16_ext =
+        has_device_extension(extensions, VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME);
 
     auto device_properties = physical_device.getProperties();
 
@@ -272,6 +275,7 @@ void VulkanContext::init() {
         supported_pipeline_robustness{};
     vk::PhysicalDeviceCooperativeMatrixFeaturesKHR
         supported_cooperative_matrix{};
+    vk::PhysicalDeviceShaderBfloat16FeaturesKHR supported_shader_bfloat16{};
 
     if (has_subgroup_size_control_ext) {
       supported_shader_float16_int8.pNext = &supported_subgroup_size_control;
@@ -279,17 +283,37 @@ void VulkanContext::init() {
         supported_subgroup_size_control.pNext = &supported_pipeline_robustness;
         if (has_cooperative_matrix_ext) {
           supported_pipeline_robustness.pNext = &supported_cooperative_matrix;
+          if (has_shader_bfloat16_ext) {
+            supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
+          }
+        } else if (has_shader_bfloat16_ext) {
+          supported_pipeline_robustness.pNext = &supported_shader_bfloat16;
         }
       } else if (has_cooperative_matrix_ext) {
         supported_subgroup_size_control.pNext = &supported_cooperative_matrix;
+        if (has_shader_bfloat16_ext) {
+          supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
+        }
+      } else if (has_shader_bfloat16_ext) {
+        supported_shader_float16_int8.pNext = &supported_shader_bfloat16;
       }
     } else if (has_pipeline_robustness_ext) {
       supported_shader_float16_int8.pNext = &supported_pipeline_robustness;
       if (has_cooperative_matrix_ext) {
         supported_pipeline_robustness.pNext = &supported_cooperative_matrix;
+        if (has_shader_bfloat16_ext) {
+          supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
+        }
+      } else if (has_shader_bfloat16_ext) {
+        supported_pipeline_robustness.pNext = &supported_shader_bfloat16;
       }
     } else if (has_cooperative_matrix_ext) {
       supported_shader_float16_int8.pNext = &supported_cooperative_matrix;
+      if (has_shader_bfloat16_ext) {
+        supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
+      }
+    } else if (has_shader_bfloat16_ext) {
+      supported_shader_float16_int8.pNext = &supported_shader_bfloat16;
     }
 
     physical_device.getFeatures2(&supported_features);
@@ -312,6 +336,7 @@ void VulkanContext::init() {
     vk::PhysicalDevicePipelineRobustnessFeaturesEXT
         enabled_pipeline_robustness{};
     vk::PhysicalDeviceCooperativeMatrixFeaturesKHR enabled_cooperative_matrix{};
+    vk::PhysicalDeviceShaderBfloat16FeaturesKHR enabled_shader_bfloat16{};
 
     // Link enabled feature chain (same pattern as supported features)
     if (has_subgroup_size_control_ext) {
@@ -320,17 +345,37 @@ void VulkanContext::init() {
         enabled_subgroup_size_control.pNext = &enabled_pipeline_robustness;
         if (has_cooperative_matrix_ext) {
           enabled_pipeline_robustness.pNext = &enabled_cooperative_matrix;
+          if (has_shader_bfloat16_ext) {
+            enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
+          }
+        } else if (has_shader_bfloat16_ext) {
+          enabled_pipeline_robustness.pNext = &enabled_shader_bfloat16;
         }
       } else if (has_cooperative_matrix_ext) {
         enabled_subgroup_size_control.pNext = &enabled_cooperative_matrix;
+        if (has_shader_bfloat16_ext) {
+          enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
+        }
+      } else if (has_shader_bfloat16_ext) {
+        enabled_shader_float16_int8.pNext = &enabled_shader_bfloat16;
       }
     } else if (has_pipeline_robustness_ext) {
       enabled_shader_float16_int8.pNext = &enabled_pipeline_robustness;
       if (has_cooperative_matrix_ext) {
         enabled_pipeline_robustness.pNext = &enabled_cooperative_matrix;
+        if (has_shader_bfloat16_ext) {
+          enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
+        }
+      } else if (has_shader_bfloat16_ext) {
+        enabled_pipeline_robustness.pNext = &enabled_shader_bfloat16;
       }
     } else if (has_cooperative_matrix_ext) {
       enabled_shader_float16_int8.pNext = &enabled_cooperative_matrix;
+      if (has_shader_bfloat16_ext) {
+        enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
+      }
+    } else if (has_shader_bfloat16_ext) {
+      enabled_shader_float16_int8.pNext = &enabled_shader_bfloat16;
     }
 
     if (supported_vulkan11_features.storageBuffer16BitAccess) {
@@ -342,6 +387,11 @@ void VulkanContext::init() {
     if (supported_shader_float16_int8.shaderFloat16) {
       enabled_shader_float16_int8.shaderFloat16 = VK_TRUE;
       shader_float16_supported = true;
+    }
+    if (has_shader_bfloat16_ext &&
+        supported_shader_bfloat16.shaderBFloat16Type) {
+      enabled_shader_bfloat16.shaderBFloat16Type = VK_TRUE;
+      shader_bfloat16_supported = true;
     }
     if (has_subgroup_size_control_ext &&
         supported_subgroup_size_control.subgroupSizeControl &&
@@ -460,6 +510,7 @@ void VulkanContext::init() {
     mem_properties_ = mem_properties;
     is_unified_memory_ = is_unified_memory;
     this->shader_float16_supported_ = shader_float16_supported;
+    this->shader_bfloat16_supported_ = shader_bfloat16_supported;
     this->subgroup_size_control_supported_ = subgroup_size_control_supported;
     this->subgroup_require_full_support_ = subgroup_require_full_support;
     this->subgroup_min_size_ = subgroup_min_size;
@@ -514,6 +565,7 @@ void VulkanContext::cleanup() {
   timeline_value_ = 0;
   is_unified_memory_ = false;
   shader_float16_supported_ = false;
+  shader_bfloat16_supported_ = false;
   subgroup_size_control_supported_ = false;
   subgroup_require_full_support_ = false;
   subgroup_min_size_ = 0;

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -614,6 +614,9 @@ void VulkanContext::init() {
     if (coopmat_flash_attention_f32acc_supported) {
       device_extensions.push_back(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
     }
+    if (shader_bfloat16_supported) {
+      device_extensions.push_back(VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME);
+    }
 
     vk::DeviceCreateInfo device_create_info;
     device_create_info.flags = vk::DeviceCreateFlags();

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -66,6 +66,9 @@ class VulkanContext {
   bool shader_float16_supported() const {
     return shader_float16_supported_;
   }
+  bool shader_bfloat16_supported() const {
+    return shader_bfloat16_supported_;
+  }
   bool subgroup_size_control_supported() const {
     return subgroup_size_control_supported_;
   }
@@ -117,6 +120,7 @@ class VulkanContext {
   bool initialized_{false};
   bool is_unified_memory_{false};
   bool shader_float16_supported_{false};
+  bool shader_bfloat16_supported_{false};
   bool subgroup_size_control_supported_{false};
   bool subgroup_require_full_support_{false};
   uint32_t subgroup_min_size_{0};

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -4,6 +4,7 @@
 
 #include <atomic>
 #include <memory>
+#include <mutex>
 #include <vector>
 
 // Use C++ Vulkan API instead of C API
@@ -66,9 +67,7 @@ class VulkanContext {
   bool shader_float16_supported() const {
     return shader_float16_supported_;
   }
-  bool shader_bfloat16_supported() const {
-    return shader_bfloat16_supported_;
-  }
+  bool shader_bfloat16_supported() const;
   bool subgroup_size_control_supported() const {
     return subgroup_size_control_supported_;
   }
@@ -102,6 +101,7 @@ class VulkanContext {
 
   void init();
   void cleanup();
+  bool probe_shader_bfloat16_support() const;
 
   // C++ Vulkan API objects (RAII)
   vk::Instance instance_;
@@ -120,7 +120,10 @@ class VulkanContext {
   bool initialized_{false};
   bool is_unified_memory_{false};
   bool shader_float16_supported_{false};
-  bool shader_bfloat16_supported_{false};
+  bool shader_bfloat16_extension_present_{false};
+  bool shader_bfloat16_reported_supported_{false};
+  mutable std::once_flag shader_bfloat16_probe_once_;
+  mutable bool shader_bfloat16_supported_{false};
   bool subgroup_size_control_supported_{false};
   bool subgroup_require_full_support_{false};
   uint32_t subgroup_min_size_{0};


### PR DESCRIPTION
## Summary
- add runtime BF16 shader probing in the Vulkan context so native BF16 kernels stay enabled on drivers that misreport capability bits
- gate Vulkan BF16 arithmetic paths and fall back through FP16 staging for matmul, matvec, logsumexp, RoPE, and fused quantized matmul when BF16 execution is actually unavailable
- keep the BF16 flash-attention path guarded by runtime capability checks and preserve benchmarked inference performance on the RX 7900 XTX stack

## Benchmarks
- BF16 (`mlx-community/Qwen3-0.6B-bf16`, `-p 128 -g 32`)
  - prompt_tps: `467.576`
  - generation_tps: `12.759`
  - peak_memory: `1.236 GB`
- 8bit (`mlx-community/Qwen3-0.6B-8bit`, `-p 128 -g 32`)
  - prompt_tps: `174.523`
  - generation_tps: `11.392`
  - peak_memory: `0.750 GB`

## Notes
- base branch: `feat/vulkan`
- benchmark runs used `OMPI_MCA_accelerator=^rocm` to avoid the known ROCm/OpenMPI exit crash on this machine
- this branch also includes the earlier Vulkan flash-attention BF16 fallback fix already present on the branch history
