### PR TITLE
fix(vulkan): reuse scratch buffers for hot temporaries

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -373,13 +373,24 @@ struct ScratchSlot {
 };
 
 struct StagingScratchOwner {
-  array owner;
+  std::shared_ptr<array::Data> owner;
   size_t bytes{0};
   bool in_use{false};
 };
 
 constexpr char kStagingUploadScratchLane[] = "staging.upload";
 constexpr char kStagingReadbackScratchLane[] = "staging.readback";
+
+std::shared_ptr<array::Data> make_owned_staging_allocation(size_t size) {
+  auto data = std::make_shared<array::Data>(allocator::malloc(size));
+  auto* buffer = static_cast<VulkanBuffer*>(data->buffer.ptr());
+  if (buffer == nullptr || buffer->buffer == VK_NULL_HANDLE ||
+      buffer->mapped_ptr == nullptr) {
+    throw std::runtime_error(
+        "[vulkan::staging] Failed to allocate host-visible staging buffer.");
+  }
+  return data;
+}
 
 const VulkanBuffer* get_vulkan_buffer(
     const std::shared_ptr<array::Data>& data) {
@@ -668,7 +679,7 @@ class VulkanDevice {
     return make_scratch_view(*slot.owner, std::move(shape), dtype);
   }
 
-  array acquire_staging_scratch(
+  std::shared_ptr<array::Data> acquire_staging_scratch(
       const Stream& s,
       const std::string& lane,
       size_t bytes) {
@@ -696,37 +707,57 @@ class VulkanDevice {
     if (selected == nullptr) {
       selected = growable;
       if (selected == nullptr) {
-        owners.push_back(StagingScratchOwner{make_scratch_owner(bytes), bytes, false});
+        owners.push_back(
+            StagingScratchOwner{make_owned_staging_allocation(bytes), bytes, false});
         selected = &owners.back();
       } else {
-        selected->owner = make_scratch_owner(bytes);
+        selected->owner = make_owned_staging_allocation(bytes);
         selected->bytes = bytes;
       }
     }
 
     selected->in_use = true;
-    return make_scratch_view(selected->owner, {static_cast<int>(bytes)}, uint8);
+    return selected->owner;
   }
 
   void release_staging_scratch(
-      int stream_index,
+      StreamData* stream,
       const std::string& lane,
       const array::Data* owner_data) {
-    if (owner_data == nullptr) {
+    if (stream == nullptr || owner_data == nullptr) {
       return;
     }
 
-    auto* stream = get_stream(stream_index);
     auto it = stream->staging_slots.find(lane);
     if (it == stream->staging_slots.end()) {
       return;
     }
 
     for (auto& owner : it->second) {
-      auto data = owner.owner.data_shared_ptr();
-      if (data.get() == owner_data) {
+      if (owner.owner.get() == owner_data) {
         owner.in_use = false;
         return;
+      }
+    }
+  }
+
+  void retain_data(int stream_index, std::shared_ptr<array::Data> data) {
+    if (!data) {
+      return;
+    }
+
+    auto* stream = get_stream(stream_index);
+    if (stream->recording) {
+      if (stream->recording_ref_ids.insert(data.get()).second) {
+        stream->recording_refs.push_back(std::move(data));
+      }
+      return;
+    }
+
+    if (!stream->in_flight_submissions.empty()) {
+      auto& submission = stream->in_flight_submissions.back();
+      if (submission.ref_ids.insert(data.get()).second) {
+        submission.refs.push_back(std::move(data));
       }
     }
   }
@@ -1870,9 +1901,9 @@ void enqueue_owned_staging_upload(
         "[vulkan::enqueue_owned_staging_upload] Null destination buffer.");
   }
 
-  array staging = VulkanDevice::get().acquire_staging_scratch(
+  auto* stream = VulkanDevice::get().get_stream(s.index);
+  auto staging_data = VulkanDevice::get().acquire_staging_scratch(
       s, kStagingUploadScratchLane, size);
-  auto staging_data = staging.data_shared_ptr();
   auto* staging_buffer = get_vulkan_buffer(staging_data);
   if (staging_buffer == nullptr || staging_buffer->buffer == VK_NULL_HANDLE ||
       staging_buffer->mapped_ptr == nullptr) {
@@ -1891,12 +1922,12 @@ void enqueue_owned_staging_upload(
   copy_region.size = static_cast<VkDeviceSize>(size);
   command_buffer.copyBuffer(staging_buffer->buffer, dst_buffer, {copy_region});
 
-  retain_array_for_stream(s, staging);
+  VulkanDevice::get().retain_data(s.index, staging_data);
   add_completion_callback_for_stream(
       s,
-      [stream_index = s.index, staging_data = std::move(staging_data)]() {
+      [stream, staging_data = std::move(staging_data)]() {
         VulkanDevice::get().release_staging_scratch(
-            stream_index, kStagingUploadScratchLane, staging_data.get());
+            stream, kStagingUploadScratchLane, staging_data.get());
       });
   end_transfer_command_recording(s.index);
 }
@@ -1920,9 +1951,9 @@ void enqueue_owned_staging_readback(
         "[vulkan::enqueue_owned_staging_readback] Null source buffer.");
   }
 
-  array staging = VulkanDevice::get().acquire_staging_scratch(
+  auto* stream = VulkanDevice::get().get_stream(s.index);
+  auto staging_data = VulkanDevice::get().acquire_staging_scratch(
       s, kStagingReadbackScratchLane, size);
-  auto staging_data = staging.data_shared_ptr();
   auto* staging_buffer = get_vulkan_buffer(staging_data);
   if (staging_buffer == nullptr || staging_buffer->buffer == VK_NULL_HANDLE ||
       staging_buffer->mapped_ptr == nullptr) {
@@ -1937,17 +1968,17 @@ void enqueue_owned_staging_readback(
   copy_region.size = static_cast<VkDeviceSize>(size);
   command_buffer.copyBuffer(src_buffer, staging_buffer->buffer, {copy_region});
 
-  retain_array_for_stream(s, staging);
+  VulkanDevice::get().retain_data(s.index, staging_data);
   add_completion_callback_for_stream(
       s,
-      [stream_index = s.index,
+      [stream,
        staging_data = std::move(staging_data),
        size,
        completion = std::move(completion)]() {
         auto* completed_buffer = get_vulkan_buffer(staging_data);
         completion(completed_buffer->mapped_ptr, size);
         VulkanDevice::get().release_staging_scratch(
-            stream_index, kStagingReadbackScratchLane, staging_data.get());
+            stream, kStagingReadbackScratchLane, staging_data.get());
       });
   end_transfer_command_recording(s.index);
 }

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -372,16 +372,14 @@ struct ScratchSlot {
   bool needs_barrier{false};
 };
 
-std::shared_ptr<array::Data> make_owned_staging_allocation(size_t size) {
-  auto data = std::make_shared<array::Data>(allocator::malloc(size));
-  auto* buffer = static_cast<VulkanBuffer*>(data->buffer.ptr());
-  if (buffer == nullptr || buffer->buffer == VK_NULL_HANDLE ||
-      buffer->mapped_ptr == nullptr) {
-    throw std::runtime_error(
-        "[vulkan::staging] Failed to allocate host-visible staging buffer.");
-  }
-  return data;
-}
+struct StagingScratchOwner {
+  array owner;
+  size_t bytes{0};
+  bool in_use{false};
+};
+
+constexpr char kStagingUploadScratchLane[] = "staging.upload";
+constexpr char kStagingReadbackScratchLane[] = "staging.readback";
 
 const VulkanBuffer* get_vulkan_buffer(
     const std::shared_ptr<array::Data>& data) {
@@ -440,6 +438,7 @@ struct StreamData {
   std::vector<BufferAccessRange> unsynced_reads;
   std::vector<BufferAccessRange> unsynced_writes;
   std::unordered_map<std::string, ScratchSlot> scratch_slots;
+  std::unordered_map<std::string, std::vector<StagingScratchOwner>> staging_slots;
   std::deque<std::string> recent_primitives;
   uint64_t deferred_total_bytes{0};
   uint64_t deferred_heavy_bytes{0};
@@ -667,6 +666,69 @@ class VulkanDevice {
     }
 
     return make_scratch_view(*slot.owner, std::move(shape), dtype);
+  }
+
+  array acquire_staging_scratch(
+      const Stream& s,
+      const std::string& lane,
+      size_t bytes) {
+    auto* stream = get_stream(s.index);
+    retire_submissions(stream, false);
+
+    auto& owners = stream->staging_slots[lane];
+    StagingScratchOwner* best_fit = nullptr;
+    StagingScratchOwner* growable = nullptr;
+
+    for (auto& owner : owners) {
+      if (owner.in_use) {
+        continue;
+      }
+      if (owner.bytes >= bytes) {
+        if (best_fit == nullptr || owner.bytes < best_fit->bytes) {
+          best_fit = &owner;
+        }
+      } else if (growable == nullptr) {
+        growable = &owner;
+      }
+    }
+
+    StagingScratchOwner* selected = best_fit;
+    if (selected == nullptr) {
+      selected = growable;
+      if (selected == nullptr) {
+        owners.push_back(StagingScratchOwner{make_scratch_owner(bytes), bytes, false});
+        selected = &owners.back();
+      } else {
+        selected->owner = make_scratch_owner(bytes);
+        selected->bytes = bytes;
+      }
+    }
+
+    selected->in_use = true;
+    return make_scratch_view(selected->owner, {static_cast<int>(bytes)}, uint8);
+  }
+
+  void release_staging_scratch(
+      int stream_index,
+      const std::string& lane,
+      const array::Data* owner_data) {
+    if (owner_data == nullptr) {
+      return;
+    }
+
+    auto* stream = get_stream(stream_index);
+    auto it = stream->staging_slots.find(lane);
+    if (it == stream->staging_slots.end()) {
+      return;
+    }
+
+    for (auto& owner : it->second) {
+      auto data = owner.owner.data_shared_ptr();
+      if (data.get() == owner_data) {
+        owner.in_use = false;
+        return;
+      }
+    }
   }
 
   void mark_scratch_written(const Stream& s, const std::string& lane) {
@@ -1808,8 +1870,15 @@ void enqueue_owned_staging_upload(
         "[vulkan::enqueue_owned_staging_upload] Null destination buffer.");
   }
 
-  auto staging = make_owned_staging_allocation(size);
-  auto* staging_buffer = get_vulkan_buffer(staging);
+  array staging = VulkanDevice::get().acquire_staging_scratch(
+      s, kStagingUploadScratchLane, size);
+  auto staging_data = staging.data_shared_ptr();
+  auto* staging_buffer = get_vulkan_buffer(staging_data);
+  if (staging_buffer == nullptr || staging_buffer->buffer == VK_NULL_HANDLE ||
+      staging_buffer->mapped_ptr == nullptr) {
+    throw std::runtime_error(
+        "[vulkan::staging] Failed to acquire host-visible upload buffer.");
+  }
   std::memcpy(
       static_cast<char*>(staging_buffer->mapped_ptr),
       src,
@@ -1822,7 +1891,13 @@ void enqueue_owned_staging_upload(
   copy_region.size = static_cast<VkDeviceSize>(size);
   command_buffer.copyBuffer(staging_buffer->buffer, dst_buffer, {copy_region});
 
-  retain_shared_for_stream(s, std::static_pointer_cast<void>(staging));
+  retain_array_for_stream(s, staging);
+  add_completion_callback_for_stream(
+      s,
+      [stream_index = s.index, staging_data = std::move(staging_data)]() {
+        VulkanDevice::get().release_staging_scratch(
+            stream_index, kStagingUploadScratchLane, staging_data.get());
+      });
   end_transfer_command_recording(s.index);
 }
 
@@ -1845,8 +1920,15 @@ void enqueue_owned_staging_readback(
         "[vulkan::enqueue_owned_staging_readback] Null source buffer.");
   }
 
-  auto staging = make_owned_staging_allocation(size);
-  auto* staging_buffer = get_vulkan_buffer(staging);
+  array staging = VulkanDevice::get().acquire_staging_scratch(
+      s, kStagingReadbackScratchLane, size);
+  auto staging_data = staging.data_shared_ptr();
+  auto* staging_buffer = get_vulkan_buffer(staging_data);
+  if (staging_buffer == nullptr || staging_buffer->buffer == VK_NULL_HANDLE ||
+      staging_buffer->mapped_ptr == nullptr) {
+    throw std::runtime_error(
+        "[vulkan::staging] Failed to acquire host-visible readback buffer.");
+  }
 
   vk::CommandBuffer command_buffer = begin_transfer_command_recording(s.index);
   vk::BufferCopy copy_region;
@@ -1855,14 +1937,17 @@ void enqueue_owned_staging_readback(
   copy_region.size = static_cast<VkDeviceSize>(size);
   command_buffer.copyBuffer(src_buffer, staging_buffer->buffer, {copy_region});
 
-  retain_shared_for_stream(s, std::static_pointer_cast<void>(staging));
+  retain_array_for_stream(s, staging);
   add_completion_callback_for_stream(
       s,
-      [staging = std::move(staging),
+      [stream_index = s.index,
+       staging_data = std::move(staging_data),
        size,
        completion = std::move(completion)]() {
-        auto* completed_buffer = get_vulkan_buffer(staging);
+        auto* completed_buffer = get_vulkan_buffer(staging_data);
         completion(completed_buffer->mapped_ptr, size);
+        VulkanDevice::get().release_staging_scratch(
+            stream_index, kStagingReadbackScratchLane, staging_data.get());
       });
   end_transfer_command_recording(s.index);
 }

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -20,6 +20,10 @@ namespace mlx::core::vulkan {
 
 namespace {
 
+constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
+constexpr char kSoftmaxLargeSumScratchLane[] = "softmax.large.tmp_sum";
+constexpr char kCumsumMultipassScratchLane[] = "cumsum.multipass.tmp";
+
 bool trace_descriptor_epochs_enabled() {
   static const bool enabled = []() {
     if (const char* env = std::getenv("MLX_VULKAN_TRACE_SYNC");
@@ -2261,10 +2265,10 @@ void dispatch_softmax_large_op(
   }
   const int tmp_elements = static_cast<int>(tmp_elements_u64);
 
-  array temp_max({tmp_elements}, float32, nullptr, {});
-  array temp_sum({tmp_elements}, float32, nullptr, {});
-  temp_max.set_data(allocator::malloc(temp_max.nbytes()));
-  temp_sum.set_data(allocator::malloc(temp_sum.nbytes()));
+  array temp_max = acquire_scratch_array(
+      s, kSoftmaxLargeMaxScratchLane, {tmp_elements}, float32);
+  array temp_sum = acquire_scratch_array(
+      s, kSoftmaxLargeSumScratchLane, {tmp_elements}, float32);
 
   const std::array<BoundArray, 6> bound_arrays = {{
       {&in, "src0"},
@@ -2339,6 +2343,9 @@ void dispatch_softmax_large_op(
       s,
       grid,
       {128u, 4u});
+
+  mark_scratch_array_written(s, kSoftmaxLargeMaxScratchLane);
+  mark_scratch_array_written(s, kSoftmaxLargeSumScratchLane);
 }
 
 void dispatch_diag_mask_inf_op(
@@ -2555,8 +2562,8 @@ void dispatch_cumsum_op(
   }
   const int tmp_elements = static_cast<int>(tmp_elements_u64);
 
-  array temp({tmp_elements}, float32, nullptr, {});
-  temp.set_data(allocator::malloc(temp.nbytes()));
+  array temp = acquire_scratch_array(
+      s, kCumsumMultipassScratchLane, {tmp_elements}, float32);
 
   const std::array<BoundArray, 3> bound_arrays = {{
       {&in, "src0"},
@@ -2605,6 +2612,8 @@ void dispatch_cumsum_op(
       s,
       grid,
       {128u, 32u});
+
+  mark_scratch_array_written(s, kCumsumMultipassScratchLane);
 }
 
 void dispatch_mul_mm_op(

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -487,6 +487,20 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
         gpu_out = self._run_on_device(mx.gpu, run_copy).astype(mx.float32)
         self._assert_outputs_close(gpu_out, cpu_out, atol=0.0, rtol=0.0)
 
+    def test_host_staging_reuse_vulkan_gpu(self):
+        for start in range(4):
+            host_src = self._run_on_device(
+                mx.cpu,
+                lambda start=start: mx.arange(start, start + 4096, dtype=mx.float32),
+            )
+
+            def run_copy(host_src=host_src):
+                return host_src[128:640].astype(mx.float16).astype(mx.float32)
+
+            cpu_out = self._run_on_device(mx.cpu, run_copy)
+            gpu_out = self._run_on_device(mx.gpu, run_copy)
+            self._assert_outputs_close(gpu_out, cpu_out, atol=0.0, rtol=0.0)
+
 
 def _cases():
     return [


### PR DESCRIPTION
## Summary
- reuse scratch lanes for large softmax and multipass cumsum temporaries instead of allocating fresh Vulkan buffers per dispatch
- reuse per-stream host-visible staging buffers for upload and readback helpers, releasing each lane only after the submission completes
- add a Vulkan regression test that repeatedly exercises host staging reuse alongside the existing large softmax and cumsum coverage

## Validation
- ./dev.sh build
- ./dev.sh run pytest mlx/python/tests/test_vulkan_ops.py -k 'softmax_large or cumsum or host_source_slice_cast_copy_vulkan_gpu or host_staging_reuse_vulkan_gpu or bf16_copy_with_large_destination_offset_vulkan_gpu'

## Benchmarks
- bf16: prompt_tps=1274.891, generation_tps=7.215, peak_memory=1.923
- 8bit: prompt_tps=736.508, generation_tps=6.617, peak_memory=1.361

## Closes
- Closes goniz/mlx-vulkan#7