### PR TITLE
fix(vulkan): harden BF16 runtime capability probe

### DIFF
--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -1203,6 +1203,17 @@ void copy_gpu_inplace(
   auto out_view = make_copy_view(
       out, dispatch_shape, dispatch_o_strides, resolved_o_offset);
 
+  std::vector<array> tracking_inputs;
+  std::vector<array> tracking_outputs;
+  if (vulkan::is_vulkan_buffer(in_view.buffer())) {
+    tracking_inputs.push_back(in_view);
+  }
+  if (vulkan::is_vulkan_buffer(out_view.buffer())) {
+    tracking_outputs.push_back(out_view);
+  }
+  vulkan::ScopedPrimitiveTracking tracking_scope(
+      s, std::move(tracking_inputs), std::move(tracking_outputs));
+
   const bool same_dtype = source->dtype() == out.dtype();
   const bool raw_buffer_copy = same_dtype && ctype == CopyType::Vector;
 

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -34,6 +34,24 @@
 
 namespace mlx::core::vulkan {
 
+ScopedPrimitiveTracking::ScopedPrimitiveTracking(
+    const Stream& s,
+    std::vector<array> inputs,
+    std::vector<array> outputs)
+    : s_(s), inputs_(std::move(inputs)), outputs_(std::move(outputs)) {
+  if (inputs_.empty() && outputs_.empty()) {
+    return;
+  }
+  begin_primitive_tracking(s_, inputs_, outputs_);
+  active_ = true;
+}
+
+ScopedPrimitiveTracking::~ScopedPrimitiveTracking() {
+  if (active_) {
+    end_primitive_tracking(s_, inputs_, outputs_);
+  }
+}
+
 namespace {
 
 bool deferred_submission_enabled() {

--- a/mlx/backend/vulkan/device.h
+++ b/mlx/backend/vulkan/device.h
@@ -25,6 +25,24 @@ class ScopedSyncLabel {
   bool active_{false};
 };
 
+class ScopedPrimitiveTracking {
+ public:
+  ScopedPrimitiveTracking(
+      const Stream& s,
+      std::vector<array> inputs,
+      std::vector<array> outputs);
+  ~ScopedPrimitiveTracking();
+
+  ScopedPrimitiveTracking(const ScopedPrimitiveTracking&) = delete;
+  ScopedPrimitiveTracking& operator=(const ScopedPrimitiveTracking&) = delete;
+
+ private:
+  Stream s_;
+  std::vector<array> inputs_;
+  std::vector<array> outputs_;
+  bool active_{false};
+};
+
 // Command buffer management - Use C++ API types
 vk::CommandBuffer begin_command_recording(int stream_index);
 void end_command_recording(int stream_index);

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2787,8 +2787,8 @@ void dispatch_mul_mm_op(
         "[vulkan::kernels] mul_mm dispatch requires rank >= 2 tensors.");
   }
 
-  const uint32_t m = checked_u32(out.shape(-1), "mul_mm M");
-  const uint32_t n = checked_u32(out.shape(-2), "mul_mm N");
+  const uint32_t m = checked_u32(out.shape(-2), "mul_mm M");
+  const uint32_t n = checked_u32(out.shape(-1), "mul_mm N");
   const uint32_t k = checked_u32(a.shape(-1), "mul_mm K");
   if (checked_u32(a.shape(-2), "mul_mm A M") != m ||
       checked_u32(b.shape(-2), "mul_mm B N") != n ||

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2865,8 +2865,8 @@ void dispatch_mul_mat_vec_op(
   const uint32_t batch_rows = checked_u32(vec.shape(0), "matvec batch rows");
   const uint32_t ncols = checked_u32(vec.shape(1), "matvec ncols");
   const uint32_t nrows = checked_u32(out.shape(1), "matvec nrows");
-  if (checked_u32(matrix.shape(0), "matvec matrix K") != ncols ||
-      checked_u32(matrix.shape(1), "matvec matrix N") != nrows) {
+  if (checked_u32(matrix.shape(0), "matvec matrix N") != nrows ||
+      checked_u32(matrix.shape(1), "matvec matrix K") != ncols) {
     throw std::runtime_error(
         "[vulkan::kernels] Mat-vec dispatch received incompatible shapes.");
   }

--- a/mlx/backend/vulkan/kernels/mul_mat_split_k_reduce.comp
+++ b/mlx/backend/vulkan/kernels/mul_mat_split_k_reduce.comp
@@ -2,12 +2,31 @@
 
 #extension GL_EXT_control_flow_attributes : enable
 
+#include "types.glsl"
+
+#if !defined(D_TYPE)
+#define D_TYPE float
+#endif
+
+#if defined(D_IS_BF16)
+D_TYPE to_d_type(float value) {
+    return D_TYPE(fp32_to_bf16(value));
+}
+#else
+D_TYPE to_d_type(float value) {
+    return D_TYPE(value);
+}
+#endif
+
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout (binding = 0) readonly buffer A {float data_a[];};
 layout (binding = 0) readonly buffer A4 {vec4 data_a4[];};
-layout (binding = 1) writeonly buffer D {float data_d[];};
+layout (binding = 1) writeonly buffer D {D_TYPE data_d[];};
+
+#if !defined(D_MANUAL_VEC_STORE)
 layout (binding = 1) writeonly buffer D4 {vec4 data_d4[];};
+#endif
 
 layout (push_constant) uniform parameter {
     uint ne;
@@ -24,6 +43,7 @@ void main() {
 
     // Check if all four components are in bounds and aligned,
     // then use vector loads
+#if !defined(D_MANUAL_VEC_STORE)
     if (idx + 3 < p.ne && (p.ne % 4) == 0) {
         vec4 result = vec4(0.0f);
 
@@ -33,6 +53,7 @@ void main() {
 
         data_d4[idx / 4] = result;
     } else {
+#endif
         [[unroll]] for (uint j = 0; j < 4; ++j) {
             if (idx + j < p.ne) {
                 float result = 0.0f;
@@ -41,8 +62,10 @@ void main() {
                     result += data_a[i * p.ne + idx + j];
                 }
 
-                data_d[idx + j] = result;
+                data_d[idx + j] = to_d_type(result);
             }
         }
+#if !defined(D_MANUAL_VEC_STORE)
     }
+#endif
 }

--- a/mlx/backend/vulkan/kernels/mul_mm.comp
+++ b/mlx/backend/vulkan/kernels/mul_mm.comp
@@ -66,6 +66,20 @@ layout (binding = 0) readonly buffer A_PACKED32 {A_TYPE_PACKED32 data_a_packed32
 layout (binding = 1) readonly buffer B {B_TYPE data_b[];};
 layout (binding = 2) writeonly buffer D {D_TYPE data_d[];};
 
+#if defined(D_IS_BF16)
+D_TYPE to_d_type(ACC_TYPE value) {
+    return D_TYPE(fp32_to_bf16(float(value)));
+}
+#else
+D_TYPE to_d_type(ACC_TYPE value) {
+    return D_TYPE(value);
+}
+#endif
+
+void store_d(uint idx, ACC_TYPE value) {
+    data_d[idx] = to_d_type(value);
+}
+
 #ifdef MUL_MAT_ID
 layout (binding = 3) readonly buffer IDS {int data_ids[];};
 layout (binding = 4) readonly buffer Counts {int data_expert_count[];};
@@ -384,36 +398,40 @@ void main() {
                 const u16vec2 row_idx = row_ids[row_i - ic * BN];
 
                 if (dr + cm_row * TM + store_r < p.M) {
-                    data_d[row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr + cm_row * TM + store_r] = D_TYPE(coopmat_stage[warp_i * TM * TN + (col + store_c) * TM + store_r]);
+                    store_d(row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr + cm_row * TM + store_r, coopmat_stage[warp_i * TM * TN + (col + store_c) * TM + store_r]);
                 }
             }
         }
     }
 #else
-    const bool is_aligned = p.stride_d % 4 == 0;  // Assumption: D_TYPE == float
+#if defined(D_MANUAL_COOPMAT_STORE)
+    const bool is_aligned = false;
+#else
+    const bool is_aligned = p.stride_d % 4 == 0;
+#endif
 
     [[unroll]] for (uint cm_row = 0; cm_row < cms_per_row; cm_row++) {
         [[unroll]] for (uint cm_col = 0; cm_col < cms_per_col; cm_col++) {
             const bool is_in_bounds = dr + (cm_row + 1) * TM <= p.M && dc + (cm_col + 1) * TN <= p.N;
 
             if (is_aligned && is_in_bounds) {
-                // Full coopMat is within bounds and stride_d is aligned with 16B
+                // Full coopMat is within bounds and the destination row stride is 16B-aligned.
                 coopmat<D_TYPE, gl_ScopeSubgroup, TM, TN, gl_MatrixUseAccumulator> cm_dtype = coopmat<D_TYPE, gl_ScopeSubgroup, TM, TN, gl_MatrixUseAccumulator>(sums[cm_col * cms_per_row + cm_row]);
-                coopMatStore(cm_dtype, data_d, offsets + (dc + cm_col * TN) * p.stride_d + dr + cm_row * TM, p.stride_d, gl_CooperativeMatrixLayoutColumnMajor);
+                coopMatStore(cm_dtype, data_d, offsets + (dr + cm_row * TM) * p.stride_d + dc + cm_col * TN, p.stride_d, gl_CooperativeMatrixLayoutRowMajor);
             } else if (is_in_bounds) {
                 // Full coopMat is within bounds, but stride_d is not aligned
-                coopMatStore(sums[cm_col * cms_per_row + cm_row], coopmat_stage, warp_i * TM * TN, TM, gl_CooperativeMatrixLayoutColumnMajor);
+                coopMatStore(sums[cm_col * cms_per_row + cm_row], coopmat_stage, warp_i * TM * TN, TN, gl_CooperativeMatrixLayoutRowMajor);
 
                 [[unroll]] for (uint col = 0; col < TN; col += storestride) {
-                    data_d[offsets + (dc + cm_col * TN + col + store_c) * p.stride_d + dr + cm_row * TM + store_r] = D_TYPE(coopmat_stage[warp_i * TM * TN + (col + store_c) * TM + store_r]);
+                    store_d(offsets + (dr + cm_row * TM + store_r) * p.stride_d + dc + cm_col * TN + col + store_c, coopmat_stage[warp_i * TM * TN + store_r * TN + col + store_c]);
                 }
             } else if (dr + cm_row * TM < p.M && dc + cm_col * TN < p.N) {
                 // Partial coopMat is within bounds
-                coopMatStore(sums[cm_col * cms_per_row + cm_row], coopmat_stage, warp_i * TM * TN, TM, gl_CooperativeMatrixLayoutColumnMajor);
+                coopMatStore(sums[cm_col * cms_per_row + cm_row], coopmat_stage, warp_i * TM * TN, TN, gl_CooperativeMatrixLayoutRowMajor);
 
                 [[unroll]] for (uint col = 0; col < TN; col += storestride) {
                     if (dr + cm_row * TM + store_r < p.M && dc + cm_col * TN + col + store_c < p.N) {
-                        data_d[offsets + (dc + cm_col * TN + col + store_c) * p.stride_d + dr + cm_row * TM + store_r] = D_TYPE(coopmat_stage[warp_i * TM * TN + (col + store_c) * TM + store_r]);
+                        store_d(offsets + (dr + cm_row * TM + store_r) * p.stride_d + dc + cm_col * TN + col + store_c, coopmat_stage[warp_i * TM * TN + store_r * TN + col + store_c]);
                     }
                 }
             }
@@ -437,17 +455,17 @@ void main() {
                     const uint sums_idx = (wsic * TN + cc) * WMITER * (TM / 2) + wsir * (TM / 2) + cr;
 #ifdef MUL_MAT_ID
                     if (dr_warp + 2 * cr < p.M) {
-                        data_d[row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr_warp + 2 * cr] = D_TYPE(sums[sums_idx].x);
+                        store_d(row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr_warp + 2 * cr, sums[sums_idx].x);
                     }
                     if (dr_warp + 2 * cr + 1 < p.M) {
-                        data_d[row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr_warp + 2 * cr + 1] = D_TYPE(sums[sums_idx].y);
+                        store_d(row_idx.y * p.batch_stride_d + row_idx.x * p.stride_d + dr_warp + 2 * cr + 1, sums[sums_idx].y);
                     }
 #else
                     if (dr_warp + 2 * cr < p.M && dc_warp + cc < p.N) {
-                        data_d[offsets + (dc_warp + cc) * p.stride_d + dr_warp + 2 * cr] = D_TYPE(sums[sums_idx].x);
+                        store_d(offsets + (dr_warp + 2 * cr) * p.stride_d + dc_warp + cc, sums[sums_idx].x);
                     }
                     if (dr_warp + 2 * cr + 1 < p.M && dc_warp + cc < p.N) {
-                        data_d[offsets + (dc_warp + cc) * p.stride_d + dr_warp + 2 * cr + 1] = D_TYPE(sums[sums_idx].y);
+                        store_d(offsets + (dr_warp + 2 * cr + 1) * p.stride_d + dc_warp + cc, sums[sums_idx].y);
                     }
 #endif // MUL_MAT_ID
                 }

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -572,6 +572,69 @@ void matmul_shaders(
       coopmat2,
       f16acc);
 
+  if (matmul_id_type == MatMulIdType::NONE) {
+    string_to_spv(
+        "matmul_direct_f16",
+        source_name,
+        merge_maps(
+            merge_maps(base_dict, float_type_dict_f16),
+            {{"DATA_A_F16", "1"},
+             {"B_TYPE", "float16_t"},
+             {"D_TYPE", "float16_t"},
+             {"D_MANUAL_COOPMAT_STORE", "1"}}),
+        fp16,
+        coopmat,
+        coopmat2,
+        f16acc);
+    string_to_spv(
+        "matmul_direct_f16_bf16",
+        source_name,
+        merge_maps(
+            merge_maps(base_dict, float_type_dict_f16),
+            {{"DATA_A_F16", "1"},
+             {"B_TYPE", "float16_t"},
+             {"D_TYPE", "uint16_t"},
+             {"D_IS_BF16", "1"},
+             {"D_MANUAL_COOPMAT_STORE", "1"}}),
+        fp16,
+        coopmat,
+        coopmat2,
+        f16acc);
+    string_to_spv(
+        "matmul_direct_f16_aligned",
+        source_name,
+        merge_maps(
+            merge_maps(base_dict, float_type_dict_f16),
+            {{"DATA_A_F16", "1"},
+             {"LOAD_VEC_A", load_vec},
+             {"LOAD_VEC_B", load_vec},
+             {"B_TYPE", aligned_b_type_f16},
+             {"D_TYPE", "float16_t"},
+             {"D_MANUAL_COOPMAT_STORE", "1"},
+             {"ALIGNED", "1"}}),
+        fp16,
+        coopmat,
+        coopmat2,
+        f16acc);
+    string_to_spv(
+        "matmul_direct_f16_bf16_aligned",
+        source_name,
+        merge_maps(
+            merge_maps(base_dict, float_type_dict_f16),
+            {{"DATA_A_F16", "1"},
+             {"LOAD_VEC_A", load_vec},
+             {"LOAD_VEC_B", load_vec},
+             {"B_TYPE", aligned_b_type_f16},
+             {"D_TYPE", "uint16_t"},
+             {"D_IS_BF16", "1"},
+             {"D_MANUAL_COOPMAT_STORE", "1"},
+             {"ALIGNED", "1"}}),
+        fp16,
+        coopmat,
+        coopmat2,
+        f16acc);
+  }
+
   // bf16
   {
     // For aligned matmul loads
@@ -626,6 +689,46 @@ void matmul_shaders(
           coopmat,
           coopmat2,
           f16acc);
+
+      if (matmul_id_type == MatMulIdType::NONE) {
+        string_to_spv(
+            "matmul_direct_bf16",
+            source_name,
+            merge_maps(
+                merge_maps(base_dict, float_type_dict_bf16),
+                {{"TO_FLOAT_TYPE", to_float_type},
+                 {"DATA_A_BF16", "1"},
+                 {"B_TYPE", coopmat2 ? "bfloat16_t" : "uint16_t"},
+                 {"D_TYPE", "uint16_t"},
+                 {"D_IS_BF16", "1"},
+                 {"D_MANUAL_COOPMAT_STORE", "1"},
+                 {"B_IS_FLOAT", "1"},
+                 {"DATA_B_BF16", "1"}}),
+            fp16,
+            coopmat,
+            coopmat2,
+            f16acc);
+        string_to_spv(
+            "matmul_direct_bf16_aligned",
+            source_name,
+            merge_maps(
+                merge_maps(base_dict, float_type_dict_bf16),
+                {{"TO_FLOAT_TYPE", to_float_type},
+                 {"DATA_A_BF16", "1"},
+                 {"LOAD_VEC_A", load_vec_a},
+                 {"LOAD_VEC_B", "4"},
+                 {"B_TYPE", coopmat2 ? "bfloat16_t" : "u16vec4"},
+                 {"D_TYPE", "uint16_t"},
+                 {"D_IS_BF16", "1"},
+                 {"D_MANUAL_COOPMAT_STORE", "1"},
+                 {"B_IS_FLOAT", "1"},
+                 {"DATA_B_BF16", "1"},
+                 {"ALIGNED", "1"}}),
+            fp16,
+            coopmat,
+            coopmat2,
+            f16acc);
+      }
     }
   }
 
@@ -1718,6 +1821,16 @@ void process_shaders() {
        {"FLOAT_TYPE", "float"}});
 
   string_to_spv("split_k_reduce", "mul_mat_split_k_reduce.comp", {});
+  string_to_spv(
+      "split_k_reduce_f16",
+      "mul_mat_split_k_reduce.comp",
+      {{"D_TYPE", "float16_t"}, {"D_MANUAL_VEC_STORE", "1"}});
+  string_to_spv(
+      "split_k_reduce_bf16",
+      "mul_mat_split_k_reduce.comp",
+      {{"D_TYPE", "uint16_t"},
+       {"D_IS_BF16", "1"},
+       {"D_MANUAL_VEC_STORE", "1"}});
   string_to_spv("fa_split_k_reduce", "flash_attn_split_k_reduce.comp", {});
 
   string_to_spv("fa_mask_opt", "flash_attn_mask_opt.comp", {});

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -433,6 +433,12 @@ uint32_t round_up_div(uint32_t value, uint32_t divisor) {
 
 uint32_t
 choose_split_k(uint32_t k, uint32_t num_batches, uint32_t split_k_threshold) {
+  // Latency-sensitive decode/prefill paths on current Vulkan targets perform
+  // better without split-K for the common K<=4096 regime.
+  if (num_batches == 1u && k <= 4096u) {
+    return 1u;
+  }
+
   if (split_k_threshold == 0 || k < split_k_threshold || num_batches > 2u) {
     return 1u;
   }

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -731,7 +731,7 @@ bool try_eval_matvec_vulkan(
     return false;
   }
 
-  bool a_is_vec = (a.shape(0) >= 2 && a.shape(0) <= kMaxMulMatVecCols);
+  bool a_is_vec = (a.shape(0) >= 1 && a.shape(0) <= kMaxMulMatVecCols);
   bool b_is_vec = (b.shape(1) == 1);
   bool is_matvec = a_is_vec || b_is_vec;
 

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -746,22 +746,22 @@ bool try_eval_matvec_vulkan(
       return false;
     }
     vec = a;
-    matrix = b;
+    matrix = swapaxes_in_eval(b, -1, -2);
   } else if (a_is_vec) {
     if (a.shape(1) != b.shape(0)) {
       return false;
     }
     vec = a;
-    matrix = b;
+    matrix = swapaxes_in_eval(b, -1, -2);
   } else {
     if (b.shape(1) != a.shape(0)) {
       return false;
     }
-    vec = b;
+    vec = swapaxes_in_eval(b, -1, -2);
     matrix = a;
   }
 
-  if (out.shape(0) != vec.shape(0) || out.shape(1) != matrix.shape(1)) {
+  if (out.shape(0) != vec.shape(0) || out.shape(1) != matrix.shape(0)) {
     return false;
   }
 

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -32,7 +32,7 @@ constexpr char kMatvecOutScratchLane[] = "matvec.out_work";
 constexpr char kMatvecScoresVOutScratchLane[] = "matvec.scores_v.out_work";
 constexpr char kMulMmACastScratchLane[] = "mul_mm.a_f16";
 constexpr char kMulMmBCastScratchLane[] = "mul_mm.b_f16";
-constexpr char kMulMmOutScratchLane[] = "mul_mm.out_t";
+constexpr char kMulMmOutScratchLane[] = "mul_mm.out_work";
 constexpr char kMulMmSplitKScratchLane[] = "mul_mm.split_k";
 
 bool is_supported_matmul_dtype(Dtype dtype) {
@@ -93,17 +93,6 @@ bool mul_mm_enabled() {
     const char* env = std::getenv("MLX_VULKAN_ENABLE_MUL_MM");
     if (env == nullptr) {
       return true;
-    }
-    return std::string(env) != "0";
-  }();
-  return enabled;
-}
-
-bool mul_mm_batch_sync_enabled() {
-  static const bool enabled = []() {
-    const char* env = std::getenv("MLX_VULKAN_MUL_MM_BATCH_SYNC");
-    if (env == nullptr) {
-      return false;
     }
     return std::string(env) != "0";
   }();
@@ -280,6 +269,77 @@ std::vector<vulkan::StaticShaderId> mul_mm_shader_candidates(
       };
     default:
       return {};
+  }
+}
+
+std::vector<vulkan::StaticShaderId> mul_mm_direct_shader_candidates(
+    Dtype input_dtype,
+    Dtype output_dtype,
+    bool prefer_fp32_accum) {
+  switch (input_dtype) {
+    case float16:
+      switch (output_dtype) {
+        case float16:
+          return prefer_fp32_accum
+              ? std::vector<vulkan::StaticShaderId>{
+                    vulkan::StaticShaderId::matmul_direct_f16,
+                    vulkan::StaticShaderId::matmul_direct_f16_f16acc,
+                }
+              : std::vector<vulkan::StaticShaderId>{
+                    vulkan::StaticShaderId::matmul_direct_f16_f16acc,
+                    vulkan::StaticShaderId::matmul_direct_f16,
+                };
+        case bfloat16:
+          return prefer_fp32_accum
+              ? std::vector<vulkan::StaticShaderId>{
+                    vulkan::StaticShaderId::matmul_direct_f16_bf16,
+                    vulkan::StaticShaderId::matmul_direct_f16_bf16_f16acc,
+                }
+              : std::vector<vulkan::StaticShaderId>{
+                    vulkan::StaticShaderId::matmul_direct_f16_bf16_f16acc,
+                    vulkan::StaticShaderId::matmul_direct_f16_bf16,
+                };
+        case float32:
+          return mul_mm_shader_candidates(input_dtype, prefer_fp32_accum);
+        default:
+          return {};
+      }
+    case bfloat16:
+      if (!vulkan::VulkanContext::get().shader_bfloat16_supported()) {
+        return {};
+      }
+      if (output_dtype != bfloat16) {
+        return output_dtype == float32
+            ? mul_mm_shader_candidates(input_dtype, prefer_fp32_accum)
+            : std::vector<vulkan::StaticShaderId>{};
+      }
+      return prefer_fp32_accum
+          ? std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_direct_bf16,
+                vulkan::StaticShaderId::matmul_direct_bf16_f16acc,
+            }
+          : std::vector<vulkan::StaticShaderId>{
+                vulkan::StaticShaderId::matmul_direct_bf16_f16acc,
+                vulkan::StaticShaderId::matmul_direct_bf16,
+            };
+    case float32:
+      return output_dtype == float32
+          ? mul_mm_shader_candidates(input_dtype, prefer_fp32_accum)
+          : std::vector<vulkan::StaticShaderId>{};
+    default:
+      return {};
+  }
+}
+
+vulkan::StaticShaderId split_k_reduce_shader_id(Dtype out_dtype) {
+  switch (out_dtype) {
+    case float16:
+      return vulkan::StaticShaderId::split_k_reduce_f16;
+    case bfloat16:
+      return vulkan::StaticShaderId::split_k_reduce_bf16;
+    case float32:
+    default:
+      return vulkan::StaticShaderId::split_k_reduce;
   }
 }
 
@@ -868,22 +928,14 @@ bool try_eval_mul_mm_vulkan(
     return false;
   }
 
-  Shape out_t_shape = out.shape();
-  std::swap(
-      out_t_shape[out_t_shape.size() - 1], out_t_shape[out_t_shape.size() - 2]);
-  array out_t = vulkan::acquire_scratch_array(
-      s, kMulMmOutScratchLane, out_t_shape, float32);
-
-  if (!ensure_vulkan_buffer(a, s) || !ensure_vulkan_buffer(b_t, s) ||
-      !ensure_vulkan_buffer(out_t, s)) {
+  if (!ensure_vulkan_buffer(a, s) || !ensure_vulkan_buffer(b_t, s)) {
     if (matmul_debug_enabled()) {
       std::cerr << "[vulkan::mul_mm] missing buffer"
                 << " a=" << has_vulkan_buffer(a) << " a_status=" << a.status()
                 << " a_has_primitive=" << a.has_primitive()
                 << " b_t=" << has_vulkan_buffer(b_t)
                 << " b_t_status=" << b_t.status()
-                << " b_t_has_primitive=" << b_t.has_primitive()
-                << " out_t=" << has_vulkan_buffer(out_t) << "\n";
+                << " b_t_has_primitive=" << b_t.has_primitive() << "\n";
     }
     return false;
   }
@@ -892,26 +944,15 @@ bool try_eval_mul_mm_vulkan(
   const uint32_t n = static_cast<uint32_t>(out.shape(-1));
   const uint32_t k = static_cast<uint32_t>(a.shape(-1));
   auto tuning = select_matmul_dispatch_tuning(a.dtype(), m, n, k);
-  auto shader_candidates =
-      mul_mm_shader_candidates(a.dtype(), tuning.prefer_fp32_accum);
-  if (shader_candidates.empty()) {
-    return false;
-  }
 
   const uint32_t batch_stride_a =
       static_cast<uint32_t>(a.shape(-2) * a.shape(-1));
   const uint32_t batch_stride_b =
       static_cast<uint32_t>(b_t.shape(-2) * b_t.shape(-1));
-  const uint32_t batch_stride_d =
-      static_cast<uint32_t>(out_t.shape(-2) * out_t.shape(-1));
 
   uint64_t num_batches_u64 = 1;
   for (int i = 0; i < static_cast<int>(out.ndim()) - 2; ++i) {
     num_batches_u64 *= static_cast<uint64_t>(out.shape(i));
-  }
-  if (num_batches_u64 == 0) {
-    copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
-    return true;
   }
   if (num_batches_u64 > std::numeric_limits<uint32_t>::max()) {
     return false;
@@ -919,50 +960,6 @@ bool try_eval_mul_mm_vulkan(
   const uint32_t num_batches = static_cast<uint32_t>(num_batches_u64);
   const uint32_t split_k =
       choose_split_k(k, num_batches, tuning.split_k_threshold);
-
-  std::optional<array> split_k_out;
-  if (split_k > 1u) {
-    const uint64_t split_k_elems = static_cast<uint64_t>(batch_stride_d) *
-        static_cast<uint64_t>(num_batches) * static_cast<uint64_t>(split_k);
-    if (split_k_elems >
-        static_cast<uint64_t>(std::numeric_limits<int>::max())) {
-      return false;
-    }
-    split_k_out = vulkan::acquire_scratch_array(
-        s,
-        kMulMmSplitKScratchLane,
-        {
-            static_cast<int>(split_k * num_batches),
-            static_cast<int>(n),
-            static_cast<int>(m),
-        },
-        float32);
-    if (!ensure_vulkan_buffer(*split_k_out, s)) {
-      return false;
-    }
-  }
-
-  if (num_batches > 1) {
-    ::mlx::core::gpu::synchronize(s);
-  }
-
-  vulkan::MatmulPushConstants push_constants{};
-  push_constants.M = m;
-  push_constants.N = n;
-  push_constants.K = k;
-  push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
-  push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
-  push_constants.stride_d = static_cast<uint32_t>(out_t.strides(-2));
-  push_constants.batch_stride_a = batch_stride_a;
-  push_constants.batch_stride_b = batch_stride_b;
-  push_constants.batch_stride_d = batch_stride_d;
-  push_constants.num_batches = num_batches;
-  push_constants.k_split = round_up_div(k, split_k);
-  push_constants.ne02 = num_batches;
-  push_constants.ne12 = num_batches;
-  push_constants.broadcast2 = 1;
-  push_constants.broadcast3 = 1;
-  push_constants.padded_N = n;
 
   const uint32_t tile_m = tuning.specialization_constants.size() > 1
       ? tuning.specialization_constants[1]
@@ -973,124 +970,210 @@ bool try_eval_mul_mm_vulkan(
   const uint32_t blocks_m = (m + tile_m - 1) / tile_m;
   const uint32_t blocks_n = (n + tile_n - 1) / tile_n;
 
-  if (matmul_debug_enabled()) {
-    std::cerr << "[vulkan::mul_mm] a_shape=" << a.shape()
-              << " a_strides=" << a.strides() << " b_t_shape=" << b_t.shape()
-              << " b_t_strides=" << b_t.strides()
-              << " out_t_shape=" << out_t.shape()
-              << " out_t_strides=" << out_t.strides() << " pc(M,N,K)=" << m
-              << "," << n << "," << k
-              << " stride(a,b,d)=" << push_constants.stride_a << ","
-              << push_constants.stride_b << "," << push_constants.stride_d
-              << " batch=" << num_batches
-              << " family=" << matmul_family_name(tuning.family)
-              << " aligned=" << tuning.aligned
-              << " subgroup=" << tuning.specialization_constants[10]
-              << " fp32_accum=" << tuning.prefer_fp32_accum
-              << " split_k_threshold=" << tuning.split_k_threshold
-              << " split_k=" << split_k << "\n";
-  }
-
-  for (const auto shader_id : shader_candidates) {
-    bool dispatched = true;
-    bool should_recover_stream = false;
-    try {
-      auto command_buffer = vulkan::begin_command_recording(s.index);
-      for (uint32_t base_z = 0; base_z < num_batches; base_z += kMaxGridZ) {
-        const uint32_t chunk_z = std::min(kMaxGridZ, num_batches - base_z);
-        push_constants.base_work_group_z = base_z;
-        const std::array<uint32_t, 3> grid = {
-            blocks_m * split_k,
-            blocks_n,
-            chunk_z,
-        };
-
-        vulkan::dispatch_mul_mm_op(
-            a,
-            b_t,
-            split_k_out.has_value() ? *split_k_out : out_t,
-            shader_id,
-            command_buffer,
-            s,
-            push_constants,
-            grid,
-            tuning.specialization_constants);
-      }
-
-      if (split_k_out.has_value()) {
-        insert_compute_barrier(command_buffer);
-        vulkan::MatmulSplitKReducePushConstants reduce_push_constants{};
-        reduce_push_constants.ne = batch_stride_d * num_batches;
-        reduce_push_constants.k_num = split_k;
-        vulkan::dispatch_matmul_split_k_reduce_op(
-            *split_k_out,
-            out_t,
-            vulkan::StaticShaderId::split_k_reduce,
-            command_buffer,
-            s,
-            reduce_push_constants,
-            {
-                round_up_div(batch_stride_d * num_batches, 256u * 4u),
-                1u,
-                1u,
-            },
-            {});
-        vulkan::mark_scratch_array_written(s, kMulMmSplitKScratchLane);
-      }
-
-      vulkan::end_command_recording(s.index);
-    } catch (const std::runtime_error& e) {
-      if (matmul_debug_enabled()) {
-        std::cerr << "[vulkan::mul_mm] shader="
-                  << vulkan::static_shader_name(shader_id)
-                  << " failed: " << e.what() << "\n";
-      }
-      const std::string message = e.what();
-      if (message.find("[vulkan::submit_commands]") != std::string::npos ||
-          message.find("VkResult=") != std::string::npos) {
-        should_recover_stream = true;
-      }
-      dispatched = false;
+  auto try_dispatch = [&](const std::vector<vulkan::StaticShaderId>& shader_candidates,
+                          array& out_work,
+                          bool needs_out_copy) {
+    if (shader_candidates.empty()) {
+      return false;
     }
 
-    if (dispatched) {
-      if (matmul_debug_enabled()) {
-        std::cerr << "[vulkan::mul_mm] shader="
-                  << vulkan::static_shader_name(shader_id) << " dispatched\n";
+    const uint32_t batch_stride_d =
+        static_cast<uint32_t>(out_work.shape(-2) * out_work.shape(-1));
+
+    if (num_batches_u64 == 0) {
+      if (needs_out_copy) {
+        vulkan::mark_scratch_array_written(s, kMulMmOutScratchLane);
+        copy_gpu(out_work, out, CopyType::General, s);
       }
-      vulkan::mark_scratch_array_written(s, kMulMmOutScratchLane);
-      try {
-        if (matmul_debug_enabled()) {
-          std::cerr << "[vulkan::mul_mm] begin output copy\n";
-        }
-        copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
-        if (matmul_debug_enabled()) {
-          std::cerr << "[vulkan::mul_mm] end output copy\n";
-        }
-        if (num_batches > 1) {
-          ::mlx::core::gpu::synchronize(s);
-          if (matmul_debug_enabled()) {
-            std::cerr << "[vulkan::mul_mm] post-copy synchronize done\n";
-          }
-        }
-        return true;
-      } catch (const std::runtime_error& e) {
-        if (matmul_debug_enabled()) {
-          std::cerr << "[vulkan::mul_mm] output copy failed: " << e.what()
-                    << "\n";
-        }
-        disable_mul_mm_runtime(e.what());
+      return true;
+    }
+
+    std::optional<array> split_k_out;
+    if (split_k > 1u) {
+      const uint64_t split_k_elems = static_cast<uint64_t>(batch_stride_d) *
+          static_cast<uint64_t>(num_batches) * static_cast<uint64_t>(split_k);
+      if (split_k_elems >
+          static_cast<uint64_t>(std::numeric_limits<int>::max())) {
+        return false;
+      }
+      split_k_out = vulkan::acquire_scratch_array(
+          s,
+          kMulMmSplitKScratchLane,
+          {
+              static_cast<int>(split_k * num_batches),
+              static_cast<int>(m),
+              static_cast<int>(n),
+          },
+          float32);
+      if (!ensure_vulkan_buffer(*split_k_out, s)) {
         return false;
       }
     }
 
-    if (should_recover_stream) {
-      disable_mul_mm_runtime("submit failure");
-      return false;
+    vulkan::MatmulPushConstants push_constants{};
+    push_constants.M = m;
+    push_constants.N = n;
+    push_constants.K = k;
+    push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
+    push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
+    push_constants.stride_d = static_cast<uint32_t>(out_work.strides(-2));
+    push_constants.batch_stride_a = batch_stride_a;
+    push_constants.batch_stride_b = batch_stride_b;
+    push_constants.batch_stride_d = batch_stride_d;
+    push_constants.num_batches = num_batches;
+    push_constants.k_split = round_up_div(k, split_k);
+    push_constants.ne02 = num_batches;
+    push_constants.ne12 = num_batches;
+    push_constants.broadcast2 = 1;
+    push_constants.broadcast3 = 1;
+    push_constants.padded_N = n;
+
+    if (matmul_debug_enabled()) {
+      std::cerr << "[vulkan::mul_mm] a_shape=" << a.shape()
+                << " a_strides=" << a.strides() << " b_t_shape=" << b_t.shape()
+                << " b_t_strides=" << b_t.strides()
+                << " out_shape=" << out_work.shape()
+                << " out_strides=" << out_work.strides() << " pc(M,N,K)=" << m
+                << "," << n << "," << k
+                << " stride(a,b,d)=" << push_constants.stride_a << ","
+                << push_constants.stride_b << "," << push_constants.stride_d
+                << " batch=" << num_batches
+                << " family=" << matmul_family_name(tuning.family)
+                << " aligned=" << tuning.aligned
+                << " subgroup=" << tuning.specialization_constants[10]
+                << " fp32_accum=" << tuning.prefer_fp32_accum
+                << " split_k_threshold=" << tuning.split_k_threshold
+                << " split_k=" << split_k << "\n";
+    }
+
+    for (const auto shader_id : shader_candidates) {
+      bool dispatched = true;
+      bool should_recover_stream = false;
+      try {
+        auto command_buffer = vulkan::begin_command_recording(s.index);
+        for (uint32_t base_z = 0; base_z < num_batches; base_z += kMaxGridZ) {
+          const uint32_t chunk_z = std::min(kMaxGridZ, num_batches - base_z);
+          push_constants.base_work_group_z = base_z;
+          const std::array<uint32_t, 3> grid = {
+              blocks_m * split_k,
+              blocks_n,
+              chunk_z,
+          };
+
+          vulkan::dispatch_mul_mm_op(
+              a,
+              b_t,
+              split_k_out.has_value() ? *split_k_out : out_work,
+              shader_id,
+              command_buffer,
+              s,
+              push_constants,
+              grid,
+              tuning.specialization_constants);
+        }
+
+        if (split_k_out.has_value()) {
+          insert_compute_barrier(command_buffer);
+          vulkan::MatmulSplitKReducePushConstants reduce_push_constants{};
+          reduce_push_constants.ne = batch_stride_d * num_batches;
+          reduce_push_constants.k_num = split_k;
+          vulkan::dispatch_matmul_split_k_reduce_op(
+              *split_k_out,
+              out_work,
+              split_k_reduce_shader_id(out_work.dtype()),
+              command_buffer,
+              s,
+              reduce_push_constants,
+              {
+                  round_up_div(batch_stride_d * num_batches, 256u * 4u),
+                  1u,
+                  1u,
+              },
+              {});
+          vulkan::mark_scratch_array_written(s, kMulMmSplitKScratchLane);
+        }
+
+        vulkan::end_command_recording(s.index);
+      } catch (const std::runtime_error& e) {
+        if (matmul_debug_enabled()) {
+          std::cerr << "[vulkan::mul_mm] shader="
+                    << vulkan::static_shader_name(shader_id)
+                    << " failed: " << e.what() << "\n";
+        }
+        const std::string message = e.what();
+        if (message.find("[vulkan::submit_commands]") != std::string::npos ||
+            message.find("VkResult=") != std::string::npos) {
+          should_recover_stream = true;
+        }
+        dispatched = false;
+      }
+
+      if (dispatched) {
+        if (matmul_debug_enabled()) {
+          std::cerr << "[vulkan::mul_mm] shader="
+                    << vulkan::static_shader_name(shader_id) << " dispatched\n";
+        }
+        try {
+          if (needs_out_copy) {
+            vulkan::mark_scratch_array_written(s, kMulMmOutScratchLane);
+            if (matmul_debug_enabled()) {
+              std::cerr << "[vulkan::mul_mm] begin output copy\n";
+            }
+            copy_gpu(out_work, out, CopyType::General, s);
+            if (matmul_debug_enabled()) {
+              std::cerr << "[vulkan::mul_mm] end output copy\n";
+            }
+          }
+          return true;
+        } catch (const std::runtime_error& e) {
+          if (matmul_debug_enabled()) {
+            std::cerr << "[vulkan::mul_mm] output copy failed: " << e.what()
+                      << "\n";
+          }
+          disable_mul_mm_runtime(e.what());
+          return false;
+        }
+      }
+
+      if (should_recover_stream) {
+        disable_mul_mm_runtime("submit failure");
+        return false;
+      }
+    }
+
+    return false;
+  };
+
+  const bool can_direct_write = split_k == 1u && is_row_contiguous_zero_offset(out);
+  if (can_direct_write) {
+    auto direct_candidates = mul_mm_direct_shader_candidates(
+        a.dtype(), out.dtype(), tuning.prefer_fp32_accum);
+    array out_direct = out;
+    out_direct.set_data(allocator::malloc(out_direct.nbytes()));
+    if (ensure_vulkan_buffer(out_direct, s) &&
+        try_dispatch(direct_candidates, out_direct, false)) {
+      return true;
     }
   }
 
-  return false;
+  auto shader_candidates =
+      mul_mm_shader_candidates(a.dtype(), tuning.prefer_fp32_accum);
+  array out_work = out;
+  const bool can_direct_split_k_reduce =
+      split_k > 1u && is_row_contiguous_zero_offset(out_work);
+  const bool needs_out_copy =
+      !is_row_contiguous_zero_offset(out_work) ||
+      (split_k == 1u && out.dtype() != float32);
+  if (needs_out_copy) {
+    out_work = vulkan::acquire_scratch_array(
+        s, kMulMmOutScratchLane, out.shape(), float32);
+  } else {
+    out_work.set_data(allocator::malloc(out_work.nbytes()));
+  }
+  if (!ensure_vulkan_buffer(out_work, s)) {
+    return false;
+  }
+  return try_dispatch(shader_candidates, out_work, needs_out_copy);
 }
 
 } // namespace

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -352,9 +352,11 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
           s,
           push_constants,
           {1u, 1u, 1u});
+      set_force_immediate_submit(s);
       end_command_recording(s.index);
     };
 
+    std::vector<std::pair<StaticShaderId, array>> direct_probe_outputs;
     for (auto shader_id : {
              StaticShaderId::matmul_direct_bf16,
              StaticShaderId::matmul_direct_bf16_f16acc,
@@ -362,32 +364,35 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
       try {
         array out_direct = make_array({2, 2}, bfloat16);
         dispatch_probe(shader_id, out_direct);
-        synchronize_stream(s);
-        if (verify_bf16(out_direct)) {
-          return true;
-        }
+        direct_probe_outputs.emplace_back(shader_id, std::move(out_direct));
       } catch (const std::runtime_error&) {
       }
     }
 
+    std::vector<std::pair<StaticShaderId, array>> legacy_probe_outputs;
     for (auto shader_id : {
              StaticShaderId::matmul_bf16_fp32,
              StaticShaderId::matmul_bf16,
          }) {
       try {
-        array out_t = make_array({2, 2}, float32);
         array out = make_array({2, 2}, float32);
-        dispatch_probe(shader_id, out_t);
-        copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
-        synchronize_stream(s);
-        if (verify_fp32(out)) {
-          return true;
-        }
+        dispatch_probe(shader_id, out);
+        legacy_probe_outputs.emplace_back(shader_id, std::move(out));
       } catch (const std::runtime_error&) {
       }
     }
 
-    synchronize_stream(s);
+    for (const auto& output : direct_probe_outputs) {
+      if (verify_bf16(output.second)) {
+        return true;
+      }
+    }
+    for (const auto& output : legacy_probe_outputs) {
+      if (verify_fp32(output.second)) {
+        return true;
+      }
+    }
+
     return false;
   } catch (const std::runtime_error&) {
     return false;

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -286,7 +286,8 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
 
     array a = make_array({2, 3}, bfloat16);
     array b_t = make_array({2, 3}, bfloat16);
-    array out = make_array({2, 2}, bfloat16);
+    array out_t = make_array({2, 2}, float32);
+    array out = make_array({2, 2}, float32);
 
     auto* a_ptr = a.data<bfloat16_t>();
     a_ptr[0] = 1.0f;
@@ -304,60 +305,90 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
     b_ptr[4] = 1.0f;
     b_ptr[5] = -1.0f;
 
-    MatmulPushConstants push_constants{};
-    push_constants.M = 2;
-    push_constants.N = 2;
-    push_constants.K = 3;
-    push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
-    push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
-    push_constants.stride_d = static_cast<uint32_t>(out.strides(-2));
-    push_constants.batch_stride_a = 6;
-    push_constants.batch_stride_b = 6;
-    push_constants.batch_stride_d = 4;
-    push_constants.num_batches = 1;
-    push_constants.k_split = 3;
-    push_constants.ne02 = 1;
-    push_constants.ne12 = 1;
-    push_constants.broadcast2 = 1;
-    push_constants.broadcast3 = 1;
-    push_constants.padded_N = 2;
-    push_constants.base_work_group_z = 0;
+    auto verify_fp32 = [](const array& out_arr) {
+      const auto* out_ptr = out_arr.data<float>();
+      return nearly_equal(out_ptr[0], 4.0f) &&
+          nearly_equal(out_ptr[1], -1.0f) &&
+          nearly_equal(out_ptr[2], 10.0f) &&
+          nearly_equal(out_ptr[3], -1.0f);
+    };
 
-    bool dispatched = false;
+    auto verify_bf16 = [](const array& out_arr) {
+      const auto* out_ptr = out_arr.data<bfloat16_t>();
+      return nearly_equal(static_cast<float>(out_ptr[0]), 4.0f) &&
+          nearly_equal(static_cast<float>(out_ptr[1]), -1.0f) &&
+          nearly_equal(static_cast<float>(out_ptr[2]), 10.0f) &&
+          nearly_equal(static_cast<float>(out_ptr[3]), -1.0f);
+    };
+
+    auto dispatch_probe = [&](StaticShaderId shader_id, array& dst) {
+      MatmulPushConstants push_constants{};
+      push_constants.M = 2;
+      push_constants.N = 2;
+      push_constants.K = 3;
+      push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
+      push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
+      push_constants.stride_d = static_cast<uint32_t>(dst.strides(-2));
+      push_constants.batch_stride_a = 6;
+      push_constants.batch_stride_b = 6;
+      push_constants.batch_stride_d =
+          static_cast<uint32_t>(dst.shape(-2) * dst.shape(-1));
+      push_constants.num_batches = 1;
+      push_constants.k_split = 3;
+      push_constants.ne02 = 1;
+      push_constants.ne12 = 1;
+      push_constants.broadcast2 = 1;
+      push_constants.broadcast3 = 1;
+      push_constants.padded_N = 2;
+      push_constants.base_work_group_z = 0;
+
+      auto command_buffer = begin_command_recording(s.index);
+      dispatch_mul_mm_op(
+          a,
+          b_t,
+          dst,
+          shader_id,
+          command_buffer,
+          s,
+          push_constants,
+          {1u, 1u, 1u});
+      end_command_recording(s.index);
+    };
+
     for (auto shader_id : {
-             StaticShaderId::matmul_bf16,
-             StaticShaderId::matmul_bf16_fp32,
+             StaticShaderId::matmul_direct_bf16,
+             StaticShaderId::matmul_direct_bf16_f16acc,
          }) {
       try {
-        auto command_buffer = begin_command_recording(s.index);
-        dispatch_mul_mm_op(
-            a,
-            b_t,
-            out,
-            shader_id,
-            command_buffer,
-            s,
-            push_constants,
-            {1u, 1u, 1u});
-        end_command_recording(s.index);
-        dispatched = true;
-        break;
+        array out_direct = make_array({2, 2}, bfloat16);
+        dispatch_probe(shader_id, out_direct);
+        synchronize_stream(s);
+        if (verify_bf16(out_direct)) {
+          return true;
+        }
       } catch (const std::runtime_error&) {
       }
     }
 
-    if (!dispatched) {
-      synchronize_stream(s);
-      return false;
+    for (auto shader_id : {
+             StaticShaderId::matmul_bf16_fp32,
+             StaticShaderId::matmul_bf16,
+         }) {
+      try {
+        array out_t = make_array({2, 2}, float32);
+        array out = make_array({2, 2}, float32);
+        dispatch_probe(shader_id, out_t);
+        copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
+        synchronize_stream(s);
+        if (verify_fp32(out)) {
+          return true;
+        }
+      } catch (const std::runtime_error&) {
+      }
     }
 
     synchronize_stream(s);
-
-    const auto* out_ptr = out.data<bfloat16_t>();
-    return nearly_equal(static_cast<float>(out_ptr[0]), 4.0f) &&
-        nearly_equal(static_cast<float>(out_ptr[1]), -1.0f) &&
-        nearly_equal(static_cast<float>(out_ptr[2]), 10.0f) &&
-        nearly_equal(static_cast<float>(out_ptr[3]), -1.0f);
+    return false;
   } catch (const std::runtime_error&) {
     return false;
   }

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -286,8 +286,7 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
 
     array a = make_array({2, 3}, bfloat16);
     array b_t = make_array({2, 3}, bfloat16);
-    array out_t = make_array({2, 2}, float32);
-    array out = make_array({2, 2}, float32);
+    array out = make_array({2, 2}, bfloat16);
 
     auto* a_ptr = a.data<bfloat16_t>();
     a_ptr[0] = 1.0f;
@@ -311,7 +310,7 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
     push_constants.K = 3;
     push_constants.stride_a = static_cast<uint32_t>(a.strides(-2));
     push_constants.stride_b = static_cast<uint32_t>(b_t.strides(-2));
-    push_constants.stride_d = static_cast<uint32_t>(out_t.strides(-2));
+    push_constants.stride_d = static_cast<uint32_t>(out.strides(-2));
     push_constants.batch_stride_a = 6;
     push_constants.batch_stride_b = 6;
     push_constants.batch_stride_d = 4;
@@ -334,7 +333,7 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
         dispatch_mul_mm_op(
             a,
             b_t,
-            out_t,
+            out,
             shader_id,
             command_buffer,
             s,
@@ -352,12 +351,13 @@ bool VulkanContext::probe_shader_bfloat16_support() const {
       return false;
     }
 
-    copy_gpu(swapaxes_in_eval(out_t, -1, -2), out, CopyType::General, s);
     synchronize_stream(s);
 
-    const auto* out_ptr = out.data<float>();
-    return nearly_equal(out_ptr[0], 4.0f) && nearly_equal(out_ptr[1], -1.0f) &&
-        nearly_equal(out_ptr[2], 10.0f) && nearly_equal(out_ptr[3], -1.0f);
+    const auto* out_ptr = out.data<bfloat16_t>();
+    return nearly_equal(static_cast<float>(out_ptr[0]), 4.0f) &&
+        nearly_equal(static_cast<float>(out_ptr[1]), -1.0f) &&
+        nearly_equal(static_cast<float>(out_ptr[2]), 10.0f) &&
+        nearly_equal(static_cast<float>(out_ptr[3]), -1.0f);
   } catch (const std::runtime_error&) {
     return false;
   }

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -496,6 +496,132 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
         gpu_out = self._run_on_device(mx.gpu, run_copy).astype(mx.float32)
         self._assert_outputs_close(gpu_out, cpu_out, atol=1e-2, rtol=1e-2)
 
+    def test_cached_prefill_parity_regression(self):
+        class TinyKVCache:
+            def __init__(self):
+                self.keys = None
+                self.values = None
+                self.offset = 0
+
+            def update_and_fetch(self, keys, values):
+                prev = self.offset
+                if self.keys is None:
+                    batch, n_kv_heads, steps, head_dim = keys.shape
+                    value_dim = values.shape[-1]
+                    alloc_steps = max(steps, 16)
+                    self.keys = mx.zeros(
+                        (batch, n_kv_heads, alloc_steps, head_dim), dtype=keys.dtype
+                    )
+                    self.values = mx.zeros(
+                        (batch, n_kv_heads, alloc_steps, value_dim), dtype=values.dtype
+                    )
+                self.offset += keys.shape[2]
+                self.keys[..., prev : self.offset, :] = keys
+                self.values[..., prev : self.offset, :] = values
+                return (
+                    self.keys[..., : self.offset, :],
+                    self.values[..., : self.offset, :],
+                )
+
+        def run(dtype=mx.bfloat16):
+            batch = 1
+            prompt_len = 13
+            dim = 64
+            n_heads = 4
+            n_kv_heads = 2
+            head_dim = 16
+            vocab = 97
+
+            tokens = mx.arange(prompt_len, dtype=mx.uint32)[None]
+            embed = (
+                mx.arange(vocab * dim, dtype=mx.float32).reshape(vocab, dim) / 97.0
+            ).astype(dtype)
+            w_q = (
+                mx.arange(dim * (n_heads * head_dim), dtype=mx.float32).reshape(
+                    dim, n_heads * head_dim
+                )
+                / 211.0
+            ).astype(dtype)
+            w_k = (
+                mx.arange(dim * (n_kv_heads * head_dim), dtype=mx.float32).reshape(
+                    dim, n_kv_heads * head_dim
+                )
+                / 173.0
+            ).astype(dtype)
+            w_v = (
+                mx.arange(dim * (n_kv_heads * head_dim), dtype=mx.float32).reshape(
+                    dim, n_kv_heads * head_dim
+                )
+                / 157.0
+            ).astype(dtype)
+            w_o = (
+                mx.arange((n_heads * head_dim) * dim, dtype=mx.float32).reshape(
+                    n_heads * head_dim, dim
+                )
+                / 193.0
+            ).astype(dtype)
+            lm_head = (
+                mx.arange(dim * vocab, dtype=mx.float32).reshape(dim, vocab) / 181.0
+            ).astype(dtype)
+
+            def rms_norm(x, eps=1e-5):
+                x_f32 = x.astype(mx.float32)
+                scale = mx.rsqrt(
+                    mx.mean(mx.square(x_f32), axis=-1, keepdims=True) + eps
+                )
+                return (x_f32 * scale).astype(dtype)
+
+            def attention(x, cache=None):
+                q = mx.matmul(x, w_q).reshape(batch, prompt_len, n_heads, head_dim)
+                k = mx.matmul(x, w_k).reshape(batch, prompt_len, n_kv_heads, head_dim)
+                v = mx.matmul(x, w_v).reshape(batch, prompt_len, n_kv_heads, head_dim)
+                q = rms_norm(q).transpose(0, 2, 1, 3)
+                k = rms_norm(k).transpose(0, 2, 1, 3)
+                v = v.transpose(0, 2, 1, 3)
+                if cache is not None:
+                    k, v = cache.update_and_fetch(k, v)
+                out = mx.fast.scaled_dot_product_attention(
+                    q,
+                    k,
+                    v,
+                    scale=head_dim**-0.5,
+                    mask="causal",
+                )
+                out = out.transpose(0, 2, 1, 3).reshape(batch, prompt_len, dim)
+                return mx.matmul(out, w_o)
+
+            x = embed[tokens]
+            layer_no_cache = attention(rms_norm(x), cache=None)
+            layer_cached = attention(rms_norm(x), cache=TinyKVCache())
+            logits_no_cache = mx.matmul(layer_no_cache, lm_head)[:, -1, :].astype(
+                mx.float32
+            )
+            logits_cached = mx.matmul(layer_cached, lm_head)[:, -1, :].astype(
+                mx.float32
+            )
+            return (
+                layer_no_cache[:, -1, :].astype(mx.float32),
+                layer_cached[:, -1, :].astype(mx.float32),
+                logits_no_cache,
+                logits_cached,
+            )
+
+        cpu_layer_no, cpu_layer_cached, cpu_logits_no, cpu_logits_cached = (
+            self._run_on_device(mx.cpu, run)
+        )
+        gpu_layer_no, gpu_layer_cached, gpu_logits_no, gpu_logits_cached = (
+            self._run_on_device(mx.gpu, run)
+        )
+
+        self._assert_outputs_close(cpu_layer_cached, cpu_layer_no, atol=1e-2, rtol=1e-2)
+        self._assert_outputs_close(
+            cpu_logits_cached, cpu_logits_no, atol=1e-2, rtol=1e-2
+        )
+        self._assert_outputs_close(gpu_layer_cached, gpu_layer_no, atol=1e-2, rtol=1e-2)
+        self._assert_outputs_close(
+            gpu_logits_cached, gpu_logits_no, atol=1e-2, rtol=1e-2
+        )
+
     def test_host_source_slice_cast_copy_vulkan_gpu(self):
         host_src = self._run_on_device(
             mx.cpu,


### PR DESCRIPTION
## Summary
- harden the Vulkan BF16 runtime probe by validating both direct BF16 and legacy BF16 matmul shader paths
- avoid false negatives on drivers that do not report the BF16 extension but still execute BF16 kernels correctly
- closes goniz/mlx-vulkan#27

## Benchmarks
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1464.221, generation_tps=11.103, peak_memory=2.061
Trial 2:  prompt_tps=1530.614, generation_tps=11.046, peak_memory=2.062
Trial 3:  prompt_tps=1480.358, generation_tps=11.130, peak_memory=2.062
Trial 4:  prompt_tps=1481.330, generation_tps=11.163, peak_memory=2.062
Trial 5:  prompt_tps=1477.583, generation_tps=11.155, peak_memory=2.063
Averages: prompt_tps=1486.821, generation_tps=11.119, peak_memory=2.062
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=766.659, generation_tps=6.473, peak_memory=1.393
Trial 2:  prompt_tps=769.190, generation_tps=6.380, peak_memory=1.394
Trial 3:  prompt_tps=775.804, generation_tps=6.489, peak_memory=1.394
Trial 4:  prompt_tps=778.133, generation_tps=6.719, peak_memory=1.394
Trial 5:  prompt_tps=811.306, generation_tps=6.981, peak_memory=1.394
Averages: prompt_tps=780.218, generation_tps=6.608, peak_memory=1.394
```