### PR TITLE
vulkan: dispatch mul_mat_vec for small batched matmul

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -18,6 +18,8 @@
 
 namespace mlx::core::vulkan {
 
+constexpr uint32_t kMaxMulMatVecCols = 8;
+
 namespace {
 
 constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
@@ -2754,11 +2756,12 @@ void dispatch_mul_mat_vec_op(
     throw std::runtime_error(
         "[vulkan::kernels] Mat-vec dispatch requires rank-2 tensors.");
   }
-  if (vec.shape(0) != 1 || out.shape(0) != 1) {
+  if (vec.shape(0) != out.shape(0)) {
     throw std::runtime_error(
-        "[vulkan::kernels] Mat-vec dispatch expects a single input row.");
+        "[vulkan::kernels] Mat-vec dispatch expects matching batch rows.");
   }
 
+  const uint32_t batch_rows = checked_u32(vec.shape(0), "matvec batch rows");
   const uint32_t ncols = checked_u32(vec.shape(1), "matvec ncols");
   const uint32_t nrows = checked_u32(out.shape(1), "matvec nrows");
   if (checked_u32(matrix.shape(0), "matvec matrix K") != ncols ||
@@ -2777,7 +2780,6 @@ void dispatch_mul_mat_vec_op(
   push_constants.batch_stride_b = ncols;
   push_constants.batch_stride_d = nrows;
   push_constants.fusion_flags = 0;
-  push_constants.base_work_group_y = 0;
   push_constants.ne02 = 1;
   push_constants.ne12 = 1;
   push_constants.broadcast2 = 1;
@@ -2794,17 +2796,30 @@ void dispatch_mul_mat_vec_op(
   constexpr uint32_t kMaxWorkgroupsX = 65535u;
   const uint32_t groups_z = (nrows + kMaxWorkgroupsX - 1u) / kMaxWorkgroupsX;
   const uint32_t groups_x = (nrows + groups_z - 1u) / groups_z;
-  const std::array<uint32_t, 3> grid = {groups_x, 1u, groups_z};
 
-  dispatch_with_spec(
-      shader_id,
-      KernelSpecId::MatVec,
-      bound_arrays,
-      push_constants,
-      nrows,
-      cmd_buffer,
-      s,
-      grid);
+  for (uint32_t base_work_group_y = 0; base_work_group_y < batch_rows;
+       base_work_group_y += kMaxMulMatVecCols) {
+    push_constants.base_work_group_y = base_work_group_y;
+    const uint32_t num_cols =
+        std::min(kMaxMulMatVecCols, batch_rows - base_work_group_y);
+    const std::array<uint32_t, 3> grid = {groups_x, 1u, groups_z};
+    const std::vector<uint32_t> specialization_constants = {
+        32u,
+        1u,
+        num_cols,
+    };
+
+    dispatch_with_spec(
+        shader_id,
+        KernelSpecId::MatVec,
+        bound_arrays,
+        push_constants,
+        nrows,
+        cmd_buffer,
+        s,
+        grid,
+        specialization_constants);
+  }
 }
 
 void dispatch_random_bits_op(

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -25,6 +25,7 @@ namespace mlx::core {
 namespace {
 
 constexpr uint32_t kMaxGridZ = 65535;
+constexpr uint32_t kMaxMulMatVecCols = 8;
 constexpr char kMatvecMatrixCastScratchLane[] = "matvec.matrix_f16";
 constexpr char kMatvecVectorCastScratchLane[] = "matvec.vec_f16";
 constexpr char kMatvecOutScratchLane[] = "matvec.out_work";
@@ -71,7 +72,7 @@ bool matvec_enabled() {
   static const bool enabled = []() {
     const char* env = std::getenv("MLX_VULKAN_ENABLE_MATVEC");
     if (env == nullptr) {
-      return false;
+      return true;
     }
     return std::string(env) != "0";
   }();
@@ -487,7 +488,7 @@ bool try_eval_matvec_vulkan(
     return false;
   }
 
-  bool a_is_vec = (a.shape(0) == 1);
+  bool a_is_vec = (a.shape(0) >= 2 && a.shape(0) <= kMaxMulMatVecCols);
   bool b_is_vec = (b.shape(1) == 1);
   bool is_matvec = a_is_vec || b_is_vec;
 


### PR DESCRIPTION
## Summary
- dispatch `mul_mat_vec` with dynamic `NUM_COLS` specializations for small left-hand batch sizes up to 8
- keep the existing `mul_mm` path for the `N=1` case while enabling the Vulkan matvec fast path by default for the intended `2..8` batch window
- closes goniz/mlx-vulkan#20

## Validation
- `./dev.sh build`
- verified small batched Vulkan matmul correctness against CPU for `2x64 @ 64x32`
- verified `1x64 @ 64x32` still routes correctly and matches CPU

## Benchmarks
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1297.800, generation_tps=8.538, peak_memory=1.939
Trial 2:  prompt_tps=1291.340, generation_tps=8.652, peak_memory=1.939
Trial 3:  prompt_tps=1292.220, generation_tps=8.616, peak_memory=1.940
Trial 4:  prompt_tps=1292.054, generation_tps=8.558, peak_memory=1.940
Trial 5:  prompt_tps=1300.796, generation_tps=8.506, peak_memory=1.940
Averages: prompt_tps=1294.842, generation_tps=8.574, peak_memory=1.940
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=787.710, generation_tps=6.523, peak_memory=1.613
Trial 2:  prompt_tps=783.946, generation_tps=6.727, peak_memory=1.613
Trial 3:  prompt_tps=797.283, generation_tps=6.914, peak_memory=1.613
Trial 4:  prompt_tps=800.104, generation_tps=7.136, peak_memory=1.614
Trial 5:  prompt_tps=807.044, generation_tps=6.925, peak_memory=1.614
Averages: prompt_tps=795.217, generation_tps=6.845, peak_memory=1.613
```