### PR TITLE
fix(vulkan): cast int64_t indices to int in dynamic_general_copy shader

### DIFF
--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -350,7 +350,7 @@ std::string build_dynamic_general_copy_shader(
       os << "  }\n";
     }
   }
-  os << "  output_buf.data[output_index] = input_buf.data[input_index];\n";
+  os << "  output_buf.data[uint(output_index)] = input_buf.data[uint(input_index)];\n";
   os << "}\n";
   return os.str();
 }


### PR DESCRIPTION
## Summary
Fixes GLSL compilation error in `dynamic_general_copy` shader when handling 5D slice updates.

## Problem
The `dynamic_general_copy` shader was using `int64_t` values directly as array indices, but GLSL requires scalar integer types (`int` or `uint`) for array indexing. This caused the following error:
```
dynamic_general_copy_f32_...:29: error: '[]' : scalar integer expression required
```

## Solution
Cast `int64_t` indices to `uint` when accessing buffer arrays:
```cpp
// Before
output_buf.data[output_index] = input_buf.data[input_index];

// After
output_buf.data[uint(output_index)] = input_buf.data[uint(input_index)];
```

**Why `uint` instead of `int`:** The shader path explicitly allows up to 2^32-1 elements (dispatch_dynamic_general_copy only rejects > uint32_t::max()). Using `int()` would truncate valid positive indices above 2^31-1, causing silent misaddressing on large copies. `uint()` properly preserves the full range up to 2^32-1.

## Testing
- All 119 Vulkan tests pass
- Specifically fixes `test_dynamic_slice_update_5d_regression`

## Benchmarks (Qwen3 0.6B)

### BF16
```
Averages: prompt_tps=1271.256, generation_tps=7.042, peak_memory=1.923
```

### 8-bit Quantized
```
Averages: prompt_tps=738.084, generation_tps=6.626, peak_memory=1.361
```

Closes goniz/mlx-vulkan#13