### PR TITLE
fix(vulkan): tune matmul dispatch and split-K reduction

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -55,17 +55,18 @@ void hash_combine(size_t& seed, const T& value) {
       std::hash<T>{}(value) + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
 }
 
-const std::vector<uint32_t>& matmul_specialization_constants() {
+std::vector<uint32_t> matmul_specialization_constants(
+    const std::vector<uint32_t>& selected_spec) {
   // Conservative matmul tile that avoids relying on device-specific tuning.
   // constant_id mapping in mul_mm.comp:
   //   0: BLOCK_SIZE, 1: BM, 2: BN, 3: BK, 4: WM, 5: WN,
   //   6: WMITER, 7: TM, 8: TN, 9: TK, 10: WARP
   static const std::vector<uint32_t> kDefaultSpec = {
       32, 32, 32, 16, 32, 32, 2, 2, 2, 1, 32};
-  static const std::vector<uint32_t> kSpec = []() {
+  static const std::vector<uint32_t> kEnvSpec = []() {
     const char* env = std::getenv("MLX_VULKAN_MATMUL_SPEC");
     if (env == nullptr || std::strlen(env) == 0) {
-      return kDefaultSpec;
+      return std::vector<uint32_t>{};
     }
 
     std::vector<uint32_t> parsed;
@@ -83,11 +84,17 @@ const std::vector<uint32_t>& matmul_specialization_constants() {
       }
     }
     if (parsed.size() != kDefaultSpec.size()) {
-      return kDefaultSpec;
+      return std::vector<uint32_t>{};
     }
     return parsed;
   }();
-  return kSpec;
+  if (!kEnvSpec.empty()) {
+    return kEnvSpec;
+  }
+  if (selected_spec.size() == kDefaultSpec.size()) {
+    return selected_spec;
+  }
+  return kDefaultSpec;
 }
 
 VkDescriptorSetLayoutBinding make_storage_buffer_binding(uint32_t binding) {
@@ -190,6 +197,13 @@ PipelineCreationOptions pipeline_creation_options(
       options.require_full_subgroups = true;
       options.required_subgroup_size = specialization_constants[8];
     }
+  }
+
+  if (starts_with(shader_name, "matmul_") &&
+      specialization_constants.size() > 10 &&
+      specialization_constants[10] != 0) {
+    options.require_full_subgroups = true;
+    options.required_subgroup_size = specialization_constants[10];
   }
 
   return options;
@@ -313,6 +327,7 @@ enum class KernelSpecId {
   CumsumMultipass,
   MatVec,
   Matmul,
+  MatmulSplitKReduce,
   RandomBits,
   Gather,
   GatherAxis,
@@ -351,7 +366,7 @@ KernelSpec make_kernel_spec(
       grid_kind};
 }
 
-const std::array<KernelSpec, 28> kKernelSpecs = {
+const std::array<KernelSpec, 29> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2},
         sizeof(BinaryPushConstants),
@@ -411,6 +426,10 @@ const std::array<KernelSpec, 28> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2},
         sizeof(MatmulPushConstants),
+        DispatchGridKind::Linear1D),
+    make_kernel_spec(
+        {0, 1},
+        sizeof(MatmulSplitKReducePushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
         {0, 1},
@@ -1946,8 +1965,10 @@ void dispatch_norm_op(
     const Stream& s,
     float eps) {
   const uint32_t axis_size = checked_u32(in.shape(in.ndim() - 1), "norm axis");
-  const uint32_t row_count = axis_size == 0 ? 0 : checked_u32(out.size() / axis_size, "norm rows");
-  const auto push_constants = make_generic_push_constants(axis_size, eps, 0.0f, 0.0f, 0.0f);
+  const uint32_t row_count =
+      axis_size == 0 ? 0 : checked_u32(out.size() / axis_size, "norm rows");
+  const auto push_constants =
+      make_generic_push_constants(axis_size, eps, 0.0f, 0.0f, 0.0f);
   const uint32_t grid_x = std::min<uint32_t>(row_count, 512u);
   const uint32_t grid_y = std::min<uint32_t>((row_count + 511u) / 512u, 512u);
   const uint32_t grid_z = (row_count + 262144u - 1u) / 262144u;
@@ -1976,7 +1997,7 @@ void dispatch_layer_norm_affine_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const LayerNormAffinePushConstants& push_constants) {
-    const std::array<BoundArray, 4> bound_arrays = {{
+  const std::array<BoundArray, 4> bound_arrays = {{
       {&x, "src0"},
       {&weight, "src1"},
       {&bias, "src2"},
@@ -2176,24 +2197,28 @@ void dispatch_softmax_back_op(
     return;
   }
 
-  if (grad.ndim() == 0 || grad.shape() != y.shape() || grad.shape() != out.shape()) {
+  if (grad.ndim() == 0 || grad.shape() != y.shape() ||
+      grad.shape() != out.shape()) {
     throw std::runtime_error(
         "[vulkan::kernels] SoftmaxBack requires matching non-scalar shapes.");
   }
 
-  const uint32_t row_width = checked_u32(out.shape(out.ndim() - 1), "softmax_back KX");
+  const uint32_t row_width =
+      checked_u32(out.shape(out.ndim() - 1), "softmax_back KX");
   if (row_width == 0) {
     throw std::runtime_error(
         "[vulkan::kernels] SoftmaxBack requires non-zero KX.");
   }
 
-  const uint32_t total_elements = checked_u32(out.size(), "softmax_back elements");
+  const uint32_t total_elements =
+      checked_u32(out.size(), "softmax_back elements");
   if (total_elements % row_width != 0) {
     throw std::runtime_error(
         "[vulkan::kernels] SoftmaxBack elements are not divisible by KX.");
   }
   const uint32_t row_count = total_elements / row_width;
-  auto push_constants = make_generic_push_constants(row_width, scale, 0.0f, 0.0f, 0.0f);
+  auto push_constants =
+      make_generic_push_constants(row_width, scale, 0.0f, 0.0f, 0.0f);
   push_constants.KY = row_count;
 
   const std::array<BoundArray, 3> bound_arrays = {{
@@ -2624,7 +2649,8 @@ void dispatch_mul_mm_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const MatmulPushConstants& push_constants,
-    const std::array<uint32_t, 3>& grid) {
+    const std::array<uint32_t, 3>& grid,
+    const std::vector<uint32_t>& specialization_constants) {
   if (a.ndim() < 2 || b.ndim() < 2 || out.ndim() < 2) {
     throw std::runtime_error(
         "[vulkan::kernels] mul_mm dispatch requires rank >= 2 tensors.");
@@ -2655,7 +2681,38 @@ void dispatch_mul_mm_op(
       cmd_buffer,
       s,
       grid,
-      matmul_specialization_constants());
+      matmul_specialization_constants(specialization_constants));
+}
+
+void dispatch_matmul_split_k_reduce_op(
+    const array& in,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const MatmulSplitKReducePushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid,
+    const std::vector<uint32_t>& specialization_constants) {
+  if (in.nbytes() == 0 || out.nbytes() == 0) {
+    return;
+  }
+
+  const std::array<BoundArray, 2> bound_arrays = {{
+      {&in, "src"},
+      {&out, "dst"},
+  }};
+  const uint32_t num_elements = checked_mul_u32(
+      push_constants.ne, 1u, "matmul split-k reduce output elements");
+  dispatch_with_spec(
+      shader_id,
+      KernelSpecId::MatmulSplitKReduce,
+      bound_arrays,
+      push_constants,
+      num_elements,
+      cmd_buffer,
+      s,
+      grid,
+      specialization_constants);
 }
 
 void dispatch_mul_mat_vec_op(
@@ -3194,7 +3251,7 @@ void dispatch_fused_affine_matmul_op(
       cmd_buffer,
       s,
       grid,
-      matmul_specialization_constants());
+      matmul_specialization_constants({}));
 }
 
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -424,6 +424,11 @@ struct MatmulPushConstants {
   uint32_t padded_N;
 };
 
+struct MatmulSplitKReducePushConstants {
+  uint32_t ne;
+  uint32_t k_num;
+};
+
 struct MatVecPushConstants {
   uint32_t ncols;
   uint32_t stride_a;
@@ -725,7 +730,18 @@ void dispatch_mul_mm_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const MatmulPushConstants& push_constants,
-    const std::array<uint32_t, 3>& grid);
+    const std::array<uint32_t, 3>& grid,
+    const std::vector<uint32_t>& specialization_constants = {});
+
+void dispatch_matmul_split_k_reduce_op(
+    const array& in,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const MatmulSplitKReducePushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid,
+    const std::vector<uint32_t>& specialization_constants = {});
 
 void dispatch_mul_mat_vec_op(
     const array& matrix,

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -1,7 +1,7 @@
 // Copyright © 2024 Apple Inc.
 
-#include "mlx/backend/common/broadcasting.h"
 #include "mlx/backend/common/matmul.h"
+#include "mlx/backend/common/broadcasting.h"
 #include "mlx/backend/gpu/copy.h"
 #include "mlx/backend/gpu/eval.h"
 #include "mlx/backend/vulkan/allocator.h"
@@ -12,6 +12,7 @@
 #include "mlx/primitives.h"
 #include "mlx/utils.h"
 
+#include <array>
 #include <atomic>
 #include <cstdlib>
 #include <iostream>
@@ -23,8 +24,6 @@ namespace mlx::core {
 
 namespace {
 
-constexpr uint32_t kMulMmTileM = 32;
-constexpr uint32_t kMulMmTileN = 32;
 constexpr uint32_t kMaxGridZ = 65535;
 constexpr char kMatvecMatrixCastScratchLane[] = "matvec.matrix_f16";
 constexpr char kMatvecVectorCastScratchLane[] = "matvec.vec_f16";
@@ -32,9 +31,32 @@ constexpr char kMatvecOutScratchLane[] = "matvec.out_work";
 constexpr char kMulMmACastScratchLane[] = "mul_mm.a_f16";
 constexpr char kMulMmBCastScratchLane[] = "mul_mm.b_f16";
 constexpr char kMulMmOutScratchLane[] = "mul_mm.out_t";
+constexpr char kMulMmSplitKScratchLane[] = "mul_mm.split_k";
 
 bool is_supported_matmul_dtype(Dtype dtype) {
   return dtype == float32 || dtype == float16 || dtype == bfloat16;
+}
+
+void insert_compute_barrier(VkCommandBuffer command_buffer) {
+  VkMemoryBarrier barrier{};
+  barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+  barrier.srcAccessMask =
+      static_cast<VkAccessFlags>(vk::AccessFlagBits::eShaderWrite);
+  barrier.dstAccessMask = static_cast<VkAccessFlags>(
+      vk::AccessFlagBits::eShaderRead | vk::AccessFlagBits::eShaderWrite);
+  vkCmdPipelineBarrier(
+      command_buffer,
+      static_cast<VkPipelineStageFlags>(
+          vk::PipelineStageFlagBits::eComputeShader),
+      static_cast<VkPipelineStageFlags>(
+          vk::PipelineStageFlagBits::eComputeShader),
+      0,
+      1,
+      &barrier,
+      0,
+      nullptr,
+      0,
+      nullptr);
 }
 
 bool matmul_debug_enabled() {
@@ -194,21 +216,61 @@ std::vector<vulkan::StaticShaderId> matvec_shader_candidates(
   return {};
 }
 
-std::vector<vulkan::StaticShaderId> mul_mm_shader_candidates(Dtype dtype) {
+enum class MatmulFamily : uint8_t {
+  Small,
+  Medium,
+  Large,
+};
+
+struct MatmulFamilySpec {
+  std::array<uint32_t, 11> spec;
+  uint32_t fp32_accum_k_threshold;
+};
+
+struct MatmulProfile {
+  uint32_t preferred_subgroup_size;
+  std::array<MatmulFamilySpec, 3> aligned;
+  std::array<MatmulFamilySpec, 3> unaligned;
+};
+
+struct MatmulDispatchTuning {
+  std::vector<uint32_t> specialization_constants;
+  MatmulFamily family{MatmulFamily::Small};
+  bool aligned{false};
+  bool prefer_fp32_accum{false};
+  uint32_t split_k_threshold{0};
+};
+
+constexpr std::array<uint32_t, 11> kSafeMatmulSpec =
+    {32, 32, 32, 16, 32, 32, 2, 2, 2, 1, 32};
+
+std::vector<vulkan::StaticShaderId> mul_mm_shader_candidates(
+    Dtype dtype,
+    bool prefer_fp32_accum) {
   switch (dtype) {
     case float16:
-      return {
-          vulkan::StaticShaderId::matmul_f16,
-          vulkan::StaticShaderId::matmul_f16_fp32,
-      };
+      return prefer_fp32_accum
+          ? std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_f16_fp32,
+                vulkan::StaticShaderId::matmul_f16,
+            }
+          : std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_f16,
+                vulkan::StaticShaderId::matmul_f16_fp32,
+            };
     case bfloat16:
       if (!vulkan::VulkanContext::get().shader_bfloat16_supported()) {
         return {};
       }
-      return {
-          vulkan::StaticShaderId::matmul_bf16,
-          vulkan::StaticShaderId::matmul_bf16_fp32,
-      };
+      return prefer_fp32_accum
+          ? std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_bf16_fp32,
+                vulkan::StaticShaderId::matmul_bf16,
+            }
+          : std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_bf16,
+                vulkan::StaticShaderId::matmul_bf16_fp32,
+            };
     case float32:
       return {
           vulkan::StaticShaderId::matmul_f32_f32_fp32,
@@ -217,6 +279,139 @@ std::vector<vulkan::StaticShaderId> mul_mm_shader_candidates(Dtype dtype) {
     default:
       return {};
   }
+}
+
+const char* matmul_family_name(MatmulFamily family) {
+  switch (family) {
+    case MatmulFamily::Small:
+      return "small";
+    case MatmulFamily::Medium:
+      return "medium";
+    case MatmulFamily::Large:
+      return "large";
+  }
+  return "small";
+}
+
+MatmulProfile default_matmul_profile(uint32_t subgroup_size) {
+  (void)subgroup_size;
+  return {
+      32,
+      {{{kSafeMatmulSpec, 512},
+        {kSafeMatmulSpec, 1024},
+        {kSafeMatmulSpec, 2048}}},
+      {{{kSafeMatmulSpec, 512},
+        {kSafeMatmulSpec, 768},
+        {kSafeMatmulSpec, 1536}}},
+  };
+}
+
+MatmulProfile matmul_profile_for_device() {
+  const auto& ctx = vulkan::VulkanContext::get();
+  const uint32_t device_subgroup = std::max(ctx.subgroup_size(), 32u);
+
+  switch (ctx.architecture()) {
+    case vulkan::GpuArchitecture::AmdRdna:
+      return {
+          std::max(device_subgroup, 64u),
+          {{{kSafeMatmulSpec, 768},
+            {kSafeMatmulSpec, 1536},
+            {kSafeMatmulSpec, 3072}}},
+          {{{kSafeMatmulSpec, 512},
+            {kSafeMatmulSpec, 1024},
+            {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::Nvidia:
+      return {
+          32,
+          {{{kSafeMatmulSpec, 2048},
+            {kSafeMatmulSpec, 4096},
+            {kSafeMatmulSpec, 8192}}},
+          {{{kSafeMatmulSpec, 1024},
+            {kSafeMatmulSpec, 2048},
+            {kSafeMatmulSpec, 4096}}},
+      };
+    case vulkan::GpuArchitecture::Intel:
+    case vulkan::GpuArchitecture::Apple:
+    case vulkan::GpuArchitecture::Qualcomm:
+      return {
+          32,
+          {{{kSafeMatmulSpec, 768},
+            {kSafeMatmulSpec, 1536},
+            {kSafeMatmulSpec, 3072}}},
+          {{{kSafeMatmulSpec, 512},
+            {kSafeMatmulSpec, 1024},
+            {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::AmdCdna:
+    case vulkan::GpuArchitecture::Unknown:
+      return default_matmul_profile(device_subgroup);
+  }
+  return default_matmul_profile(device_subgroup);
+}
+
+MatmulFamily classify_matmul_family(uint32_t m, uint32_t n, uint32_t k) {
+  const uint64_t mn = static_cast<uint64_t>(m) * static_cast<uint64_t>(n);
+  if (m <= 32 || n <= 32 || mn <= 4096 || k <= 256) {
+    return MatmulFamily::Small;
+  }
+  if (mn <= 65536 || k <= 2048) {
+    return MatmulFamily::Medium;
+  }
+  return MatmulFamily::Large;
+}
+
+bool matmul_inputs_aligned(uint32_t m, uint32_t n, uint32_t k) {
+  return (m % 4u) == 0 && (n % 8u) == 0 && (k % 8u) == 0;
+}
+
+uint32_t round_up_div(uint32_t value, uint32_t divisor) {
+  return (value + divisor - 1u) / divisor;
+}
+
+uint32_t
+choose_split_k(uint32_t k, uint32_t num_batches, uint32_t split_k_threshold) {
+  if (split_k_threshold == 0 || k < split_k_threshold || num_batches > 2u) {
+    return 1u;
+  }
+
+  uint32_t split_k = round_up_div(k, split_k_threshold);
+  split_k = std::clamp(split_k, 1u, 8u);
+
+  if (k / split_k < 64u) {
+    return 1u;
+  }
+
+  return split_k;
+}
+
+MatmulDispatchTuning
+select_matmul_dispatch_tuning(Dtype dtype, uint32_t m, uint32_t n, uint32_t k) {
+  const auto profile = matmul_profile_for_device();
+  const bool aligned = matmul_inputs_aligned(m, n, k);
+  const MatmulFamily family = classify_matmul_family(m, n, k);
+  const size_t family_index = static_cast<size_t>(family);
+  const auto& family_spec =
+      aligned ? profile.aligned[family_index] : profile.unaligned[family_index];
+
+  MatmulDispatchTuning tuning;
+  tuning.specialization_constants.assign(
+      family_spec.spec.begin(), family_spec.spec.end());
+  tuning.family = family;
+  tuning.aligned = aligned;
+  tuning.split_k_threshold = family_spec.fp32_accum_k_threshold;
+  tuning.prefer_fp32_accum = dtype == float32 ||
+      (dtype != float32 && k >= family_spec.fp32_accum_k_threshold);
+
+  if (const auto& ctx = vulkan::VulkanContext::get();
+      !ctx.cooperative_matrix_supported() &&
+      ctx.architecture() == vulkan::GpuArchitecture::AmdRdna &&
+      tuning.specialization_constants.size() > 0) {
+    tuning.specialization_constants[0] =
+        std::min(tuning.specialization_constants[0], 64u);
+  }
+
+  return tuning;
 }
 
 bool is_row_contiguous_zero_offset(const array& arr) {
@@ -505,14 +700,15 @@ bool try_eval_mul_mm_vulkan(
     return false;
   }
 
-  auto shader_candidates = mul_mm_shader_candidates(a.dtype());
-  if (shader_candidates.empty()) {
-    return false;
-  }
-
   const uint32_t m = static_cast<uint32_t>(out.shape(-2));
   const uint32_t n = static_cast<uint32_t>(out.shape(-1));
   const uint32_t k = static_cast<uint32_t>(a.shape(-1));
+  auto tuning = select_matmul_dispatch_tuning(a.dtype(), m, n, k);
+  auto shader_candidates =
+      mul_mm_shader_candidates(a.dtype(), tuning.prefer_fp32_accum);
+  if (shader_candidates.empty()) {
+    return false;
+  }
 
   const uint32_t batch_stride_a =
       static_cast<uint32_t>(a.shape(-2) * a.shape(-1));
@@ -533,6 +729,30 @@ bool try_eval_mul_mm_vulkan(
     return false;
   }
   const uint32_t num_batches = static_cast<uint32_t>(num_batches_u64);
+  const uint32_t split_k =
+      choose_split_k(k, num_batches, tuning.split_k_threshold);
+
+  std::optional<array> split_k_out;
+  if (split_k > 1u) {
+    const uint64_t split_k_elems = static_cast<uint64_t>(batch_stride_d) *
+        static_cast<uint64_t>(num_batches) * static_cast<uint64_t>(split_k);
+    if (split_k_elems >
+        static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+      return false;
+    }
+    split_k_out = vulkan::acquire_scratch_array(
+        s,
+        kMulMmSplitKScratchLane,
+        {
+            static_cast<int>(split_k * num_batches),
+            static_cast<int>(n),
+            static_cast<int>(m),
+        },
+        float32);
+    if (!ensure_vulkan_buffer(*split_k_out, s)) {
+      return false;
+    }
+  }
 
   if (num_batches > 1) {
     ::mlx::core::gpu::synchronize(s);
@@ -549,15 +769,21 @@ bool try_eval_mul_mm_vulkan(
   push_constants.batch_stride_b = batch_stride_b;
   push_constants.batch_stride_d = batch_stride_d;
   push_constants.num_batches = num_batches;
-  push_constants.k_split = k;
+  push_constants.k_split = round_up_div(k, split_k);
   push_constants.ne02 = num_batches;
   push_constants.ne12 = num_batches;
   push_constants.broadcast2 = 1;
   push_constants.broadcast3 = 1;
   push_constants.padded_N = n;
 
-  const uint32_t blocks_m = (m + kMulMmTileM - 1) / kMulMmTileM;
-  const uint32_t blocks_n = (n + kMulMmTileN - 1) / kMulMmTileN;
+  const uint32_t tile_m = tuning.specialization_constants.size() > 1
+      ? tuning.specialization_constants[1]
+      : 32u;
+  const uint32_t tile_n = tuning.specialization_constants.size() > 2
+      ? tuning.specialization_constants[2]
+      : 32u;
+  const uint32_t blocks_m = (m + tile_m - 1) / tile_m;
+  const uint32_t blocks_n = (n + tile_n - 1) / tile_n;
 
   if (matmul_debug_enabled()) {
     std::cerr << "[vulkan::mul_mm] a_shape=" << a.shape()
@@ -568,38 +794,75 @@ bool try_eval_mul_mm_vulkan(
               << "," << n << "," << k
               << " stride(a,b,d)=" << push_constants.stride_a << ","
               << push_constants.stride_b << "," << push_constants.stride_d
-              << " batch=" << num_batches << "\n";
+              << " batch=" << num_batches
+              << " family=" << matmul_family_name(tuning.family)
+              << " aligned=" << tuning.aligned
+              << " subgroup=" << tuning.specialization_constants[10]
+              << " fp32_accum=" << tuning.prefer_fp32_accum
+              << " split_k_threshold=" << tuning.split_k_threshold
+              << " split_k=" << split_k << "\n";
   }
 
   for (const auto shader_id : shader_candidates) {
     bool dispatched = true;
     bool should_recover_stream = false;
-    for (uint32_t base_z = 0; base_z < num_batches; base_z += kMaxGridZ) {
-      const uint32_t chunk_z = std::min(kMaxGridZ, num_batches - base_z);
-      push_constants.base_work_group_z = base_z;
-      const std::array<uint32_t, 3> grid = {blocks_m, blocks_n, chunk_z};
+    try {
+      auto command_buffer = vulkan::begin_command_recording(s.index);
+      for (uint32_t base_z = 0; base_z < num_batches; base_z += kMaxGridZ) {
+        const uint32_t chunk_z = std::min(kMaxGridZ, num_batches - base_z);
+        push_constants.base_work_group_z = base_z;
+        const std::array<uint32_t, 3> grid = {
+            blocks_m * split_k,
+            blocks_n,
+            chunk_z,
+        };
 
-      try {
-        auto command_buffer = vulkan::begin_command_recording(s.index);
         vulkan::dispatch_mul_mm_op(
-            a, b_t, out_t, shader_id, command_buffer, s, push_constants, grid);
-        vulkan::end_command_recording(s.index);
-      } catch (const std::runtime_error& e) {
-        if (matmul_debug_enabled()) {
-          std::cerr << "[vulkan::mul_mm] shader="
-                    << vulkan::static_shader_name(shader_id)
-                    << " failed: " << e.what() << "\n";
-        }
-        const std::string message = e.what();
-        if (message.find("[vulkan::submit_commands]") != std::string::npos ||
-            message.find("VkResult=") != std::string::npos) {
-          should_recover_stream = true;
-        }
-        dispatched = false;
+            a,
+            b_t,
+            split_k_out.has_value() ? *split_k_out : out_t,
+            shader_id,
+            command_buffer,
+            s,
+            push_constants,
+            grid,
+            tuning.specialization_constants);
       }
-      if (!dispatched) {
-        break;
+
+      if (split_k_out.has_value()) {
+        insert_compute_barrier(command_buffer);
+        vulkan::MatmulSplitKReducePushConstants reduce_push_constants{};
+        reduce_push_constants.ne = batch_stride_d * num_batches;
+        reduce_push_constants.k_num = split_k;
+        vulkan::dispatch_matmul_split_k_reduce_op(
+            *split_k_out,
+            out_t,
+            vulkan::StaticShaderId::split_k_reduce,
+            command_buffer,
+            s,
+            reduce_push_constants,
+            {
+                round_up_div(batch_stride_d * num_batches, 256u),
+                1u,
+                1u,
+            },
+            {});
+        vulkan::mark_scratch_array_written(s, kMulMmSplitKScratchLane);
       }
+
+      vulkan::end_command_recording(s.index);
+    } catch (const std::runtime_error& e) {
+      if (matmul_debug_enabled()) {
+        std::cerr << "[vulkan::mul_mm] shader="
+                  << vulkan::static_shader_name(shader_id)
+                  << " failed: " << e.what() << "\n";
+      }
+      const std::string message = e.what();
+      if (message.find("[vulkan::submit_commands]") != std::string::npos ||
+          message.find("VkResult=") != std::string::npos) {
+        should_recover_stream = true;
+      }
+      dispatched = false;
     }
 
     if (dispatched) {

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -842,7 +842,7 @@ bool try_eval_mul_mm_vulkan(
             s,
             reduce_push_constants,
             {
-                round_up_div(batch_stride_d * num_batches, 256u),
+                round_up_div(batch_stride_d * num_batches, 256u * 4u),
                 1u,
                 1u,
             },

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -91,8 +91,7 @@ QueueFamilyIndices find_queue_families(vk::PhysicalDevice physical_device) {
   indices.compute_family = compute_family;
   indices.transfer_family = compute_family;
 
-  const bool distinct_transfer_family =
-      (compute_family != transfer_family) &&
+  const bool distinct_transfer_family = (compute_family != transfer_family) &&
       (queue_families[transfer_family].queueFlags &
        vk::QueueFlagBits::eTransfer) != vk::QueueFlagBits{};
   if (distinct_transfer_family) {
@@ -121,6 +120,33 @@ bool has_device_extension(
       [name](const vk::ExtensionProperties& ext) {
         return std::string(ext.extensionName) == name;
       });
+}
+
+bool device_name_contains(const std::string& name, const char* needle) {
+  return name.find(needle) != std::string::npos;
+}
+
+GpuArchitecture classify_gpu_architecture(
+    uint32_t vendor_id,
+    const std::string& device_name) {
+  switch (vendor_id) {
+    case 0x1002u:
+      if (device_name_contains(device_name, "Instinct") ||
+          device_name_contains(device_name, "MI")) {
+        return GpuArchitecture::AmdCdna;
+      }
+      return GpuArchitecture::AmdRdna;
+    case 0x10DEu:
+      return GpuArchitecture::Nvidia;
+    case 0x8086u:
+      return GpuArchitecture::Intel;
+    case 0x106Bu:
+      return GpuArchitecture::Apple;
+    case 0x5143u:
+      return GpuArchitecture::Qualcomm;
+    default:
+      return GpuArchitecture::Unknown;
+  }
 }
 
 bool bf16_capability_debug_enabled() {
@@ -323,8 +349,13 @@ void VulkanContext::init() {
   bool subgroup_require_full_support = false;
   uint32_t subgroup_min_size = 0;
   uint32_t subgroup_max_size = 0;
+  uint32_t subgroup_size = 0;
   bool pipeline_robustness_supported = false;
+  bool cooperative_matrix_supported = false;
   bool coopmat_flash_attention_f32acc_supported = false;
+  bool integer_dot_product_supported = false;
+  uint32_t vendor_id = 0;
+  GpuArchitecture architecture = GpuArchitecture::Unknown;
   vk::PhysicalDeviceMemoryProperties mem_properties;
   vk::Semaphore timeline_semaphore;
   uint64_t timeline_value = 0;
@@ -393,6 +424,9 @@ void VulkanContext::init() {
         has_device_extension(extensions, VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME);
 
     auto device_properties = physical_device.getProperties();
+    vendor_id = device_properties.vendorID;
+    architecture = classify_gpu_architecture(
+        vendor_id, std::string(device_properties.deviceName));
 
     is_unified_memory =
         (device_properties.deviceType ==
@@ -451,6 +485,9 @@ void VulkanContext::init() {
     vk::PhysicalDeviceShaderFloat16Int8Features supported_shader_float16_int8;
     supported_features.pNext = &supported_vulkan11_features;
     supported_vulkan11_features.pNext = &supported_shader_float16_int8;
+    vk::PhysicalDeviceShaderIntegerDotProductFeatures
+        supported_shader_integer_dot_product{};
+    supported_shader_float16_int8.pNext = &supported_shader_integer_dot_product;
 
     vk::PhysicalDeviceSubgroupSizeControlFeatures
         supported_subgroup_size_control{};
@@ -461,7 +498,8 @@ void VulkanContext::init() {
     vk::PhysicalDeviceShaderBfloat16FeaturesKHR supported_shader_bfloat16{};
 
     if (has_subgroup_size_control_ext) {
-      supported_shader_float16_int8.pNext = &supported_subgroup_size_control;
+      supported_shader_integer_dot_product.pNext =
+          &supported_subgroup_size_control;
       if (has_pipeline_robustness_ext) {
         supported_subgroup_size_control.pNext = &supported_pipeline_robustness;
         if (has_cooperative_matrix_ext) {
@@ -478,10 +516,11 @@ void VulkanContext::init() {
           supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
         }
       } else if (has_shader_bfloat16_ext) {
-        supported_shader_float16_int8.pNext = &supported_shader_bfloat16;
+        supported_shader_integer_dot_product.pNext = &supported_shader_bfloat16;
       }
     } else if (has_pipeline_robustness_ext) {
-      supported_shader_float16_int8.pNext = &supported_pipeline_robustness;
+      supported_shader_integer_dot_product.pNext =
+          &supported_pipeline_robustness;
       if (has_cooperative_matrix_ext) {
         supported_pipeline_robustness.pNext = &supported_cooperative_matrix;
         if (has_shader_bfloat16_ext) {
@@ -491,21 +530,28 @@ void VulkanContext::init() {
         supported_pipeline_robustness.pNext = &supported_shader_bfloat16;
       }
     } else if (has_cooperative_matrix_ext) {
-      supported_shader_float16_int8.pNext = &supported_cooperative_matrix;
+      supported_shader_integer_dot_product.pNext =
+          &supported_cooperative_matrix;
       if (has_shader_bfloat16_ext) {
         supported_cooperative_matrix.pNext = &supported_shader_bfloat16;
       }
     } else if (has_shader_bfloat16_ext) {
-      supported_shader_float16_int8.pNext = &supported_shader_bfloat16;
+      supported_shader_integer_dot_product.pNext = &supported_shader_bfloat16;
     }
 
     physical_device.getFeatures2(&supported_features);
 
     // Query subgroup size control properties
+    vk::PhysicalDeviceSubgroupProperties subgroup_props{};
     vk::PhysicalDeviceSubgroupSizeControlProperties subgroup_size_control_props;
+    vk::PhysicalDeviceShaderIntegerDotProductProperties
+        shader_integer_dot_product_props{};
     vk::PhysicalDeviceProperties2 props2;
-    props2.pNext = &subgroup_size_control_props;
+    props2.pNext = &subgroup_props;
+    subgroup_props.pNext = &subgroup_size_control_props;
+    subgroup_size_control_props.pNext = &shader_integer_dot_product_props;
     physical_device.getProperties2(&props2);
+    subgroup_size = subgroup_props.subgroupSize;
 
     // Build enabled features
     vk::PhysicalDeviceFeatures2 enabled_features;
@@ -513,6 +559,9 @@ void VulkanContext::init() {
     vk::PhysicalDeviceShaderFloat16Int8Features enabled_shader_float16_int8;
     enabled_features.pNext = &enabled_vulkan11_features;
     enabled_vulkan11_features.pNext = &enabled_shader_float16_int8;
+    vk::PhysicalDeviceShaderIntegerDotProductFeatures
+        enabled_shader_integer_dot_product{};
+    enabled_shader_float16_int8.pNext = &enabled_shader_integer_dot_product;
 
     vk::PhysicalDeviceSubgroupSizeControlFeatures
         enabled_subgroup_size_control{};
@@ -523,7 +572,7 @@ void VulkanContext::init() {
 
     // Link enabled feature chain (same pattern as supported features)
     if (has_subgroup_size_control_ext) {
-      enabled_shader_float16_int8.pNext = &enabled_subgroup_size_control;
+      enabled_shader_integer_dot_product.pNext = &enabled_subgroup_size_control;
       if (has_pipeline_robustness_ext) {
         enabled_subgroup_size_control.pNext = &enabled_pipeline_robustness;
         if (has_cooperative_matrix_ext) {
@@ -540,10 +589,10 @@ void VulkanContext::init() {
           enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
         }
       } else if (has_shader_bfloat16_ext) {
-        enabled_shader_float16_int8.pNext = &enabled_shader_bfloat16;
+        enabled_shader_integer_dot_product.pNext = &enabled_shader_bfloat16;
       }
     } else if (has_pipeline_robustness_ext) {
-      enabled_shader_float16_int8.pNext = &enabled_pipeline_robustness;
+      enabled_shader_integer_dot_product.pNext = &enabled_pipeline_robustness;
       if (has_cooperative_matrix_ext) {
         enabled_pipeline_robustness.pNext = &enabled_cooperative_matrix;
         if (has_shader_bfloat16_ext) {
@@ -553,12 +602,12 @@ void VulkanContext::init() {
         enabled_pipeline_robustness.pNext = &enabled_shader_bfloat16;
       }
     } else if (has_cooperative_matrix_ext) {
-      enabled_shader_float16_int8.pNext = &enabled_cooperative_matrix;
+      enabled_shader_integer_dot_product.pNext = &enabled_cooperative_matrix;
       if (has_shader_bfloat16_ext) {
         enabled_cooperative_matrix.pNext = &enabled_shader_bfloat16;
       }
     } else if (has_shader_bfloat16_ext) {
-      enabled_shader_float16_int8.pNext = &enabled_shader_bfloat16;
+      enabled_shader_integer_dot_product.pNext = &enabled_shader_bfloat16;
     }
 
     if (supported_vulkan11_features.storageBuffer16BitAccess) {
@@ -595,9 +644,14 @@ void VulkanContext::init() {
       enabled_pipeline_robustness.pipelineRobustness = VK_TRUE;
       pipeline_robustness_supported = true;
     }
+    if (supported_shader_integer_dot_product.shaderIntegerDotProduct) {
+      enabled_shader_integer_dot_product.shaderIntegerDotProduct = VK_TRUE;
+      integer_dot_product_supported = true;
+    }
     if (has_cooperative_matrix_ext &&
         supported_cooperative_matrix.cooperativeMatrix) {
       enabled_cooperative_matrix.cooperativeMatrix = VK_TRUE;
+      cooperative_matrix_supported = true;
       coopmat_flash_attention_f32acc_supported = false;
 
       // Check for flash attention support
@@ -665,7 +719,8 @@ void VulkanContext::init() {
     device = physical_device.createDevice(device_create_info);
 
     // 5. Get queues and create timeline semaphore
-    compute_queue = device.getQueue(compute_queue_family_index, compute_queue_index);
+    compute_queue =
+        device.getQueue(compute_queue_family_index, compute_queue_index);
     if (has_separate_transfer_queue) {
       transfer_queue =
           device.getQueue(transfer_queue_family_index, transfer_queue_index);
@@ -702,10 +757,15 @@ void VulkanContext::init() {
     this->subgroup_require_full_support_ = subgroup_require_full_support;
     this->subgroup_min_size_ = subgroup_min_size;
     this->subgroup_max_size_ = subgroup_max_size;
+    this->subgroup_size_ = subgroup_size;
     this->pipeline_robustness_supported_ = pipeline_robustness_supported;
+    this->cooperative_matrix_supported_ = cooperative_matrix_supported;
     this->coopmat_flash_attention_f32acc_supported_ =
         coopmat_flash_attention_f32acc_supported &&
         subgroup_require_full_support;
+    this->integer_dot_product_supported_ = integer_dot_product_supported;
+    this->vendor_id_ = vendor_id;
+    this->architecture_ = architecture;
     initialized_ = true;
   } catch (...) {
     // Clean up partially initialized resources on failure
@@ -759,8 +819,13 @@ void VulkanContext::cleanup() {
   subgroup_require_full_support_ = false;
   subgroup_min_size_ = 0;
   subgroup_max_size_ = 0;
+  subgroup_size_ = 0;
   pipeline_robustness_supported_ = false;
+  cooperative_matrix_supported_ = false;
   coopmat_flash_attention_f32acc_supported_ = false;
+  integer_dot_product_supported_ = false;
+  vendor_id_ = 0;
+  architecture_ = GpuArchitecture::Unknown;
 
   // Clear memory properties by creating a default-constructed one
   vk::PhysicalDeviceMemoryProperties empty_props;

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -420,6 +420,8 @@ void VulkanContext::init() {
         extensions, VK_EXT_PIPELINE_ROBUSTNESS_EXTENSION_NAME);
     const bool has_cooperative_matrix_ext = has_device_extension(
         extensions, VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
+    const bool has_shader_integer_dot_product_ext = has_device_extension(
+        extensions, VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME);
     const bool has_shader_bfloat16_ext =
         has_device_extension(extensions, VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME);
 
@@ -644,7 +646,8 @@ void VulkanContext::init() {
       enabled_pipeline_robustness.pipelineRobustness = VK_TRUE;
       pipeline_robustness_supported = true;
     }
-    if (supported_shader_integer_dot_product.shaderIntegerDotProduct) {
+    if (has_shader_integer_dot_product_ext &&
+        supported_shader_integer_dot_product.shaderIntegerDotProduct) {
       enabled_shader_integer_dot_product.shaderIntegerDotProduct = VK_TRUE;
       integer_dot_product_supported = true;
     }
@@ -698,6 +701,10 @@ void VulkanContext::init() {
     }
     if (coopmat_flash_attention_f32acc_supported) {
       device_extensions.push_back(VK_KHR_COOPERATIVE_MATRIX_EXTENSION_NAME);
+    }
+    if (integer_dot_product_supported) {
+      device_extensions.push_back(
+          VK_KHR_SHADER_INTEGER_DOT_PRODUCT_EXTENSION_NAME);
     }
     if (shader_bfloat16_supported) {
       device_extensions.push_back(VK_KHR_SHADER_BFLOAT16_EXTENSION_NAME);

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -18,6 +18,16 @@ MLX_API bool is_available();
 MLX_API bool is_unified_memory();
 MLX_API int device_count();
 
+enum class GpuArchitecture : uint8_t {
+  Unknown,
+  AmdRdna,
+  AmdCdna,
+  Nvidia,
+  Intel,
+  Apple,
+  Qualcomm,
+};
+
 class VulkanContext {
  public:
   static VulkanContext& get();
@@ -80,11 +90,26 @@ class VulkanContext {
   uint32_t subgroup_max_size() const {
     return subgroup_max_size_;
   }
+  uint32_t subgroup_size() const {
+    return subgroup_size_;
+  }
   bool pipeline_robustness_supported() const {
     return pipeline_robustness_supported_;
   }
+  bool cooperative_matrix_supported() const {
+    return cooperative_matrix_supported_;
+  }
   bool coopmat_flash_attention_f32acc_supported() const {
     return coopmat_flash_attention_f32acc_supported_;
+  }
+  bool integer_dot_product_supported() const {
+    return integer_dot_product_supported_;
+  }
+  uint32_t vendor_id() const {
+    return vendor_id_;
+  }
+  GpuArchitecture architecture() const {
+    return architecture_;
   }
 
   // Find memory type that supports the given properties
@@ -128,8 +153,13 @@ class VulkanContext {
   bool subgroup_require_full_support_{false};
   uint32_t subgroup_min_size_{0};
   uint32_t subgroup_max_size_{0};
+  uint32_t subgroup_size_{0};
   bool pipeline_robustness_supported_{false};
+  bool cooperative_matrix_supported_{false};
   bool coopmat_flash_attention_f32acc_supported_{false};
+  bool integer_dot_product_supported_{false};
+  uint32_t vendor_id_{0};
+  GpuArchitecture architecture_{GpuArchitecture::Unknown};
   vk::PhysicalDeviceMemoryProperties mem_properties_{};
 };
 


### PR DESCRIPTION
## Summary
- add Vulkan device capability reporting and architecture-aware matmul dispatch tuning for `mul_mm`
- add split-K execution plus reduction for Vulkan matmul while keeping the shipped tile spec on a known-safe tuple
- address review feedback for split-K reduction dispatch sizing and integer-dot-product extension gating

## Validation
- `./dev.sh build`
- direct CPU/GPU parity checks for 2D, batched, broadcasted, and forced split-K matmul shapes
- `./dev.sh run pytest mlx/python/tests/test_vulkan_ops.py -k \"quantized_matmul_fused_low_precision_regression or quantized_matmul_fused_flatten_batches_regression\" -q`

## Benchmarks
- `./dev.sh benchmark bf16`
  - prompt_tps: `1282.661`
  - generation_tps: `8.866`
  - peak_memory: `1.940`
- `./dev.sh benchmark 8bit`
  - prompt_tps: `770.902`
  - generation_tps: `7.066`
  - peak_memory: `1.378`

## Closes
Closes goniz/mlx-vulkan#6