### PR TITLE
fix(vulkan): tune softmax subgroup reductions

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -26,6 +26,9 @@ constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
 constexpr char kSoftmaxLargeSumScratchLane[] = "softmax.large.tmp_sum";
 constexpr char kCumsumMultipassScratchLane[] = "cumsum.multipass.tmp";
 constexpr uint32_t kDescriptorSetBatchSize = 32;
+constexpr uint32_t kVendorIdAmd = 0x1002u;
+constexpr uint32_t kVendorIdIntel = 0x8086u;
+constexpr uint32_t kVendorIdNvidia = 0x10DEu;
 
 bool trace_descriptor_epochs_enabled() {
   static const bool enabled = []() {
@@ -182,6 +185,12 @@ PipelineCreationOptions pipeline_creation_options(
     const std::string& shader_name,
     const std::vector<uint32_t>& specialization_constants) {
   PipelineCreationOptions options;
+
+  if ((shader_name == "soft_max_f32" || shader_name == "soft_max_f32_f16") &&
+      !specialization_constants.empty()) {
+    options.required_subgroup_size = specialization_constants[0];
+    return options;
+  }
 
   if (shader_name == "fa_mask_opt") {
     options.disable_robustness = true;
@@ -706,6 +715,31 @@ make_sum_rows_push_constants(const array& in, const array& out, float weight) {
       push_constants.ne01, push_constants.ne0_1mp, push_constants.ne0_1L);
 
   return push_constants;
+}
+
+uint32_t select_softmax_block_size(uint32_t row_width) {
+  if (row_width > 1024u) {
+    return 512u;
+  }
+
+  const auto& context = VulkanContext::get();
+  const uint32_t subgroup_size = std::max(context.subgroup_size(), 1u);
+
+  switch (context.vendor_id()) {
+    case kVendorIdAmd:
+      if (context.subgroup_size_control_supported() &&
+          context.subgroup_min_size() <= 64u &&
+          context.subgroup_max_size() >= 64u) {
+        return 64u;
+      }
+      return std::min(64u, subgroup_size);
+    case kVendorIdNvidia:
+      return 32u;
+    case kVendorIdIntel:
+      return row_width <= 64u ? 8u : 16u;
+    default:
+      return std::min(32u, subgroup_size);
+  }
 }
 
 SoftmaxPushConstants make_softmax_push_constants(
@@ -2260,6 +2294,7 @@ void dispatch_softmax_op(
         "[vulkan::kernels] Softmax elements are not divisible by KX.");
   }
   const uint32_t row_count = total_elements / row_width;
+  const uint32_t block_size = select_softmax_block_size(row_width);
   const auto push_constants =
       make_softmax_push_constants(in, row_width, row_count);
 
@@ -2278,7 +2313,7 @@ void dispatch_softmax_op(
       cmd_buffer,
       s,
       std::nullopt,
-      {32u});
+      {block_size});
 }
 
 void dispatch_softmax_back_op(

--- a/mlx/backend/vulkan/kernels/soft_max.comp
+++ b/mlx/backend/vulkan/kernels/soft_max.comp
@@ -1,6 +1,8 @@
 #version 450
 
 #extension GL_EXT_control_flow_attributes : enable
+#extension GL_KHR_shader_subgroup_basic : enable
+#extension GL_KHR_shader_subgroup_arithmetic : enable
 
 layout (push_constant) uniform parameter
 {
@@ -34,6 +36,48 @@ layout (binding = 2) readonly buffer Z {float data_c[];};
 layout (binding = 3) buffer D {D_TYPE data_d[];};
 
 shared FLOAT_TYPE vals[BLOCK_SIZE];
+
+bool use_subgroup_reduction() {
+    return gl_NumSubgroups == 1;
+}
+
+FLOAT_TYPE reduce_max(FLOAT_TYPE value, uint tid) {
+    if (use_subgroup_reduction()) {
+        return subgroupMax(value);
+    }
+
+    vals[tid] = value;
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            vals[tid] = max(vals[tid], vals[tid + s]);
+        }
+        barrier();
+    }
+
+    value = vals[0];
+    barrier();
+    return value;
+}
+
+FLOAT_TYPE reduce_sum(FLOAT_TYPE value, uint tid) {
+    if (use_subgroup_reduction()) {
+        return subgroupAdd(value);
+    }
+
+    vals[tid] = value;
+    barrier();
+    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
+        if (tid < s) {
+            vals[tid] += vals[tid + s];
+        }
+        barrier();
+    }
+
+    value = vals[0];
+    barrier();
+    return value;
+}
 
 // num_iters is the number of BLOCK_SIZE loop iterations we need to iterate
 // over all the columns. The main function tries to pass a constant here,
@@ -99,18 +143,7 @@ void soft_max(uint num_iters) {
         }
     }
 
-    // reduce across the workgroup
-    vals[tid] = max_val;
-    barrier();
-    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) {
-            vals[tid] = max(vals[tid], vals[tid + s]);
-        }
-        barrier();
-    }
-
-    max_val = vals[0];
-    barrier();
+    max_val = reduce_max(max_val, tid);
 
     FLOAT_TYPE sum = FLOAT_TYPE(0.0f);
 
@@ -139,16 +172,7 @@ void soft_max(uint num_iters) {
         }
     }
 
-    // reduce across the workgroup
-    vals[tid] = sum;
-    barrier();
-    [[unroll]] for (uint s = BLOCK_SIZE / 2; s > 0; s >>= 1) {
-        if (tid < s) {
-            vals[tid] += vals[tid + s];
-        }
-        barrier();
-    }
-    sum = vals[0];
+    sum = reduce_sum(sum, tid);
 
     if (p.has_sinks != 0) {
         sum += FLOAT_TYPE(exp(FLOAT_TYPE(data_c[i02]) - max_val));

--- a/mlx/backend/vulkan/softmax.cpp
+++ b/mlx/backend/vulkan/softmax.cpp
@@ -96,6 +96,8 @@ bool try_eval_softmax_vulkan(
   set_unary_output_data(in, softmax_out_storage);
 
   array out_work = softmax_out_storage;
+  array in_kernel = collapse_softmax_leading_dims(in, s);
+  array out_kernel = collapse_softmax_leading_dims(out_work, s);
 
   if (in.shape() != out_work.shape()) {
     trace_softmax_failure("input_output_shape_mismatch");
@@ -130,8 +132,8 @@ bool try_eval_softmax_vulkan(
     auto command_buffer = vulkan::begin_command_recording(s.index);
     if (use_large_softmax) {
       vulkan::dispatch_softmax_large_op(
-          in,
-          out_work,
+          in_kernel,
+          out_kernel,
           use_f16_variant ? vulkan::StaticShaderId::soft_max_large1_f32_f16
                           : vulkan::StaticShaderId::soft_max_large1_f32,
           use_f16_variant ? vulkan::StaticShaderId::soft_max_large2_f32_f16
@@ -142,8 +144,8 @@ bool try_eval_softmax_vulkan(
           s);
     } else {
       vulkan::dispatch_softmax_op(
-          in,
-          out_work,
+          in_kernel,
+          out_kernel,
           use_f16_variant ? vulkan::StaticShaderId::soft_max_f32_f16
                           : vulkan::StaticShaderId::soft_max_f32,
           command_buffer,

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -199,6 +199,28 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             rtol=5e-2,
         )
 
+    def test_softmax_decode_shape_regressions(self):
+        cases = (
+            (mx.float32, (2, 20, 64), 1e-5, 1e-5),
+            (mx.float32, (3, 4, 5, 256), 1e-5, 1e-5),
+            (mx.float16, (1, 8, 1, 1025), 5e-3, 5e-3),
+        )
+
+        def fn(shape, dtype):
+            size = int(np.prod(shape))
+            x = mx.arange(size, dtype=mx.float32).reshape(shape)
+            x = (x - size / 2) / shape[-1]
+            x = x.astype(dtype)
+            return mx.softmax(x, axis=-1).astype(mx.float32)
+
+        for dtype, shape, atol, rtol in cases:
+            with self.subTest(dtype=str(dtype), shape=shape):
+                self._assert_cpu_gpu_same(
+                    lambda shape=shape, dtype=dtype: fn(shape, dtype),
+                    atol=atol,
+                    rtol=rtol,
+                )
+
     def test_list_getitem_regression(self):
         def fn():
             a = mx.arange(16, dtype=mx.float32).reshape(4, 4)


### PR DESCRIPTION
## Summary
- tune Vulkan softmax workgroup sizing by vendor and require the selected subgroup size on softmax pipelines
- use subgroup max/sum reductions in the softmax shader with a shared-memory fallback path
- add focused Vulkan softmax parity coverage for decode-like shapes

Closes goniz/mlx-vulkan#24.

## Benchmarks
Ran from the parent repo with:
- \\`./dev.sh benchmark bf16\\`
- \\`./dev.sh benchmark 8bit\\`

### bf16
\
\
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1276.459, generation_tps=8.461, peak_memory=1.939
Trial 2:  prompt_tps=1307.298, generation_tps=8.518, peak_memory=1.939
Trial 3:  prompt_tps=1290.686, generation_tps=8.501, peak_memory=1.940
Trial 4:  prompt_tps=1296.521, generation_tps=8.535, peak_memory=1.940
Trial 5:  prompt_tps=1290.960, generation_tps=8.559, peak_memory=1.940
Averages: prompt_tps=1292.385, generation_tps=8.515, peak_memory=1.940
\
\
### 8bit
\
\
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=776.254, generation_tps=6.451, peak_memory=1.613
Trial 2:  prompt_tps=775.056, generation_tps=6.419, peak_memory=1.613
Trial 3:  prompt_tps=775.018, generation_tps=6.474, peak_memory=1.613
Trial 4:  prompt_tps=798.315, generation_tps=6.944, peak_memory=1.614
Trial 5:  prompt_tps=794.164, generation_tps=6.963, peak_memory=1.614
Averages: prompt_tps=783.762, generation_tps=6.650, peak_memory=1.613
\
\