### PR TITLE
vulkan: batch descriptor set allocation by layout

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -1401,49 +1401,63 @@ vk::DescriptorSet KernelManager::allocate_descriptor_set(
 
   vk::Device device = VulkanContext::get().device();
 
-  vk::DescriptorSetAllocateInfo allocInfo;
-  allocInfo.setDescriptorPool(descriptor_pool_);
-  std::vector<vk::DescriptorSetLayout> layouts(kDescriptorSetBatchSize, layout);
-  allocInfo.setSetLayouts(layouts);
+  std::optional<vk::SystemError> last_error;
+  for (uint32_t batch_size = kDescriptorSetBatchSize; batch_size >= 1;
+       batch_size /= 2) {
+    vk::DescriptorSetAllocateInfo allocInfo;
+    allocInfo.setDescriptorPool(descriptor_pool_);
+    std::vector<vk::DescriptorSetLayout> layouts(batch_size, layout);
+    allocInfo.setSetLayouts(layouts);
 
-  try {
-    auto descriptor_sets = device.allocateDescriptorSets(allocInfo);
-    if (descriptor_sets.empty()) {
-      throw std::runtime_error("Failed to allocate descriptor set batch.");
-    }
+    try {
+      auto descriptor_sets = device.allocateDescriptorSets(allocInfo);
+      if (descriptor_sets.empty()) {
+        throw std::runtime_error("Failed to allocate descriptor set batch.");
+      }
 
-    vk::DescriptorSet descriptor_set = descriptor_sets.back();
-    descriptor_sets.pop_back();
+      vk::DescriptorSet descriptor_set = descriptor_sets.back();
+      descriptor_sets.pop_back();
 
-    {
-      std::lock_guard<std::mutex> lock(descriptor_sets_mutex_);
-      auto& reusable_sets = reusable_descriptor_sets_[layout];
-      reusable_sets.insert(
-          reusable_sets.end(), descriptor_sets.begin(), descriptor_sets.end());
-      descriptor_set_layouts_[descriptor_set] = layout;
-      for (const auto& reusable_set : descriptor_sets) {
-        descriptor_set_layouts_[reusable_set] = layout;
+      {
+        std::lock_guard<std::mutex> lock(descriptor_sets_mutex_);
+        auto& reusable_sets = reusable_descriptor_sets_[layout];
+        reusable_sets.insert(
+            reusable_sets.end(), descriptor_sets.begin(), descriptor_sets.end());
+        descriptor_set_layouts_[descriptor_set] = layout;
+        for (const auto& reusable_set : descriptor_sets) {
+          descriptor_set_layouts_[reusable_set] = layout;
+        }
+      }
+
+      if (trace_descriptor_epochs_enabled()) {
+        std::ostringstream oss;
+        oss << "batch_allocate layout=0x" << std::hex
+            << reinterpret_cast<uintptr_t>(
+                   static_cast<VkDescriptorSetLayout>(layout))
+            << " count=" << std::dec << (descriptor_sets.size() + 1)
+            << " set=0x" << std::hex
+            << reinterpret_cast<uintptr_t>(
+                    static_cast<VkDescriptorSet>(descriptor_set))
+            << std::dec;
+        trace_descriptor_epochs(oss.str());
+      }
+
+      return descriptor_set;
+    } catch (const vk::SystemError& e) {
+      last_error = e;
+      if (batch_size == 1) {
+        break;
       }
     }
-
-    if (trace_descriptor_epochs_enabled()) {
-      std::ostringstream oss;
-      oss << "batch_allocate layout=0x" << std::hex
-          << reinterpret_cast<uintptr_t>(
-                 static_cast<VkDescriptorSetLayout>(layout))
-          << " count=" << std::dec << (descriptor_sets.size() + 1)
-          << " set=0x" << std::hex
-          << reinterpret_cast<uintptr_t>(
-                  static_cast<VkDescriptorSet>(descriptor_set))
-          << std::dec;
-      trace_descriptor_epochs(oss.str());
-    }
-
-    return descriptor_set;
-  } catch (const vk::SystemError& e) {
-    throw std::runtime_error(
-        "Failed to allocate descriptor set: " + std::string(e.what()));
   }
+
+  if (last_error.has_value()) {
+    throw std::runtime_error(
+        "Failed to allocate descriptor set: " +
+        std::string(last_error->what()));
+  }
+
+  throw std::runtime_error("Failed to allocate descriptor set.");
 }
 
 void KernelManager::free_descriptor_set(VkDescriptorSet set) {

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -23,6 +23,7 @@ namespace {
 constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
 constexpr char kSoftmaxLargeSumScratchLane[] = "softmax.large.tmp_sum";
 constexpr char kCumsumMultipassScratchLane[] = "cumsum.multipass.tmp";
+constexpr uint32_t kDescriptorSetBatchSize = 32;
 
 bool trace_descriptor_epochs_enabled() {
   static const bool enabled = []() {
@@ -1402,25 +1403,38 @@ vk::DescriptorSet KernelManager::allocate_descriptor_set(
 
   vk::DescriptorSetAllocateInfo allocInfo;
   allocInfo.setDescriptorPool(descriptor_pool_);
-  allocInfo.setSetLayouts(layout);
+  std::vector<vk::DescriptorSetLayout> layouts(kDescriptorSetBatchSize, layout);
+  allocInfo.setSetLayouts(layouts);
 
   try {
     auto descriptor_sets = device.allocateDescriptorSets(allocInfo);
-    vk::DescriptorSet descriptor_set = descriptor_sets[0];
+    if (descriptor_sets.empty()) {
+      throw std::runtime_error("Failed to allocate descriptor set batch.");
+    }
+
+    vk::DescriptorSet descriptor_set = descriptor_sets.back();
+    descriptor_sets.pop_back();
 
     {
       std::lock_guard<std::mutex> lock(descriptor_sets_mutex_);
+      auto& reusable_sets = reusable_descriptor_sets_[layout];
+      reusable_sets.insert(
+          reusable_sets.end(), descriptor_sets.begin(), descriptor_sets.end());
       descriptor_set_layouts_[descriptor_set] = layout;
+      for (const auto& reusable_set : descriptor_sets) {
+        descriptor_set_layouts_[reusable_set] = layout;
+      }
     }
 
     if (trace_descriptor_epochs_enabled()) {
       std::ostringstream oss;
-      oss << "allocate layout=0x" << std::hex
+      oss << "batch_allocate layout=0x" << std::hex
           << reinterpret_cast<uintptr_t>(
                  static_cast<VkDescriptorSetLayout>(layout))
-          << " set=0x"
+          << " count=" << std::dec << (descriptor_sets.size() + 1)
+          << " set=0x" << std::hex
           << reinterpret_cast<uintptr_t>(
-                 static_cast<VkDescriptorSet>(descriptor_set))
+                  static_cast<VkDescriptorSet>(descriptor_set))
           << std::dec;
       trace_descriptor_epochs(oss.str());
     }


### PR DESCRIPTION
## Summary
- batch Vulkan descriptor-set allocation per descriptor layout instead of allocating one set at a time on cache misses
- keep the existing epoch-based reuse path, but seed the reusable pool with the rest of each allocated batch so hot dispatch sites avoid repeated allocation calls
- Closes goniz/mlx-vulkan#4

## Benchmarks
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1283.619, generation_tps=8.550, peak_memory=1.939
Trial 2:  prompt_tps=1276.633, generation_tps=8.559, peak_memory=1.939
Trial 3:  prompt_tps=1281.072, generation_tps=8.546, peak_memory=1.940
Trial 4:  prompt_tps=1278.043, generation_tps=8.546, peak_memory=1.940
Trial 5:  prompt_tps=1269.367, generation_tps=8.535, peak_memory=1.940
Averages: prompt_tps=1277.747, generation_tps=8.547, peak_memory=1.940
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=757.561, generation_tps=6.340, peak_memory=1.613
Trial 2:  prompt_tps=763.369, generation_tps=6.466, peak_memory=1.613
Trial 3:  prompt_tps=760.756, generation_tps=6.637, peak_memory=1.613
Trial 4:  prompt_tps=780.940, generation_tps=6.874, peak_memory=1.614
Trial 5:  prompt_tps=777.656, generation_tps=6.960, peak_memory=1.614
Averages: prompt_tps=768.057, generation_tps=6.655, peak_memory=1.613
```