### PR TITLE
fix(vulkan): avoid global raw_ptr synchronization

### DIFF
--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -4,13 +4,11 @@
 
 #include <algorithm>
 #include <array>
-#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
-#include <thread>
 #include <vector>
 
 #include "mlx/backend/gpu/device_info.h"
@@ -34,39 +32,6 @@ bool trace_cpu_access_enabled() {
   return enabled;
 }
 
-bool trace_sync_enabled() {
-  const char* env = std::getenv("MLX_VULKAN_TRACE_SYNC");
-  return env != nullptr && std::string(env) != "0";
-}
-
-void trace_raw_ptr_sync(
-    const vulkan::VulkanBuffer& buf,
-    const char* action,
-    vk::Semaphore semaphore,
-    uint64_t timeline_value) {
-  if (!trace_sync_enabled()) {
-    return;
-  }
-
-  using Clock = std::chrono::steady_clock;
-  static const auto start = Clock::now();
-  static std::mutex trace_mutex;
-
-  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
-                      Clock::now() - start)
-                      .count();
-
-  std::lock_guard<std::mutex> lock(trace_mutex);
-  std::cerr << "[vulkan-trace +" << ms
-            << "ms tid=" << std::this_thread::get_id() << "] raw_ptr action="
-            << action << " buffer=" << buf.buffer << " mapped=" << buf.mapped_ptr
-            << " size=" << buf.size;
-  if (semaphore && timeline_value != 0) {
-    std::cerr << " timeline_value=" << timeline_value;
-  }
-  std::cerr << std::endl;
-}
-
 } // namespace
 
 Allocator& allocator() {
@@ -87,40 +52,7 @@ void* Buffer::raw_ptr() {
               << flags << std::dec << "\n";
   }
 
-  vk::Semaphore wait_semaphore;
-  uint64_t wait_timeline_value = 0;
-  {
-    std::lock_guard<std::mutex> affinity_lock(buf->queue_affinity_mutex);
-    wait_semaphore = buf->last_semaphore;
-    wait_timeline_value = buf->last_timeline_value;
-  }
-
-  if (wait_semaphore && wait_timeline_value != 0) {
-    trace_raw_ptr_sync(*buf, "wait-buffer", wait_semaphore, wait_timeline_value);
-
-    vk::SemaphoreWaitInfo wait_info;
-    wait_info.semaphoreCount = 1;
-    wait_info.pSemaphores = &wait_semaphore;
-    wait_info.pValues = &wait_timeline_value;
-
-    auto result = vulkan::VulkanContext::get().device().waitSemaphores(
-        wait_info, UINT64_MAX);
-    if (result != vk::Result::eSuccess) {
-      vulkan::throw_if_vk_error(
-          static_cast<VkResult>(result),
-          "[vulkan::raw_ptr] Failed waiting for buffer timeline");
-    }
-
-    std::lock_guard<std::mutex> affinity_lock(buf->queue_affinity_mutex);
-    if (buf->last_semaphore == wait_semaphore &&
-        buf->last_timeline_value == wait_timeline_value) {
-      buf->last_semaphore = vk::Semaphore();
-      buf->last_timeline_value = 0;
-      buf->queue_affinity = vulkan::VulkanBuffer::QueueAffinity::None;
-    }
-  } else {
-    trace_raw_ptr_sync(*buf, "skip-sync", wait_semaphore, wait_timeline_value);
-  }
+  vulkan::synchronize_buffer_for_host_access(buf);
 
   return buf->mapped_ptr;
 }

--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -4,11 +4,13 @@
 
 #include <algorithm>
 #include <array>
+#include <chrono>
 #include <cstdlib>
 #include <iostream>
 #include <limits>
 #include <sstream>
 #include <stdexcept>
+#include <thread>
 #include <vector>
 
 #include "mlx/backend/gpu/device_info.h"
@@ -32,6 +34,39 @@ bool trace_cpu_access_enabled() {
   return enabled;
 }
 
+bool trace_sync_enabled() {
+  const char* env = std::getenv("MLX_VULKAN_TRACE_SYNC");
+  return env != nullptr && std::string(env) != "0";
+}
+
+void trace_raw_ptr_sync(
+    const vulkan::VulkanBuffer& buf,
+    const char* action,
+    vk::Semaphore semaphore,
+    uint64_t timeline_value) {
+  if (!trace_sync_enabled()) {
+    return;
+  }
+
+  using Clock = std::chrono::steady_clock;
+  static const auto start = Clock::now();
+  static std::mutex trace_mutex;
+
+  const auto ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                      Clock::now() - start)
+                      .count();
+
+  std::lock_guard<std::mutex> lock(trace_mutex);
+  std::cerr << "[vulkan-trace +" << ms
+            << "ms tid=" << std::this_thread::get_id() << "] raw_ptr action="
+            << action << " buffer=" << buf.buffer << " mapped=" << buf.mapped_ptr
+            << " size=" << buf.size;
+  if (semaphore && timeline_value != 0) {
+    std::cerr << " timeline_value=" << timeline_value;
+  }
+  std::cerr << std::endl;
+}
+
 } // namespace
 
 Allocator& allocator() {
@@ -51,8 +86,42 @@ void* Buffer::raw_ptr() {
               << " alloc=" << buf->allocation_size << " flags=0x" << std::hex
               << flags << std::dec << "\n";
   }
-  
-  vulkan::synchronize_all();
+
+  vk::Semaphore wait_semaphore;
+  uint64_t wait_timeline_value = 0;
+  {
+    std::lock_guard<std::mutex> affinity_lock(buf->queue_affinity_mutex);
+    wait_semaphore = buf->last_semaphore;
+    wait_timeline_value = buf->last_timeline_value;
+  }
+
+  if (wait_semaphore && wait_timeline_value != 0) {
+    trace_raw_ptr_sync(*buf, "wait-buffer", wait_semaphore, wait_timeline_value);
+
+    vk::SemaphoreWaitInfo wait_info;
+    wait_info.semaphoreCount = 1;
+    wait_info.pSemaphores = &wait_semaphore;
+    wait_info.pValues = &wait_timeline_value;
+
+    auto result = vulkan::VulkanContext::get().device().waitSemaphores(
+        wait_info, UINT64_MAX);
+    if (result != vk::Result::eSuccess) {
+      vulkan::throw_if_vk_error(
+          static_cast<VkResult>(result),
+          "[vulkan::raw_ptr] Failed waiting for buffer timeline");
+    }
+
+    std::lock_guard<std::mutex> affinity_lock(buf->queue_affinity_mutex);
+    if (buf->last_semaphore == wait_semaphore &&
+        buf->last_timeline_value == wait_timeline_value) {
+      buf->last_semaphore = vk::Semaphore();
+      buf->last_timeline_value = 0;
+      buf->queue_affinity = vulkan::VulkanBuffer::QueueAffinity::None;
+    }
+  } else {
+    trace_raw_ptr_sync(*buf, "skip-sync", wait_semaphore, wait_timeline_value);
+  }
+
   return buf->mapped_ptr;
 }
 

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -803,6 +803,73 @@ class VulkanDevice {
     trace_sync("sync(all) done");
   }
 
+  void synchronize_buffer_for_host_access(VulkanBuffer* buffer) {
+    if (buffer == nullptr) {
+      return;
+    }
+
+    {
+      std::lock_guard<std::mutex> lock(mutex_);
+      for (auto& [_, stream] : streams_) {
+        if (!stream->recording ||
+            !stream_has_pending_host_write(stream.get(), buffer)) {
+          continue;
+        }
+
+        submit_commands(
+            stream.get(),
+            "raw_ptr host access",
+            {},
+            {},
+            stream->recording_transfer);
+      }
+    }
+
+    vk::Semaphore wait_semaphore;
+    uint64_t wait_timeline_value = 0;
+    {
+      std::lock_guard<std::mutex> affinity_lock(buffer->queue_affinity_mutex);
+      wait_semaphore = buffer->last_semaphore;
+      wait_timeline_value = buffer->last_timeline_value;
+    }
+
+    std::ostringstream oss;
+    oss << "raw_ptr action="
+        << ((wait_semaphore && wait_timeline_value != 0) ? "wait-buffer"
+                                                         : "skip-sync")
+        << " buffer=" << buffer->buffer << " mapped=" << buffer->mapped_ptr
+        << " size=" << buffer->size;
+    if (wait_semaphore && wait_timeline_value != 0) {
+      oss << " timeline_value=" << wait_timeline_value;
+    }
+    trace_sync(oss.str());
+
+    if (!wait_semaphore || wait_timeline_value == 0) {
+      return;
+    }
+
+    vk::SemaphoreWaitInfo wait_info;
+    wait_info.semaphoreCount = 1;
+    wait_info.pSemaphores = &wait_semaphore;
+    wait_info.pValues = &wait_timeline_value;
+
+    auto result = VulkanContext::get().device().waitSemaphores(
+        wait_info, UINT64_MAX);
+    if (result != vk::Result::eSuccess) {
+      throw_if_vk_error(
+          static_cast<VkResult>(result),
+          "[vulkan::raw_ptr] Failed waiting for buffer timeline");
+    }
+
+    std::lock_guard<std::mutex> affinity_lock(buffer->queue_affinity_mutex);
+    if (buffer->last_semaphore == wait_semaphore &&
+        buffer->last_timeline_value == wait_timeline_value) {
+      buffer->last_semaphore = vk::Semaphore();
+      buffer->last_timeline_value = 0;
+      buffer->queue_affinity = VulkanBuffer::QueueAffinity::None;
+    }
+  }
+
   void retain_array(int stream_index, const array& arr) {
     auto* stream = get_stream(stream_index);
     auto data = arr.data_shared_ptr();
@@ -1598,6 +1665,18 @@ class VulkanDevice {
 
   static bool overlaps(const BufferAccessRange& a, const BufferAccessRange& b) {
     return a.buffer == b.buffer && a.begin < b.end && b.begin < a.end;
+  }
+
+  static bool stream_has_pending_host_write(
+      const StreamData* stream,
+      const VulkanBuffer* buffer) {
+    for (const auto& write : stream->unsynced_writes) {
+      if (write.storage == buffer) {
+        return true;
+      }
+    }
+
+    return false;
   }
 
   static bool has_access_hazard(
@@ -2420,6 +2499,10 @@ void set_force_immediate_submit(Stream s) {
 
 void synchronize_all() {
   VulkanDevice::get().synchronize();
+}
+
+void synchronize_buffer_for_host_access(VulkanBuffer* buffer) {
+  VulkanDevice::get().synchronize_buffer_for_host_access(buffer);
 }
 
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/device.h
+++ b/mlx/backend/vulkan/device.h
@@ -14,6 +14,8 @@
 
 namespace mlx::core::vulkan {
 
+struct VulkanBuffer;
+
 class ScopedSyncLabel {
  public:
   explicit ScopedSyncLabel(std::string label);
@@ -70,5 +72,6 @@ void finalize_stream(Stream s);
 void synchronize_stream(Stream s);
 void set_force_immediate_submit(Stream s);
 void synchronize_all();
+void synchronize_buffer_for_host_access(VulkanBuffer* buffer);
 
 } // namespace mlx::core::vulkan

--- a/tests/allocator_tests.cpp
+++ b/tests/allocator_tests.cpp
@@ -1,12 +1,62 @@
 // Copyright © 2023 Apple Inc.
 
+#include <cstdlib>
+#include <iostream>
+#include <sstream>
 #include <stdexcept>
 
 #include "doctest/doctest.h"
 
+#ifdef MLX_BUILD_VULKAN
+#include "mlx/backend/vulkan/allocator.h"
+#endif
 #include "mlx/allocator.h"
+#include "mlx/mlx.h"
 
 using namespace mlx::core;
+
+#ifdef MLX_BUILD_VULKAN
+namespace {
+
+struct ScopedEnvVar {
+  explicit ScopedEnvVar(const char* value) {
+    const char* current = std::getenv("MLX_VULKAN_TRACE_SYNC");
+    if (current) {
+      had_old_value = true;
+      old_value = current;
+    }
+    setenv("MLX_VULKAN_TRACE_SYNC", value, 1);
+  }
+
+  ~ScopedEnvVar() {
+    if (had_old_value) {
+      setenv("MLX_VULKAN_TRACE_SYNC", old_value.c_str(), 1);
+    } else {
+      unsetenv("MLX_VULKAN_TRACE_SYNC");
+    }
+  }
+
+  bool had_old_value{false};
+  std::string old_value;
+};
+
+struct ScopedCerrCapture {
+  ScopedCerrCapture() : old_buf(std::cerr.rdbuf(stream.rdbuf())) {}
+
+  ~ScopedCerrCapture() {
+    std::cerr.rdbuf(old_buf);
+  }
+
+  std::string str() const {
+    return stream.str();
+  }
+
+  std::ostringstream stream;
+  std::streambuf* old_buf;
+};
+
+} // namespace
+#endif
 
 TEST_CASE("test simple allocations") {
   {
@@ -39,3 +89,28 @@ TEST_CASE("test large allocations") {
     allocator::free(buffer);
   }
 }
+
+#ifdef MLX_BUILD_VULKAN
+TEST_CASE("test vulkan raw_ptr skips global sync on fresh allocation") {
+  if (!gpu::is_available()) {
+    return;
+  }
+
+  ScopedEnvVar trace_sync("1");
+  ScopedCerrCapture capture;
+
+  auto buffer = allocator::malloc(64);
+  auto* vk_buffer = static_cast<vulkan::VulkanBuffer*>(buffer.ptr());
+  REQUIRE(vk_buffer != nullptr);
+  CHECK_FALSE(static_cast<bool>(vk_buffer->last_semaphore));
+  CHECK_EQ(vk_buffer->last_timeline_value, 0);
+
+  (void)buffer.raw_ptr();
+
+  allocator::free(buffer);
+
+  auto trace = capture.str();
+  CHECK_NE(trace.find("raw_ptr action=skip-sync"), std::string::npos);
+  CHECK_EQ(trace.find("sync(all) begin"), std::string::npos);
+}
+#endif


### PR DESCRIPTION
## Summary
- Replace `Buffer::raw_ptr()`'s unconditional global `synchronize_all()` with a targeted timeline semaphore wait on the specific Vulkan buffer.
- Skip synchronization entirely for fresh buffers with no pending GPU writes and add `MLX_VULKAN_TRACE_SYNC` logging for raw pointer wait/skip decisions.
- Add a Vulkan regression test that verifies fresh allocations do not trigger a full-device sync on `raw_ptr()`.

Closes goniz/mlx-vulkan#26.

## Validation
- `./dev.sh build`
- `cmake --build build --target tests`
- `./build/tests/tests --test-case="test vulkan raw_ptr skips global sync on fresh allocation"`
- `MLX_VULKAN_TRACE_SYNC=1 ./dev.sh run python -c "import mlx.core as mx; mx.set_default_device(mx.gpu); a = mx.arange(3); b = a + 1; print(b.tolist())"`

## Benchmark Results
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1297.685, generation_tps=8.483, peak_memory=1.985
Trial 2:  prompt_tps=1293.348, generation_tps=8.466, peak_memory=1.986
Trial 3:  prompt_tps=1285.620, generation_tps=8.618, peak_memory=1.986
Trial 4:  prompt_tps=1284.020, generation_tps=8.526, peak_memory=1.986
Trial 5:  prompt_tps=1291.422, generation_tps=8.499, peak_memory=1.987
Averages: prompt_tps=1290.419, generation_tps=8.518, peak_memory=1.986
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=775.789, generation_tps=6.414, peak_memory=1.613
Trial 2:  prompt_tps=775.058, generation_tps=6.501, peak_memory=1.613
Trial 3:  prompt_tps=777.165, generation_tps=6.944, peak_memory=1.613
Trial 4:  prompt_tps=800.859, generation_tps=6.988, peak_memory=1.614
Trial 5:  prompt_tps=803.561, generation_tps=7.108, peak_memory=1.614
Averages: prompt_tps=786.486, generation_tps=6.791, peak_memory=1.613
```