### PR TITLE
fix(vulkan): reduce decode copy queue churn

### DIFF
--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -30,6 +30,8 @@ using mlx::core::Shape;
 using mlx::core::Strides;
 namespace vulkan = mlx::core::vulkan;
 
+constexpr size_t kMinTransferQueueCopyBytes = 256 * 1024;
+
 std::string copy_dtype_suffix(Dtype dtype);
 
 bool has_row_contiguous_strides(const mlx::core::array& arr) {
@@ -336,40 +338,17 @@ std::string build_dynamic_general_copy_shader(
   }
   if (!shape.empty()) {
     os << "  uint remaining = linear_idx;\n";
-    os << "  const uint shape_dims[" << shape.size() << "] = uint["
-       << shape.size() << "](";
-    for (size_t i = 0; i < shape.size(); ++i) {
-      if (i > 0) {
-        os << ", ";
-      }
-      os << static_cast<uint32_t>(shape[i]);
+    for (int dim = static_cast<int>(shape.size()) - 1; dim >= 0; --dim) {
+      os << "  {\n";
+      os << "    uint coord = remaining % " << static_cast<uint32_t>(shape[dim])
+         << "u;\n";
+      os << "    remaining /= " << static_cast<uint32_t>(shape[dim]) << "u;\n";
+      os << "    input_index += int64_t(coord) * int64_t(" << i_strides[dim]
+         << ");\n";
+      os << "    output_index += int64_t(coord) * int64_t(" << o_strides[dim]
+         << ");\n";
+      os << "  }\n";
     }
-    os << ");\n";
-    os << "  const int64_t input_strides[" << i_strides.size() << "] = int64_t["
-       << i_strides.size() << "](";
-    for (size_t i = 0; i < i_strides.size(); ++i) {
-      if (i > 0) {
-        os << ", ";
-      }
-      os << i_strides[i];
-    }
-    os << ");\n";
-    os << "  const int64_t output_strides[" << o_strides.size()
-       << "] = int64_t[" << o_strides.size() << "](";
-    for (size_t i = 0; i < o_strides.size(); ++i) {
-      if (i > 0) {
-        os << ", ";
-      }
-      os << o_strides[i];
-    }
-    os << ");\n";
-    os << "  for (int dim = " << (static_cast<int>(shape.size()) - 1)
-       << "; dim >= 0; --dim) {\n";
-    os << "    uint coord = remaining % shape_dims[dim];\n";
-    os << "    remaining /= shape_dims[dim];\n";
-    os << "    input_index += int64_t(coord) * input_strides[dim];\n";
-    os << "    output_index += int64_t(coord) * output_strides[dim];\n";
-    os << "  }\n";
   }
   os << "  output_buf.data[output_index] = input_buf.data[input_index];\n";
   os << "}\n";
@@ -918,6 +897,10 @@ bool trace_copy_dispatch_enabled() {
   return enabled;
 }
 
+bool should_use_transfer_queue_for_copy(size_t copy_bytes) {
+  return copy_bytes >= kMinTransferQueueCopyBytes;
+}
+
 std::optional<vulkan::StaticShaderId> get_copy_shader_id(
     const mlx::core::array& in,
     mlx::core::array& out) {
@@ -1401,8 +1384,13 @@ void copy_gpu_inplace(
     return;
   }
 
+  const size_t copy_bytes =
+      static_cast<size_t>(dispatch_elements) * size_of(out.dtype());
+  // Small copies, especially decode-time KV cache updates, are latency
+  // sensitive and do better when they stay in the current compute submission.
   const bool use_transfer_queue =
-      raw_buffer_copy || contiguous_large_rank_copy || segmented_buffer_copy;
+      (raw_buffer_copy || contiguous_large_rank_copy || segmented_buffer_copy) &&
+      should_use_transfer_queue_for_copy(copy_bytes);
   vk::CommandBuffer cmd_buffer = use_transfer_queue
       ? vulkan::begin_transfer_command_recording(s.index)
       : vulkan::begin_command_recording(s.index);

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -1395,8 +1395,7 @@ class VulkanDevice {
     resources->compute_command_buffer =
         vk_device.allocateCommandBuffers(compute_alloc_info)[0];
 
-    if (has_separate_transfer &&
-        compute_queue_family != transfer_queue_family) {
+    if (has_separate_transfer) {
       vk::CommandPoolCreateInfo transfer_pool_info(
           vk::CommandPoolCreateFlagBits::eResetCommandBuffer,
           transfer_queue_family);

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -26,11 +26,11 @@ constexpr char kCumsumMultipassScratchLane[] = "cumsum.multipass.tmp";
 
 bool trace_descriptor_epochs_enabled() {
   static const bool enabled = []() {
-    if (const char* env = std::getenv("MLX_VULKAN_TRACE_SYNC");
+    if (const char* env = std::getenv("MLX_VULKAN_TRACE_DESCRIPTORS");
         env != nullptr) {
       return std::string(env) != "0";
     }
-    if (const char* env = std::getenv("MLX_VULKAN_TRACE_DESCRIPTORS");
+    if (const char* env = std::getenv("MLX_VULKAN_TRACE_SYNC");
         env != nullptr) {
       return std::string(env) != "0";
     }

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -8,6 +8,7 @@
 #include "mlx/backend/vulkan/kernels.h"
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <mutex>
@@ -22,7 +23,9 @@ namespace {
 
 struct QueueFamilyIndices {
   uint32_t compute_family{0};
+  uint32_t compute_queue_index{0};
   uint32_t transfer_family{0};
+  uint32_t transfer_queue_index{0};
   bool has_separate_transfer{false};
 };
 
@@ -86,10 +89,25 @@ QueueFamilyIndices find_queue_families(vk::PhysicalDevice physical_device) {
 
   QueueFamilyIndices indices;
   indices.compute_family = compute_family;
-  indices.transfer_family = transfer_family;
-  indices.has_separate_transfer = (compute_family != transfer_family) &&
+  indices.transfer_family = compute_family;
+
+  const bool distinct_transfer_family =
+      (compute_family != transfer_family) &&
       (queue_families[transfer_family].queueFlags &
        vk::QueueFlagBits::eTransfer) != vk::QueueFlagBits{};
+  if (distinct_transfer_family) {
+    indices.transfer_family = transfer_family;
+    indices.has_separate_transfer = true;
+    return indices;
+  }
+
+  if ((queue_families[compute_family].queueFlags &
+       vk::QueueFlagBits::eTransfer) != vk::QueueFlagBits{} &&
+      queue_families[compute_family].queueCount > 1) {
+    indices.transfer_family = compute_family;
+    indices.transfer_queue_index = 1;
+    indices.has_separate_transfer = true;
+  }
 
   return indices;
 }
@@ -294,7 +312,9 @@ void VulkanContext::init() {
   vk::Queue compute_queue;
   vk::Queue transfer_queue;
   uint32_t compute_queue_family_index = 0;
+  uint32_t compute_queue_index = 0;
   uint32_t transfer_queue_family_index = 0;
+  uint32_t transfer_queue_index = 0;
   bool has_separate_transfer_queue = false;
   bool is_unified_memory = false;
   bool shader_float16_supported = false;
@@ -344,7 +364,9 @@ void VulkanContext::init() {
         auto indices = find_queue_families(candidate);
         physical_device = candidate;
         compute_queue_family_index = indices.compute_family;
+        compute_queue_index = indices.compute_queue_index;
         transfer_queue_family_index = indices.transfer_family;
+        transfer_queue_index = indices.transfer_queue_index;
         has_separate_transfer_queue = indices.has_separate_transfer;
         found_compute_device = true;
         break;
@@ -389,9 +411,19 @@ void VulkanContext::init() {
     // 4. Create logical device using C++ API
     float queue_priority = 1.0f;
     float queue_priority_low = 0.5f;
+    std::array<float, 2> shared_family_priorities = {
+        queue_priority, queue_priority_low};
     std::vector<vk::DeviceQueueCreateInfo> queue_create_infos;
 
-    if (has_separate_transfer_queue) {
+    if (has_separate_transfer_queue &&
+        compute_queue_family_index == transfer_queue_family_index) {
+      vk::DeviceQueueCreateInfo queue_info(
+          vk::DeviceQueueCreateFlags(),
+          compute_queue_family_index,
+          static_cast<uint32_t>(shared_family_priorities.size()),
+          shared_family_priorities.data());
+      queue_create_infos.push_back(queue_info);
+    } else if (has_separate_transfer_queue) {
       vk::DeviceQueueCreateInfo compute_queue_info(
           vk::DeviceQueueCreateFlags(),
           compute_queue_family_index,
@@ -633,9 +665,10 @@ void VulkanContext::init() {
     device = physical_device.createDevice(device_create_info);
 
     // 5. Get queues and create timeline semaphore
-    compute_queue = device.getQueue(compute_queue_family_index, 0);
+    compute_queue = device.getQueue(compute_queue_family_index, compute_queue_index);
     if (has_separate_transfer_queue) {
-      transfer_queue = device.getQueue(transfer_queue_family_index, 0);
+      transfer_queue =
+          device.getQueue(transfer_queue_family_index, transfer_queue_index);
     } else {
       transfer_queue = compute_queue;
     }


### PR DESCRIPTION
## Summary
- keep small latency-sensitive Vulkan copies on the compute queue so decode does not bounce between compute and transfer for tiny updates
- add same-family dual-queue selection so devices with multiple queues in one family can still use a distinct transfer queue
- allow sync tracing to disable descriptor spam explicitly, which makes bounded trace runs usable again

Closes goniz/mlx-vulkan#1.

## Benchmark
`./dev.sh benchmark bf16`

- prompt_tps=1274.035
- generation_tps=7.279
- peak_memory=1.923
