### PR TITLE
fix(vulkan): tune scalar flash attention for Intel and AMD

### DIFF
--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -152,6 +152,7 @@ struct FlashAttentionTuningParams {
   uint32_t row_split;
   uint32_t subgroup_size;
   uint32_t shmem_staging;
+  bool disable_subgroups;
   uint32_t limit_occupancy_shmem;
 };
 
@@ -290,6 +291,17 @@ bool flash_attention_coopmat_shmem_supported(
       max_compute_shared_memory_size();
 }
 
+bool intel_is_battlemage(uint32_t device_id) {
+  switch (device_id) {
+    case 0xE212u:
+    case 0xE20Cu:
+    case 0xE20Bu:
+      return true;
+    default:
+      return false;
+  }
+}
+
 FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
     uint32_t hsk,
     uint32_t hsv,
@@ -300,10 +312,21 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
   const uint32_t subgroup_size = std::max(device_subgroup_size, 1u);
   const bool unified_memory = vulkan::VulkanContext::get().is_unified_memory();
   const uint32_t d = hsk | hsv;
+  const auto architecture = vulkan::VulkanContext::get().architecture();
 
   FlashAttentionTuningParams result{};
   result.path = FlashAttentionTuningParams::Path::Scalar;
-  result.subgroup_size = subgroup_size;
+  result.disable_subgroups = false;
+
+  if (vendor_id == kVendorIdIntel) {
+    result.subgroup_size = 32u;
+    result.disable_subgroups = true;
+  } else if (vendor_id == kVendorIdAmd &&
+             architecture == vulkan::GpuArchitecture::AmdRdna) {
+    result.subgroup_size = n_rows < 4u ? 32u : subgroup_size;
+  } else {
+    result.subgroup_size = subgroup_size;
+  }
 
   uint32_t row_split_max_hsk = 64u;
   if (vendor_id == kVendorIdAmd && !unified_memory) {
@@ -311,11 +334,11 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
   }
   result.row_split = (n_rows < 4 || hsk <= row_split_max_hsk) ? 1u : 4u;
 
-  if (subgroup_size > 32u &&
+  if (result.subgroup_size > 32u &&
       (n_rows < 4 || hsk < (result.row_split == 1 ? 128u : 64u))) {
-    result.workgroup_size = subgroup_size * 2u;
+    result.workgroup_size = result.subgroup_size * 2u;
   } else {
-    result.workgroup_size = subgroup_size * 4u;
+    result.workgroup_size = result.subgroup_size * 4u;
   }
   result.workgroup_size = std::clamp(result.workgroup_size, 32u, 256u);
 
@@ -335,7 +358,7 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
   }
 
   const uint32_t d_lsb = lowest_set_bit(d);
-  result.d_split = std::min(std::min(subgroup_size, 8u), d_lsb / 4u);
+  result.d_split = std::min(std::min(result.subgroup_size, 8u), d_lsb / 4u);
   result.shmem_staging =
       (vendor_id == kVendorIdNvidia && hsk < 256u && hsv < 256u) ? 1u : 0u;
 
@@ -377,6 +400,7 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_coopmat1(
   result.block_cols = 64u;
   result.row_split = 4u;
   result.subgroup_size = subgroup_size;
+  result.disable_subgroups = false;
   result.workgroup_size = 4u * subgroup_size;
   result.d_split =
       std::min(std::min(subgroup_size, 8u), lowest_set_bit(d) / 4u);
@@ -448,7 +472,15 @@ FlashAttentionExecutionPlan make_flash_attention_execution_plan(
 
   const uint32_t tr = (q_len + tuning.block_rows - 1u) / tuning.block_rows;
   const uint32_t total_wgs_no_split = std::max(tr * q_heads * batch, 1u);
-  const uint32_t target_workgroups = 32u;
+  uint32_t shader_core_count = vulkan::VulkanContext::get().shader_core_count();
+  if (shader_core_count == 0u) {
+    shader_core_count = 16u;
+  }
+  if (vulkan::VulkanContext::get().vendor_id() == kVendorIdIntel &&
+      !intel_is_battlemage(vulkan::VulkanContext::get().device_id())) {
+    shader_core_count *= 2u;
+  }
+  const uint32_t target_workgroups = shader_core_count * 2u;
   uint32_t split_k = total_wgs_no_split < target_workgroups
       ? (target_workgroups + total_wgs_no_split - 1u) / total_wgs_no_split
       : 1u;
@@ -668,7 +700,7 @@ bool try_dispatch_flash_attention_native_vulkan(
       plan.aligned ? 0u : 1u,
       tuning.d_split,
       tuning.row_split,
-      tuning.subgroup_size,
+      tuning.disable_subgroups ? 0u : tuning.subgroup_size,
       tuning.shmem_staging,
       (plan.use_mask_opt ? 1u : 0u) | (has_mask ? 2u : 0u) |
           (do_causal ? 8u : 0u),
@@ -711,7 +743,11 @@ bool try_dispatch_flash_attention_native_vulkan(
           },
           {
               128u,
-              std::max(1u, 128u / std::max(tuning.subgroup_size, 1u)),
+              std::max(
+                  1u,
+                  128u / std::max(
+                             tuning.disable_subgroups ? 32u : tuning.subgroup_size,
+                             1u)),
               tuning.block_rows,
               tuning.block_cols,
           });

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -711,6 +711,8 @@ bool try_dispatch_flash_attention_native_vulkan(
     auto command_buffer = vulkan::begin_command_recording(s.index);
 
     if (plan.use_mask_opt) {
+      const uint32_t mask_opt_subgroup_size =
+          std::max(vulkan::VulkanContext::get().subgroup_size(), 1u);
       vulkan::FlashAttentionMaskOptPushConstants mask_opt_push_constants{};
       mask_opt_push_constants.nem0 = kv_len;
       mask_opt_push_constants.nem1 = push_constants.nem1;
@@ -743,11 +745,7 @@ bool try_dispatch_flash_attention_native_vulkan(
           },
           {
               128u,
-              std::max(
-                  1u,
-                  128u / std::max(
-                             tuning.disable_subgroups ? 32u : tuning.subgroup_size,
-                             1u)),
+              std::max(1u, 128u / mask_opt_subgroup_size),
               tuning.block_rows,
               tuning.block_cols,
           });

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -180,6 +180,41 @@ bool nearly_equal(float a, float b, float atol = 1e-3f) {
   return std::fabs(a - b) <= atol;
 }
 
+uint32_t intel_shader_core_count(uint32_t vendor_id, uint32_t device_id) {
+  if (vendor_id != 0x8086u) {
+    return 0;
+  }
+
+  switch (device_id) {
+    case 0x56A6u: // A310
+      return 6;
+    case 0x5693u: // A370M
+    case 0x56A5u: // A380
+    case 0x56B1u: // Pro A40/A50
+      return 8;
+    case 0x5697u: // A530M
+      return 12;
+    case 0x5692u: // A550M
+    case 0x56B3u: // Pro A60
+    case 0xE212u: // Pro B50
+      return 16;
+    case 0xE20Cu: // B570
+      return 18;
+    case 0xE20Bu: // B580
+      return 20;
+    case 0x56A2u: // A580
+      return 24;
+    case 0x5691u: // A730M
+    case 0x56A1u: // A750
+      return 28;
+    case 0x56A0u: // A770
+    case 0x5690u: // A770M
+      return 32;
+    default:
+      return 0;
+  }
+}
+
 } // namespace
 
 bool VulkanContext::shader_bfloat16_supported() const {
@@ -356,7 +391,9 @@ void VulkanContext::init() {
   bool coopmat2_conv2d_supported = false;
   bool integer_dot_product_supported = false;
   uint32_t vendor_id = 0;
+  uint32_t device_id = 0;
   GpuArchitecture architecture = GpuArchitecture::Unknown;
+  uint32_t shader_core_count = 0;
   vk::PhysicalDeviceMemoryProperties mem_properties;
   vk::Semaphore timeline_semaphore;
   uint64_t timeline_value = 0;
@@ -430,8 +467,10 @@ void VulkanContext::init() {
 
     auto device_properties = physical_device.getProperties();
     vendor_id = device_properties.vendorID;
+    device_id = device_properties.deviceID;
     architecture = classify_gpu_architecture(
         vendor_id, std::string(device_properties.deviceName));
+    shader_core_count = intel_shader_core_count(vendor_id, device_id);
 
     is_unified_memory =
         (device_properties.deviceType ==
@@ -830,7 +869,9 @@ void VulkanContext::init() {
     this->coopmat2_conv2d_supported_ = coopmat2_conv2d_supported;
     this->integer_dot_product_supported_ = integer_dot_product_supported;
     this->vendor_id_ = vendor_id;
+    this->device_id_ = device_id;
     this->architecture_ = architecture;
+    this->shader_core_count_ = shader_core_count;
     initialized_ = true;
   } catch (...) {
     // Clean up partially initialized resources on failure
@@ -891,7 +932,9 @@ void VulkanContext::cleanup() {
   coopmat2_conv2d_supported_ = false;
   integer_dot_product_supported_ = false;
   vendor_id_ = 0;
+  device_id_ = 0;
   architecture_ = GpuArchitecture::Unknown;
+  shader_core_count_ = 0;
 
   // Clear memory properties by creating a default-constructed one
   vk::PhysicalDeviceMemoryProperties empty_props;

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -185,6 +185,8 @@ uint32_t intel_shader_core_count(uint32_t vendor_id, uint32_t device_id) {
     return 0;
   }
 
+  // Vulkan does not expose a generic Intel Xe core-count property, so keep a
+  // conservative device-ID lookup and fall back to heuristics when unknown.
   switch (device_id) {
     case 0x56A6u: // A310
       return 6;

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -111,8 +111,14 @@ class VulkanContext {
   uint32_t vendor_id() const {
     return vendor_id_;
   }
+  uint32_t device_id() const {
+    return device_id_;
+  }
   GpuArchitecture architecture() const {
     return architecture_;
+  }
+  uint32_t shader_core_count() const {
+    return shader_core_count_;
   }
 
   // Find memory type that supports the given properties
@@ -163,7 +169,9 @@ class VulkanContext {
   bool coopmat2_conv2d_supported_{false};
   bool integer_dot_product_supported_{false};
   uint32_t vendor_id_{0};
+  uint32_t device_id_{0};
   GpuArchitecture architecture_{GpuArchitecture::Unknown};
+  uint32_t shader_core_count_{0};
   vk::PhysicalDeviceMemoryProperties mem_properties_{};
 };
 


### PR DESCRIPTION
## Summary
- add Intel device capability plumbing so scalar flash attention can size split-k from known shader core counts
- disable subgroup reductions on Intel scalar flash attention and keep RDNA small-row tuning aligned with upstream vendor-specific behavior
- wire the updated tuning through Vulkan flash attention specialization constants without changing unrelated backends

Closes goniz/mlx-vulkan#23.

## Validation
- `./dev.sh build`
- `./dev.sh run pytest mlx/python/tests/test_vulkan_ops.py -k \"scaled_dot_product_attention and (causal_gqa or decode_gqa or qwen_shape or additive_mask or bool_mask)\"`
- `./dev.sh benchmark bf16`
- `./dev.sh benchmark 8bit`

## Benchmarks
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1285.541, generation_tps=8.495, peak_memory=1.939
Trial 2:  prompt_tps=1270.012, generation_tps=8.923, peak_memory=1.939
Trial 3:  prompt_tps=1299.846, generation_tps=10.496, peak_memory=1.940
Trial 4:  prompt_tps=1302.840, generation_tps=10.486, peak_memory=1.940
Trial 5:  prompt_tps=1295.676, generation_tps=10.532, peak_memory=1.940
Averages: prompt_tps=1290.783, generation_tps=9.786, peak_memory=1.940
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=771.849, generation_tps=6.491, peak_memory=1.613
Trial 2:  prompt_tps=796.381, generation_tps=6.691, peak_memory=1.613
Trial 3:  prompt_tps=798.930, generation_tps=6.728, peak_memory=1.613
Trial 4:  prompt_tps=795.446, generation_tps=6.781, peak_memory=1.614
Trial 5:  prompt_tps=795.749, generation_tps=7.028, peak_memory=1.614
Averages: prompt_tps=791.671, generation_tps=6.744, peak_memory=1.613
```