### PR TITLE
fix(vulkan): reduce qmm parity error in non-transposed affine qmm

### DIFF
--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -396,7 +396,6 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   }
 
   if (!fused_dispatched) {
-    array x_mat_f32 = ensure_float32_row_contiguous(x_mat, s);
     array w_deq(expanded_quantized_shape(w, bits_), float32, nullptr, {});
     if (!vulkan::affine_dequantize_to_float32(
             w, scales, biases, w_deq, s, group_size_, bits_)) {
@@ -407,9 +406,34 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     array rhs = transpose_ ? swapaxes_in_eval(w_deq, -1, -2) : w_deq;
     rhs = ensure_row_contiguous_zero_offset(rhs, s);
 
-    if (!try_eval_matmul_vulkan({x_mat_f32, rhs}, out_work, s)) {
+    bool lowp_dispatched = false;
+    if (x_mat.dtype() != float32) {
+      array lhs_lowp = ensure_row_contiguous_zero_offset(x_mat, s);
+      array rhs_lowp(rhs.shape(), x_mat.dtype(), nullptr, {});
+      rhs_lowp.set_data(allocator::malloc(rhs_lowp.nbytes()));
+      copy_gpu(rhs, rhs_lowp, CopyType::General, s);
+
+      array out_lowp(out_work.shape(), x_mat.dtype(), nullptr, {});
+      if (try_eval_matmul_vulkan({lhs_lowp, rhs_lowp}, out_lowp, s)) {
+        out_work.set_data(allocator::malloc(out_work.nbytes()));
+        copy_gpu(out_lowp, out_work, CopyType::General, s);
+        lowp_dispatched = true;
+      }
+
+      rhs = ensure_float32_row_contiguous(rhs_lowp, s);
+    }
+
+    if (!lowp_dispatched) {
+      array x_mat_f32 = ensure_float32_row_contiguous(x_mat, s);
+      if (!try_eval_matmul_vulkan({x_mat_f32, rhs}, out_work, s)) {
+        throw std::runtime_error(
+            "[QuantizedMatmul::eval_gpu] Failed to dispatch Vulkan matmul.");
+      }
+    }
+
+    if (out_work.dtype() != float32) {
       throw std::runtime_error(
-          "[QuantizedMatmul::eval_gpu] Failed to dispatch Vulkan matmul.");
+          "[QuantizedMatmul::eval_gpu] Internal error: expected float32 work buffer.");
     }
   }
 

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -403,15 +403,15 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           "[QuantizedMatmul::eval_gpu] Failed to dequantize weights on Vulkan.");
     }
 
-    array rhs = transpose_ ? swapaxes_in_eval(w_deq, -1, -2) : w_deq;
-    rhs = ensure_row_contiguous_zero_offset(rhs, s);
+    array rhs_f32 = transpose_ ? swapaxes_in_eval(w_deq, -1, -2) : w_deq;
+    rhs_f32 = ensure_row_contiguous_zero_offset(rhs_f32, s);
 
     bool lowp_dispatched = false;
     if (x_mat.dtype() != float32) {
       array lhs_lowp = ensure_row_contiguous_zero_offset(x_mat, s);
-      array rhs_lowp(rhs.shape(), x_mat.dtype(), nullptr, {});
+      array rhs_lowp(rhs_f32.shape(), x_mat.dtype(), nullptr, {});
       rhs_lowp.set_data(allocator::malloc(rhs_lowp.nbytes()));
-      copy_gpu(rhs, rhs_lowp, CopyType::General, s);
+      copy_gpu(rhs_f32, rhs_lowp, CopyType::General, s);
 
       array out_lowp(out_work.shape(), x_mat.dtype(), nullptr, {});
       if (try_eval_matmul_vulkan({lhs_lowp, rhs_lowp}, out_lowp, s)) {
@@ -420,12 +420,11 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         lowp_dispatched = true;
       }
 
-      rhs = ensure_float32_row_contiguous(rhs_lowp, s);
     }
 
     if (!lowp_dispatched) {
       array x_mat_f32 = ensure_float32_row_contiguous(x_mat, s);
-      if (!try_eval_matmul_vulkan({x_mat_f32, rhs}, out_work, s)) {
+      if (!try_eval_matmul_vulkan({x_mat_f32, rhs_f32}, out_work, s)) {
         throw std::runtime_error(
             "[QuantizedMatmul::eval_gpu] Failed to dispatch Vulkan matmul.");
       }


### PR DESCRIPTION
## Summary
- Prefer low-precision Vulkan matmul in the non-fused affine QMM fallback when the activation is `float16`/`bfloat16`, and keep a float32 fallback for unsupported paths.
- This aligns compute precision with the dequantized reference path for non-transposed QMM and removes the small parity drift that was tripping GPU tolerance checks.
- Closes goniz/mlx-vulkan#36.

## Validation
- `./dev.sh run env DEVICE=gpu pytest mlx/python/tests/test_quantized.py -k \"test_qmm or test_qmm_shapes\" -vv`
  - Result: `5 passed, 22 deselected, 288 subtests passed`

## Benchmark Results
### `./dev.sh benchmark bf16`
```text
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1481.936, generation_tps=11.113, peak_memory=2.061
Trial 2:  prompt_tps=1448.860, generation_tps=11.183, peak_memory=2.062
Trial 3:  prompt_tps=1475.326, generation_tps=11.207, peak_memory=2.062
Trial 4:  prompt_tps=1483.196, generation_tps=11.205, peak_memory=2.062
Trial 5:  prompt_tps=1460.989, generation_tps=11.056, peak_memory=2.063
Averages: prompt_tps=1470.061, generation_tps=11.153, peak_memory=2.062
```

### `./dev.sh benchmark 8bit`
```text
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=821.389, generation_tps=6.480, peak_memory=1.410
Trial 2:  prompt_tps=823.158, generation_tps=6.220, peak_memory=1.410
Trial 3:  prompt_tps=813.995, generation_tps=6.593, peak_memory=1.411
Trial 4:  prompt_tps=825.380, generation_tps=6.479, peak_memory=1.411
Trial 5:  prompt_tps=856.918, generation_tps=7.002, peak_memory=1.411
Averages: prompt_tps=828.168, generation_tps=6.555, peak_memory=1.411
```