### PR TITLE
fix(vulkan): remove sync from cast-copy fallback staging path

### DIFF
--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -30,6 +30,11 @@ using mlx::core::Shape;
 using mlx::core::Strides;
 namespace vulkan = mlx::core::vulkan;
 
+using vulkan::cast_expr_for_dtype;
+using vulkan::dtype_to_glsl_storage_type;
+using vulkan::emit_dynamic_shader_preamble;
+using vulkan::is_vulkan_storage_array;
+
 constexpr size_t kMinTransferQueueCopyBytes = 256 * 1024;
 
 std::string copy_dtype_suffix(Dtype dtype);
@@ -130,54 +135,6 @@ size_t num_elements(const Shape& shape) {
       shape.begin(), shape.end(), size_t{1}, std::multiplies<size_t>());
 }
 
-std::string dtype_to_glsl_storage_type(Dtype dtype) {
-  switch (dtype) {
-    case mlx::core::float32:
-      return "float";
-    case mlx::core::float16:
-      return "float16_t";
-    case mlx::core::bfloat16:
-      return "uint16_t";
-    case mlx::core::bool_:
-      return "uint8_t";
-    case mlx::core::uint16:
-      return "uint16_t";
-    case mlx::core::uint8:
-      return "uint8_t";
-    case mlx::core::int8:
-      return "int8_t";
-    case mlx::core::int16:
-      return "int16_t";
-    case mlx::core::int32:
-      return "int";
-    case mlx::core::uint32:
-      return "uint";
-    case mlx::core::uint64:
-      return "uint64_t";
-    case mlx::core::int64:
-      return "int64_t";
-    case mlx::core::complex64:
-      return "vec2";
-    default:
-      throw std::runtime_error(
-          "Unsupported dtype for Vulkan dynamic shader generation.");
-  }
-}
-
-bool uses_float16_extension(Dtype dtype) {
-  return dtype == mlx::core::float16;
-}
-
-bool uses_16bit_storage(Dtype dtype) {
-  return dtype == mlx::core::float16 || dtype == mlx::core::bfloat16 ||
-      dtype == mlx::core::int16 || dtype == mlx::core::uint16;
-}
-
-bool uses_8bit_storage(Dtype dtype) {
-  return dtype == mlx::core::bool_ || dtype == mlx::core::int8 ||
-      dtype == mlx::core::uint8;
-}
-
 bool supports_dynamic_gpu_cast_dtype(Dtype dtype) {
   switch (dtype) {
     case mlx::core::bool_:
@@ -195,94 +152,6 @@ bool supports_dynamic_gpu_cast_dtype(Dtype dtype) {
     default:
       return false;
   }
-}
-
-std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output) {
-  std::ostringstream os;
-  os << "#version 450\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
-  if (needs_int64_output || dtype == mlx::core::int64 ||
-      dtype == mlx::core::uint64) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
-  }
-  if (uses_float16_extension(dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
-  }
-  if (uses_16bit_storage(dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
-    os << "#extension GL_EXT_shader_16bit_storage : require\n";
-  }
-  if (uses_8bit_storage(dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
-    os << "#extension GL_EXT_shader_8bit_storage : require\n";
-  }
-  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
-  return os.str();
-}
-
-std::string emit_dynamic_shader_preamble(
-    Dtype in_dtype,
-    Dtype out_dtype,
-    bool needs_int64_output) {
-  std::ostringstream os;
-  os << "#version 450\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
-  if (needs_int64_output || in_dtype == mlx::core::int64 ||
-      in_dtype == mlx::core::uint64 || out_dtype == mlx::core::int64 ||
-      out_dtype == mlx::core::uint64) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
-  }
-  if (uses_float16_extension(in_dtype) || uses_float16_extension(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
-  }
-  if (uses_16bit_storage(in_dtype) || uses_16bit_storage(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
-    os << "#extension GL_EXT_shader_16bit_storage : require\n";
-  }
-  if (uses_8bit_storage(in_dtype) || uses_8bit_storage(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
-    os << "#extension GL_EXT_shader_8bit_storage : require\n";
-  }
-  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
-  return os.str();
-}
-
-std::string zero_literal_for_dtype(Dtype dtype) {
-  switch (dtype) {
-    case mlx::core::float32:
-      return "0.0";
-    case mlx::core::float16:
-      return "float16_t(0.0)";
-    case mlx::core::bool_:
-      return "uint8_t(0)";
-    case mlx::core::uint8:
-      return "uint8_t(0)";
-    case mlx::core::uint16:
-      return "uint16_t(0)";
-    case mlx::core::uint32:
-      return "uint(0)";
-    case mlx::core::uint64:
-      return "uint64_t(0)";
-    case mlx::core::int8:
-      return "int8_t(0)";
-    case mlx::core::int16:
-      return "int16_t(0)";
-    case mlx::core::int32:
-      return "int(0)";
-    case mlx::core::int64:
-      return "int64_t(0)";
-    default:
-      throw std::runtime_error(
-          "Unsupported dtype for Vulkan dynamic cast shader zero literal.");
-  }
-}
-
-std::string cast_expr_for_dtype(const std::string& expr, Dtype in, Dtype out) {
-  if (out == mlx::core::bool_) {
-    return "((" + expr + ") != " + zero_literal_for_dtype(in) +
-        " ? uint8_t(1) : uint8_t(0))";
-  }
-  return dtype_to_glsl_storage_type(out) + "(" + expr + ")";
 }
 
 void append_layout_key(std::ostringstream& os, const Shape& shape) {
@@ -306,51 +175,6 @@ void validate_dynamic_offset_array(
     throw std::runtime_error(
         "Dynamic Vulkan copy offsets must be int64 scalars.");
   }
-}
-
-bool is_vulkan_storage_array(const mlx::core::array& arr) {
-  return arr.data_shared_ptr() != nullptr &&
-      mlx::core::vulkan::is_vulkan_buffer(arr.buffer());
-}
-
-void write_descriptor_binding(
-    std::vector<VkDescriptorSetLayoutBinding>& bindings,
-    uint32_t binding) {
-  bindings.push_back(
-      {binding,
-       VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
-       1,
-       VK_SHADER_STAGE_COMPUTE_BIT,
-       nullptr});
-}
-
-void write_descriptor_buffer(
-    const mlx::core::array& arr,
-    uint32_t binding,
-    VkDescriptorSet descriptor_set,
-    std::vector<VkDescriptorBufferInfo>& infos,
-    std::vector<VkWriteDescriptorSet>& writes) {
-  auto* vulkan_buffer = static_cast<const vulkan::VulkanBuffer*>(
-      static_cast<const void*>(arr.buffer().ptr()));
-  if (vulkan_buffer == nullptr || vulkan_buffer->buffer == VK_NULL_HANDLE) {
-    throw std::runtime_error("Missing Vulkan buffer for dynamic copy shader.");
-  }
-
-  VkDescriptorBufferInfo info{};
-  info.buffer = vulkan_buffer->buffer;
-  info.offset = 0;
-  info.range = VK_WHOLE_SIZE;
-  infos.push_back(info);
-
-  VkWriteDescriptorSet write{};
-  write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
-  write.dstSet = descriptor_set;
-  write.dstBinding = binding;
-  write.dstArrayElement = 0;
-  write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-  write.descriptorCount = 1;
-  write.pBufferInfo = &infos.back();
-  writes.push_back(write);
 }
 
 std::string build_dynamic_offset_shader(
@@ -439,19 +263,6 @@ std::string build_dynamic_general_copy_shader(
   return os.str();
 }
 
-void ensure_dynamic_shader_registered(
-    const std::string& shader_name,
-    const std::string& glsl_source) {
-  auto& manager = vulkan::KernelManager::get();
-  if (manager.get_shader(shader_name) != nullptr) {
-    return;
-  }
-
-  auto spirv = vulkan::compile_glsl_to_spirv(glsl_source, shader_name);
-  manager.register_shader(
-      shader_name, spirv.data(), spirv.size() * sizeof(uint32_t));
-}
-
 void dispatch_dynamic_offset_kernel(
     const mlx::core::array& indices,
     mlx::core::array& offset,
@@ -472,54 +283,15 @@ void dispatch_dynamic_offset_kernel(
       copy_dtype_suffix(indices.dtype()) + "_" +
       std::to_string(std::hash<std::string>{}(layout_key.str()));
 
-  ensure_dynamic_shader_registered(
-      shader_name,
-      build_dynamic_offset_shader(
-          indices.dtype(), indices_base_offset, stride_terms));
+  const std::string glsl_source = build_dynamic_offset_shader(
+      indices.dtype(), indices_base_offset, stride_terms);
 
-  std::vector<VkDescriptorSetLayoutBinding> bindings;
-  write_descriptor_binding(bindings, 0);
-  write_descriptor_binding(bindings, 1);
-
-  auto& manager = vulkan::KernelManager::get();
-  auto* pipeline = manager.get_pipeline(shader_name, bindings, 0);
-  auto command_buffer = vulkan::begin_command_recording(s.index);
-  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
-  vk::DescriptorSet descriptor_set =
-      manager.allocate_descriptor_set(pipeline->descriptor_layout);
-  manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
-
-  std::vector<VkDescriptorBufferInfo> infos;
-  std::vector<VkWriteDescriptorSet> writes;
-  infos.reserve(2);
-  writes.reserve(2);
-  write_descriptor_buffer(indices, 0, descriptor_set, infos, writes);
-  write_descriptor_buffer(offset, 1, descriptor_set, infos, writes);
-  vkUpdateDescriptorSets(
-      vulkan::VulkanContext::get().device(),
-      static_cast<uint32_t>(writes.size()),
-      writes.data(),
-      0,
-      nullptr);
-
-  vkCmdBindPipeline(
-      command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
-  VkDescriptorSet vk_descriptor_set =
-      static_cast<VkDescriptorSet>(descriptor_set);
-  vkCmdBindDescriptorSets(
-      command_buffer,
-      VK_PIPELINE_BIND_POINT_COMPUTE,
-      pipeline->layout,
-      0,
-      1,
-      &vk_descriptor_set,
-      0,
-      nullptr);
-  vkCmdDispatch(command_buffer, 1, 1, 1);
-
-  vulkan::retain_array_for_stream(s, indices);
-  vulkan::retain_array_for_stream(s, offset);
-  vulkan::end_command_recording(s.index);
+  vulkan::DynamicArrayRef arrays[] = {
+      {&indices, 0},
+      {&offset, 1},
+  };
+  vulkan::dispatch_dynamic_compute(
+      shader_name, glsl_source, 2, arrays, 1, 1, 1, s);
 }
 
 bool dispatch_dynamic_general_copy(
@@ -580,111 +352,60 @@ bool dispatch_dynamic_general_copy(
       copy_dtype_suffix(in.dtype()) + "_" +
       std::to_string(std::hash<std::string>{}(layout_key.str()));
 
-  ensure_dynamic_shader_registered(
-      shader_name,
-      build_dynamic_general_copy_shader(
-          in.dtype(),
-          shape,
-          i_strides,
-          o_strides,
-          in_base_offset,
-          out_base_offset,
-          i_offset,
-          o_offset,
-          dynamic_i_base_offset,
-          dynamic_o_base_offset,
-          dynamic_i_offset.has_value(),
-          dynamic_o_offset.has_value(),
-          total_elements));
+  const std::string glsl_source = build_dynamic_general_copy_shader(
+      in.dtype(),
+      shape,
+      i_strides,
+      o_strides,
+      in_base_offset,
+      out_base_offset,
+      i_offset,
+      o_offset,
+      dynamic_i_base_offset,
+      dynamic_o_base_offset,
+      dynamic_i_offset.has_value(),
+      dynamic_o_offset.has_value(),
+      total_elements);
 
-  std::vector<VkDescriptorSetLayoutBinding> bindings;
-  write_descriptor_binding(bindings, 0);
-  write_descriptor_binding(bindings, 1);
+  std::vector<vulkan::DynamicArrayRef> arrays;
+  arrays.push_back({&in, 0});
+  arrays.push_back({&out, 1});
   if (dynamic_i_offset.has_value()) {
-    write_descriptor_binding(bindings, 2);
+    arrays.push_back({&*dynamic_i_offset, 2});
   }
   if (dynamic_o_offset.has_value()) {
-    write_descriptor_binding(bindings, 3);
+    arrays.push_back({&*dynamic_o_offset, 3});
   }
-
-  auto& manager = vulkan::KernelManager::get();
-  auto* pipeline = manager.get_pipeline(shader_name, bindings, 0);
-  auto command_buffer = vulkan::begin_command_recording(s.index);
-  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
-  vk::DescriptorSet descriptor_set =
-      manager.allocate_descriptor_set(pipeline->descriptor_layout);
-  manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
-
-  std::vector<VkDescriptorBufferInfo> infos;
-  std::vector<VkWriteDescriptorSet> writes;
-  infos.reserve(4);
-  writes.reserve(4);
-  write_descriptor_buffer(in, 0, descriptor_set, infos, writes);
-  write_descriptor_buffer(out, 1, descriptor_set, infos, writes);
-  if (dynamic_i_offset.has_value()) {
-    write_descriptor_buffer(
-        *dynamic_i_offset, 2, descriptor_set, infos, writes);
-  }
-  if (dynamic_o_offset.has_value()) {
-    write_descriptor_buffer(
-        *dynamic_o_offset, 3, descriptor_set, infos, writes);
-  }
-  vkUpdateDescriptorSets(
-      vulkan::VulkanContext::get().device(),
-      static_cast<uint32_t>(writes.size()),
-      writes.data(),
-      0,
-      nullptr);
-
-  vkCmdBindPipeline(
-      command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
-  VkDescriptorSet vk_descriptor_set =
-      static_cast<VkDescriptorSet>(descriptor_set);
-  vkCmdBindDescriptorSets(
-      command_buffer,
-      VK_PIPELINE_BIND_POINT_COMPUTE,
-      pipeline->layout,
-      0,
-      1,
-      &vk_descriptor_set,
-      0,
-      nullptr);
 
   const uint32_t workgroups = std::max<uint32_t>(
       (static_cast<uint32_t>(total_elements) + 255u) / 256u, 1u);
-  vkCmdDispatch(command_buffer, workgroups, 1, 1);
-
-  vulkan::retain_array_for_stream(s, in);
-  vulkan::retain_array_for_stream(s, out);
-  if (dynamic_i_offset.has_value()) {
-    vulkan::retain_array_for_stream(s, *dynamic_i_offset);
-  }
-  if (dynamic_o_offset.has_value()) {
-    vulkan::retain_array_for_stream(s, *dynamic_o_offset);
-  }
-  vulkan::end_command_recording(s.index);
+  vulkan::dispatch_dynamic_compute(
+      shader_name,
+      glsl_source,
+      static_cast<uint32_t>(arrays.size()),
+      arrays.data(),
+      workgroups,
+      1,
+      1,
+      s);
   return true;
 }
 
-std::string build_dynamic_vector_cast_shader(
-    Dtype in_dtype,
-    Dtype out_dtype,
-    int64_t in_base_offset,
-    int64_t out_base_offset,
-    size_t total_elements) {
+std::string build_dynamic_vector_cast_shader(Dtype in_dtype, Dtype out_dtype) {
   std::ostringstream os;
   os << emit_dynamic_shader_preamble(in_dtype, out_dtype, false);
+  os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
   os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
      << dtype_to_glsl_storage_type(in_dtype) << " data[];} input_buf;\n";
   os << "layout(set = 0, binding = 1) buffer OutputBuffer {"
      << dtype_to_glsl_storage_type(out_dtype) << " data[];} output_buf;\n\n";
   os << "void main() {\n";
   os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
-  os << "  if (linear_idx >= " << total_elements << "u) {\n";
+  os << "  if (linear_idx >= pc.total_elements) {\n";
   os << "    return;\n";
   os << "  }\n";
-  os << "  uint input_index = linear_idx + " << in_base_offset << "u;\n";
-  os << "  uint output_index = linear_idx + " << out_base_offset << "u;\n";
+  os << "  uint input_index = linear_idx + pc.in_offset;\n";
+  os << "  uint output_index = linear_idx + pc.out_offset;\n";
   os << "  output_buf.data[output_index] = "
      << cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype)
      << ";\n";
@@ -719,61 +440,41 @@ bool dispatch_dynamic_vector_cast_copy(
     return false;
   }
 
-  std::ostringstream layout_key;
-  layout_key << static_cast<int>(in.dtype().val()) << ':'
-             << static_cast<int>(out.dtype().val()) << ':' << in_base_offset
-             << ':' << out_base_offset << ':' << size;
   const std::string shader_name = "dynamic_vector_cast_copy_" +
-      copy_dtype_suffix(in.dtype()) + "_" + copy_dtype_suffix(out.dtype()) +
-      "_" + std::to_string(std::hash<std::string>{}(layout_key.str()));
+      copy_dtype_suffix(in.dtype()) + "_" + copy_dtype_suffix(out.dtype());
 
-  ensure_dynamic_shader_registered(
-      shader_name,
-      build_dynamic_vector_cast_shader(
-          in.dtype(), out.dtype(), in_base_offset, out_base_offset, size));
+  const std::string glsl_source =
+      build_dynamic_vector_cast_shader(in.dtype(), out.dtype());
 
-  std::vector<VkDescriptorSetLayoutBinding> bindings;
-  write_descriptor_binding(bindings, 0);
-  write_descriptor_binding(bindings, 1);
+  vulkan::DynamicArrayRef arrays[] = {
+      {&in, 0},
+      {&out, 1},
+  };
 
-  auto& manager = vulkan::KernelManager::get();
-  auto* pipeline = manager.get_pipeline(shader_name, bindings, 0);
-  auto command_buffer = vulkan::begin_command_recording(s.index);
-  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
-  vk::DescriptorSet descriptor_set =
-      manager.allocate_descriptor_set(pipeline->descriptor_layout);
-  manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 3;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      shader_name, glsl_source, 2, arrays, kPushConstantSize, s);
 
-  std::vector<VkDescriptorBufferInfo> infos;
-  std::vector<VkWriteDescriptorSet> writes;
-  infos.reserve(2);
-  writes.reserve(2);
-  write_descriptor_buffer(in, 0, descriptor_set, infos, writes);
-  write_descriptor_buffer(out, 1, descriptor_set, infos, writes);
-  vkUpdateDescriptorSets(
-      vulkan::VulkanContext::get().device(),
-      static_cast<uint32_t>(writes.size()),
-      writes.data(),
+  struct PushConstants {
+    uint32_t in_off;
+    uint32_t out_off;
+    uint32_t total;
+  };
+  PushConstants pc{};
+  pc.in_off = static_cast<uint32_t>(in_base_offset);
+  pc.out_off = static_cast<uint32_t>(out_base_offset);
+  pc.total = static_cast<uint32_t>(size);
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
       0,
-      nullptr);
-
-  vkCmdBindPipeline(
-      command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
-  VkDescriptorSet vk_descriptor_set =
-      static_cast<VkDescriptorSet>(descriptor_set);
-  vkCmdBindDescriptorSets(
-      command_buffer,
-      VK_PIPELINE_BIND_POINT_COMPUTE,
-      pipeline->layout,
-      0,
-      1,
-      &vk_descriptor_set,
-      0,
-      nullptr);
+      kPushConstantSize,
+      &pc);
 
   const uint32_t workgroups =
       std::max<uint32_t>((static_cast<uint32_t>(size) + 255u) / 256u, 1u);
-  vkCmdDispatch(command_buffer, workgroups, 1, 1);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
 
   vulkan::retain_array_for_stream(s, in);
   vulkan::retain_array_for_stream(s, out);

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -12,8 +12,6 @@
 #include "mlx/stream.h"
 
 #include <algorithm>
-#include <atomic>
-#include <chrono>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -22,7 +20,6 @@
 #include <numeric>
 #include <sstream>
 #include <string>
-#include <thread>
 
 #include "mlx/backend/vulkan/shader_compiler.h"
 
@@ -181,6 +178,25 @@ bool uses_8bit_storage(Dtype dtype) {
       dtype == mlx::core::uint8;
 }
 
+bool supports_dynamic_gpu_cast_dtype(Dtype dtype) {
+  switch (dtype) {
+    case mlx::core::bool_:
+    case mlx::core::uint8:
+    case mlx::core::uint16:
+    case mlx::core::uint32:
+    case mlx::core::uint64:
+    case mlx::core::int8:
+    case mlx::core::int16:
+    case mlx::core::int32:
+    case mlx::core::int64:
+    case mlx::core::float16:
+    case mlx::core::float32:
+      return true;
+    default:
+      return false;
+  }
+}
+
 std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output) {
   std::ostringstream os;
   os << "#version 450\n";
@@ -202,6 +218,71 @@ std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output) {
   }
   os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
   return os.str();
+}
+
+std::string emit_dynamic_shader_preamble(
+    Dtype in_dtype,
+    Dtype out_dtype,
+    bool needs_int64_output) {
+  std::ostringstream os;
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (needs_int64_output || in_dtype == mlx::core::int64 ||
+      in_dtype == mlx::core::uint64 || out_dtype == mlx::core::int64 ||
+      out_dtype == mlx::core::uint64) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
+  }
+  if (uses_float16_extension(in_dtype) || uses_float16_extension(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+  }
+  if (uses_16bit_storage(in_dtype) || uses_16bit_storage(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  if (uses_8bit_storage(in_dtype) || uses_8bit_storage(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
+    os << "#extension GL_EXT_shader_8bit_storage : require\n";
+  }
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  return os.str();
+}
+
+std::string zero_literal_for_dtype(Dtype dtype) {
+  switch (dtype) {
+    case mlx::core::float32:
+      return "0.0";
+    case mlx::core::float16:
+      return "float16_t(0.0)";
+    case mlx::core::bool_:
+      return "uint8_t(0)";
+    case mlx::core::uint8:
+      return "uint8_t(0)";
+    case mlx::core::uint16:
+      return "uint16_t(0)";
+    case mlx::core::uint32:
+      return "uint(0)";
+    case mlx::core::uint64:
+      return "uint64_t(0)";
+    case mlx::core::int8:
+      return "int8_t(0)";
+    case mlx::core::int16:
+      return "int16_t(0)";
+    case mlx::core::int32:
+      return "int(0)";
+    case mlx::core::int64:
+      return "int64_t(0)";
+    default:
+      throw std::runtime_error(
+          "Unsupported dtype for Vulkan dynamic cast shader zero literal.");
+  }
+}
+
+std::string cast_expr_for_dtype(const std::string& expr, Dtype in, Dtype out) {
+  if (out == mlx::core::bool_) {
+    return "((" + expr + ") != " + zero_literal_for_dtype(in) +
+        " ? uint8_t(1) : uint8_t(0))";
+  }
+  return dtype_to_glsl_storage_type(out) + "(" + expr + ")";
 }
 
 void append_layout_key(std::ostringstream& os, const Shape& shape) {
@@ -585,6 +666,121 @@ bool dispatch_dynamic_general_copy(
   return true;
 }
 
+std::string build_dynamic_vector_cast_shader(
+    Dtype in_dtype,
+    Dtype out_dtype,
+    int64_t in_base_offset,
+    int64_t out_base_offset,
+    size_t total_elements) {
+  std::ostringstream os;
+  os << emit_dynamic_shader_preamble(in_dtype, out_dtype, false);
+  os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
+     << dtype_to_glsl_storage_type(in_dtype) << " data[];} input_buf;\n";
+  os << "layout(set = 0, binding = 1) buffer OutputBuffer {"
+     << dtype_to_glsl_storage_type(out_dtype) << " data[];} output_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (linear_idx >= " << total_elements << "u) {\n";
+  os << "    return;\n";
+  os << "  }\n";
+  os << "  uint input_index = linear_idx + " << in_base_offset << "u;\n";
+  os << "  uint output_index = linear_idx + " << out_base_offset << "u;\n";
+  os << "  output_buf.data[output_index] = "
+     << cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype)
+     << ";\n";
+  os << "}\n";
+  return os.str();
+}
+
+bool dispatch_dynamic_vector_cast_copy(
+    const mlx::core::array& in,
+    mlx::core::array& out,
+    size_t size,
+    int64_t in_offset,
+    int64_t out_offset,
+    const mlx::core::Stream& s) {
+  if (!is_vulkan_storage_array(in) || !is_vulkan_storage_array(out)) {
+    return false;
+  }
+  if (!supports_dynamic_gpu_cast_dtype(in.dtype()) ||
+      !supports_dynamic_gpu_cast_dtype(out.dtype())) {
+    return false;
+  }
+  if (size == 0) {
+    return true;
+  }
+  if (size > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  const int64_t in_base_offset = in_offset;
+  const int64_t out_base_offset = out_offset;
+  if (in_base_offset < 0 || out_base_offset < 0) {
+    return false;
+  }
+
+  std::ostringstream layout_key;
+  layout_key << static_cast<int>(in.dtype().val()) << ':'
+             << static_cast<int>(out.dtype().val()) << ':' << in_base_offset
+             << ':' << out_base_offset << ':' << size;
+  const std::string shader_name = "dynamic_vector_cast_copy_" +
+      copy_dtype_suffix(in.dtype()) + "_" + copy_dtype_suffix(out.dtype()) +
+      "_" + std::to_string(std::hash<std::string>{}(layout_key.str()));
+
+  ensure_dynamic_shader_registered(
+      shader_name,
+      build_dynamic_vector_cast_shader(
+          in.dtype(), out.dtype(), in_base_offset, out_base_offset, size));
+
+  std::vector<VkDescriptorSetLayoutBinding> bindings;
+  write_descriptor_binding(bindings, 0);
+  write_descriptor_binding(bindings, 1);
+
+  auto& manager = vulkan::KernelManager::get();
+  auto* pipeline = manager.get_pipeline(shader_name, bindings, 0);
+  auto command_buffer = vulkan::begin_command_recording(s.index);
+  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
+  vk::DescriptorSet descriptor_set =
+      manager.allocate_descriptor_set(pipeline->descriptor_layout);
+  manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
+
+  std::vector<VkDescriptorBufferInfo> infos;
+  std::vector<VkWriteDescriptorSet> writes;
+  infos.reserve(2);
+  writes.reserve(2);
+  write_descriptor_buffer(in, 0, descriptor_set, infos, writes);
+  write_descriptor_buffer(out, 1, descriptor_set, infos, writes);
+  vkUpdateDescriptorSets(
+      vulkan::VulkanContext::get().device(),
+      static_cast<uint32_t>(writes.size()),
+      writes.data(),
+      0,
+      nullptr);
+
+  vkCmdBindPipeline(
+      command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
+  VkDescriptorSet vk_descriptor_set =
+      static_cast<VkDescriptorSet>(descriptor_set);
+  vkCmdBindDescriptorSets(
+      command_buffer,
+      VK_PIPELINE_BIND_POINT_COMPUTE,
+      pipeline->layout,
+      0,
+      1,
+      &vk_descriptor_set,
+      0,
+      nullptr);
+
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(size) + 255u) / 256u, 1u);
+  vkCmdDispatch(command_buffer, workgroups, 1, 1);
+
+  vulkan::retain_array_for_stream(s, in);
+  vulkan::retain_array_for_stream(s, out);
+  vulkan::end_command_recording(s.index);
+  return true;
+}
+
 mlx::core::array make_copy_view(
     const mlx::core::array& base,
     const Shape& shape,
@@ -739,10 +935,6 @@ bool try_host_vector_cast_copy(
     int64_t out_offset,
     const mlx::core::Stream& s) {
   const bool in_is_vulkan = mlx::core::vulkan::is_vulkan_buffer(in.buffer());
-  auto* in_buf = in_is_vulkan
-      ? static_cast<mlx::core::vulkan::VulkanBuffer*>(
-            const_cast<void*>(static_cast<const void*>(in.buffer().ptr())))
-      : nullptr;
   auto* out_buf =
       static_cast<mlx::core::vulkan::VulkanBuffer*>(out.buffer().ptr());
 
@@ -776,83 +968,16 @@ bool try_host_vector_cast_copy(
     return true;
   }
 
-  if (in_buf->mapped_ptr != nullptr) {
-    auto* src_ptr = static_cast<const char*>(in_buf->mapped_ptr) +
-        in_offset * size_of(in.dtype());
-    convert_and_store(src_ptr);
+  if (dispatch_dynamic_vector_cast_copy(
+          in, out, size, in_offset, out_offset, s)) {
     return true;
   }
 
-  const auto readback_bytes = size * size_of(in.dtype());
-  const auto upload_offset = out_offset * size_of(out.dtype());
-  const auto in_dtype = in.dtype();
-  const auto out_dtype = out.dtype();
-
-  auto in_keepalive = in;
-  auto out_keepalive = out;
-  auto stream = s;
-  auto upload_enqueued = std::make_shared<std::atomic<bool>>(false);
-  auto callback_error = std::make_shared<std::exception_ptr>();
-
-  mlx::core::vulkan::enqueue_owned_staging_readback(
-      stream,
-      in_buf->buffer,
-      in_offset * size_of(in.dtype()),
-      readback_bytes,
-      [size,
-       in_dtype,
-       out_dtype,
-       upload_offset,
-       upload_enqueued,
-       callback_error,
-       in_keepalive = std::move(in_keepalive),
-       out_keepalive = std::move(out_keepalive),
-       stream](const void* ptr, size_t /*nbytes*/) mutable {
-        try {
-          std::vector<char> host_out(size * size_of(out_dtype));
-          host_cast_copy_dispatch_src(
-              ptr, in_dtype, host_out.data(), size, out_dtype);
-
-          auto* callback_out_buf =
-              static_cast<mlx::core::vulkan::VulkanBuffer*>(
-                  out_keepalive.buffer().ptr());
-          if (mlx::core::vulkan::VulkanContext::get().is_unified_memory() &&
-              callback_out_buf->mapped_ptr != nullptr) {
-            auto* dst_ptr = static_cast<char*>(callback_out_buf->mapped_ptr) +
-                upload_offset;
-            std::memcpy(dst_ptr, host_out.data(), host_out.size());
-            upload_enqueued->store(true, std::memory_order_release);
-            return;
-          }
-
-          mlx::core::vulkan::enqueue_owned_staging_upload(
-              stream,
-              host_out.data(),
-              host_out.size(),
-              callback_out_buf->buffer,
-              upload_offset);
-          mlx::core::vulkan::retain_array_for_stream(stream, in_keepalive);
-          mlx::core::vulkan::retain_array_for_stream(stream, out_keepalive);
-        } catch (...) {
-          *callback_error = std::current_exception();
-        }
-        upload_enqueued->store(true, std::memory_order_release);
-      });
-
-  const auto timeout_at =
-      std::chrono::steady_clock::now() + std::chrono::seconds(30);
-  while (!upload_enqueued->load(std::memory_order_acquire)) {
-    if (std::chrono::steady_clock::now() >= timeout_at) {
-      throw std::runtime_error(
-          "Timed out waiting for Vulkan cast-copy fallback readback completion.");
-    }
-    mlx::core::vulkan::finalize_stream(stream);
-    std::this_thread::yield();
-  }
-  if (*callback_error) {
-    std::rethrow_exception(*callback_error);
-  }
-  return true;
+  std::ostringstream oss;
+  oss << "Vulkan cast-copy fallback is not implemented for dtype pair in="
+      << static_cast<int>(in.dtype().val())
+      << " out=" << static_cast<int>(out.dtype().val());
+  throw std::runtime_error(oss.str());
 }
 
 std::string copy_dtype_suffix(Dtype dtype) {
@@ -1455,7 +1580,8 @@ void copy_gpu_inplace(
   // Small copies, especially decode-time KV cache updates, are latency
   // sensitive and do better when they stay in the current compute submission.
   const bool use_transfer_queue =
-      (raw_buffer_copy || contiguous_large_rank_copy || segmented_buffer_copy) &&
+      (raw_buffer_copy || contiguous_large_rank_copy ||
+       segmented_buffer_copy) &&
       should_use_transfer_queue_for_copy(copy_bytes);
   vk::CommandBuffer cmd_buffer = use_transfer_queue
       ? vulkan::begin_transfer_command_recording(s.index)

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -12,6 +12,8 @@
 #include "mlx/stream.h"
 
 #include <algorithm>
+#include <atomic>
+#include <chrono>
 #include <cstring>
 #include <functional>
 #include <iostream>
@@ -20,6 +22,7 @@
 #include <numeric>
 #include <sstream>
 #include <string>
+#include <thread>
 
 #include "mlx/backend/vulkan/shader_compiler.h"
 
@@ -788,6 +791,8 @@ bool try_host_vector_cast_copy(
   auto in_keepalive = in;
   auto out_keepalive = out;
   auto stream = s;
+  auto upload_enqueued = std::make_shared<std::atomic<bool>>(false);
+  auto callback_error = std::make_shared<std::exception_ptr>();
 
   mlx::core::vulkan::enqueue_owned_staging_readback(
       stream,
@@ -798,32 +803,55 @@ bool try_host_vector_cast_copy(
        in_dtype,
        out_dtype,
        upload_offset,
+       upload_enqueued,
+       callback_error,
        in_keepalive = std::move(in_keepalive),
        out_keepalive = std::move(out_keepalive),
        stream](const void* ptr, size_t /*nbytes*/) mutable {
-        std::vector<char> host_out(size * size_of(out_dtype));
-        host_cast_copy_dispatch_src(
-            ptr, in_dtype, host_out.data(), size, out_dtype);
+        try {
+          std::vector<char> host_out(size * size_of(out_dtype));
+          host_cast_copy_dispatch_src(
+              ptr, in_dtype, host_out.data(), size, out_dtype);
 
-        auto* callback_out_buf = static_cast<mlx::core::vulkan::VulkanBuffer*>(
-            out_keepalive.buffer().ptr());
-        if (mlx::core::vulkan::VulkanContext::get().is_unified_memory() &&
-            callback_out_buf->mapped_ptr != nullptr) {
-          auto* dst_ptr = static_cast<char*>(callback_out_buf->mapped_ptr) +
-              upload_offset;
-          std::memcpy(dst_ptr, host_out.data(), host_out.size());
-          return;
+          auto* callback_out_buf =
+              static_cast<mlx::core::vulkan::VulkanBuffer*>(
+                  out_keepalive.buffer().ptr());
+          if (mlx::core::vulkan::VulkanContext::get().is_unified_memory() &&
+              callback_out_buf->mapped_ptr != nullptr) {
+            auto* dst_ptr = static_cast<char*>(callback_out_buf->mapped_ptr) +
+                upload_offset;
+            std::memcpy(dst_ptr, host_out.data(), host_out.size());
+            upload_enqueued->store(true, std::memory_order_release);
+            return;
+          }
+
+          mlx::core::vulkan::enqueue_owned_staging_upload(
+              stream,
+              host_out.data(),
+              host_out.size(),
+              callback_out_buf->buffer,
+              upload_offset);
+          mlx::core::vulkan::retain_array_for_stream(stream, in_keepalive);
+          mlx::core::vulkan::retain_array_for_stream(stream, out_keepalive);
+        } catch (...) {
+          *callback_error = std::current_exception();
         }
-
-        mlx::core::vulkan::enqueue_owned_staging_upload(
-            stream,
-            host_out.data(),
-            host_out.size(),
-            callback_out_buf->buffer,
-            upload_offset);
-        mlx::core::vulkan::retain_array_for_stream(stream, in_keepalive);
-        mlx::core::vulkan::retain_array_for_stream(stream, out_keepalive);
+        upload_enqueued->store(true, std::memory_order_release);
       });
+
+  const auto timeout_at =
+      std::chrono::steady_clock::now() + std::chrono::seconds(30);
+  while (!upload_enqueued->load(std::memory_order_acquire)) {
+    if (std::chrono::steady_clock::now() >= timeout_at) {
+      throw std::runtime_error(
+          "Timed out waiting for Vulkan cast-copy fallback readback completion.");
+    }
+    mlx::core::vulkan::finalize_stream(stream);
+    std::this_thread::yield();
+  }
+  if (*callback_error) {
+    std::rethrow_exception(*callback_error);
+  }
   return true;
 }
 

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -780,23 +780,50 @@ bool try_host_vector_cast_copy(
     return true;
   }
 
-  auto host_in =
-      std::make_shared<std::vector<char>>(size * size_of(in.dtype()));
-  auto readback_done = std::make_shared<bool>(false);
+  const auto readback_bytes = size * size_of(in.dtype());
+  const auto upload_offset = out_offset * size_of(out.dtype());
+  const auto in_dtype = in.dtype();
+  const auto out_dtype = out.dtype();
+
+  auto in_keepalive = in;
+  auto out_keepalive = out;
+  auto stream = s;
+
   mlx::core::vulkan::enqueue_owned_staging_readback(
-      s,
+      stream,
       in_buf->buffer,
       in_offset * size_of(in.dtype()),
-      host_in->size(),
-      [host_in, readback_done](const void* ptr, size_t nbytes) {
-        std::memcpy(host_in->data(), ptr, nbytes);
-        *readback_done = true;
+      readback_bytes,
+      [size,
+       in_dtype,
+       out_dtype,
+       upload_offset,
+       in_keepalive = std::move(in_keepalive),
+       out_keepalive = std::move(out_keepalive),
+       stream](const void* ptr, size_t /*nbytes*/) mutable {
+        std::vector<char> host_out(size * size_of(out_dtype));
+        host_cast_copy_dispatch_src(
+            ptr, in_dtype, host_out.data(), size, out_dtype);
+
+        auto* callback_out_buf = static_cast<mlx::core::vulkan::VulkanBuffer*>(
+            out_keepalive.buffer().ptr());
+        if (mlx::core::vulkan::VulkanContext::get().is_unified_memory() &&
+            callback_out_buf->mapped_ptr != nullptr) {
+          auto* dst_ptr = static_cast<char*>(callback_out_buf->mapped_ptr) +
+              upload_offset;
+          std::memcpy(dst_ptr, host_out.data(), host_out.size());
+          return;
+        }
+
+        mlx::core::vulkan::enqueue_owned_staging_upload(
+            stream,
+            host_out.data(),
+            host_out.size(),
+            callback_out_buf->buffer,
+            upload_offset);
+        mlx::core::vulkan::retain_array_for_stream(stream, in_keepalive);
+        mlx::core::vulkan::retain_array_for_stream(stream, out_keepalive);
       });
-  mlx::core::vulkan::synchronize_stream(s);
-  if (!*readback_done) {
-    throw std::runtime_error("Vulkan readback did not complete for cast copy.");
-  }
-  convert_and_store(host_in->data());
   return true;
 }
 

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -3525,7 +3525,7 @@ DynamicComputeDispatch dispatch_dynamic_compute_begin(
 
   std::vector<VkDescriptorSetLayoutBinding> bindings;
   for (uint32_t i = 0; i < num_bindings; ++i) {
-    write_descriptor_binding(bindings, i);
+    write_descriptor_binding(bindings, arrays[i].binding);
   }
 
   auto& manager = KernelManager::get();

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -14,6 +14,7 @@
 #include <stdexcept>
 #include <unordered_set>
 #include "mlx/backend/vulkan/device.h"
+#include "mlx/backend/vulkan/shader_compiler.h"
 #include "mlx/backend/vulkan/vulkan.h"
 
 namespace mlx::core::vulkan {
@@ -1524,7 +1525,9 @@ vk::DescriptorSet KernelManager::allocate_descriptor_set(
         std::lock_guard<std::mutex> lock(descriptor_sets_mutex_);
         auto& reusable_sets = reusable_descriptor_sets_[layout];
         reusable_sets.insert(
-            reusable_sets.end(), descriptor_sets.begin(), descriptor_sets.end());
+            reusable_sets.end(),
+            descriptor_sets.begin(),
+            descriptor_sets.end());
         descriptor_set_layouts_[descriptor_set] = layout;
         for (const auto& reusable_set : descriptor_sets) {
           descriptor_set_layouts_[reusable_set] = layout;
@@ -1539,7 +1542,7 @@ vk::DescriptorSet KernelManager::allocate_descriptor_set(
             << " count=" << std::dec << (descriptor_sets.size() + 1)
             << " set=0x" << std::hex
             << reinterpret_cast<uintptr_t>(
-                    static_cast<VkDescriptorSet>(descriptor_set))
+                   static_cast<VkDescriptorSet>(descriptor_set))
             << std::dec;
         trace_descriptor_epochs(oss.str());
       }
@@ -3452,6 +3455,141 @@ void dispatch_fused_affine_matmul_op(
       s,
       grid,
       matmul_specialization_constants({}));
+}
+
+void write_descriptor_binding(
+    std::vector<VkDescriptorSetLayoutBinding>& bindings,
+    uint32_t binding) {
+  bindings.push_back(
+      {binding,
+       VK_DESCRIPTOR_TYPE_STORAGE_BUFFER,
+       1,
+       VK_SHADER_STAGE_COMPUTE_BIT,
+       nullptr});
+}
+
+void write_descriptor_buffer(
+    const array& arr,
+    uint32_t binding,
+    VkDescriptorSet descriptor_set,
+    std::vector<VkDescriptorBufferInfo>& infos,
+    std::vector<VkWriteDescriptorSet>& writes) {
+  auto* vulkan_buffer = static_cast<const VulkanBuffer*>(
+      static_cast<const void*>(arr.buffer().ptr()));
+  if (vulkan_buffer == nullptr || vulkan_buffer->buffer == VK_NULL_HANDLE) {
+    throw std::runtime_error("Missing Vulkan buffer for dynamic copy shader.");
+  }
+
+  VkDescriptorBufferInfo info{};
+  info.buffer = vulkan_buffer->buffer;
+  info.offset = 0;
+  info.range = VK_WHOLE_SIZE;
+  infos.push_back(info);
+
+  VkWriteDescriptorSet write{};
+  write.sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+  write.dstSet = descriptor_set;
+  write.dstBinding = binding;
+  write.dstArrayElement = 0;
+  write.descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+  write.descriptorCount = 1;
+  write.pBufferInfo = &infos.back();
+  writes.push_back(write);
+}
+
+void ensure_dynamic_shader_registered(
+    const std::string& shader_name,
+    const std::string& glsl_source) {
+  auto& manager = KernelManager::get();
+  if (manager.get_shader(shader_name) != nullptr) {
+    return;
+  }
+
+  auto spirv = compile_glsl_to_spirv(glsl_source, shader_name);
+  manager.register_shader(
+      shader_name, spirv.data(), spirv.size() * sizeof(uint32_t));
+}
+
+bool is_vulkan_storage_array(const array& arr) {
+  return arr.data_shared_ptr() != nullptr && is_vulkan_buffer(arr.buffer());
+}
+
+DynamicComputeDispatch dispatch_dynamic_compute_begin(
+    const std::string& shader_name,
+    const std::string& glsl_source,
+    uint32_t num_bindings,
+    const DynamicArrayRef* arrays,
+    uint32_t push_constant_size,
+    const Stream& s) {
+  ensure_dynamic_shader_registered(shader_name, glsl_source);
+
+  std::vector<VkDescriptorSetLayoutBinding> bindings;
+  for (uint32_t i = 0; i < num_bindings; ++i) {
+    write_descriptor_binding(bindings, i);
+  }
+
+  auto& manager = KernelManager::get();
+  auto* pipeline =
+      manager.get_pipeline(shader_name, bindings, push_constant_size);
+  auto command_buffer = begin_command_recording(s.index);
+  const uint64_t descriptor_epoch = descriptor_epoch_for_stream(s);
+  vk::DescriptorSet descriptor_set =
+      manager.allocate_descriptor_set(pipeline->descriptor_layout);
+  manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
+
+  std::vector<VkDescriptorBufferInfo> infos;
+  std::vector<VkWriteDescriptorSet> writes;
+  infos.reserve(num_bindings);
+  writes.reserve(num_bindings);
+  for (uint32_t i = 0; i < num_bindings; ++i) {
+    write_descriptor_buffer(
+        *arrays[i].arr, arrays[i].binding, descriptor_set, infos, writes);
+  }
+  vkUpdateDescriptorSets(
+      VulkanContext::get().device(),
+      static_cast<uint32_t>(writes.size()),
+      writes.data(),
+      0,
+      nullptr);
+
+  vkCmdBindPipeline(
+      command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
+  VkDescriptorSet vk_descriptor_set =
+      static_cast<VkDescriptorSet>(descriptor_set);
+  vkCmdBindDescriptorSets(
+      command_buffer,
+      VK_PIPELINE_BIND_POINT_COMPUTE,
+      pipeline->layout,
+      0,
+      1,
+      &vk_descriptor_set,
+      0,
+      nullptr);
+
+  return DynamicComputeDispatch{
+      command_buffer,
+      pipeline,
+      std::move(infos),
+      std::move(writes),
+      descriptor_set};
+}
+
+void dispatch_dynamic_compute(
+    const std::string& shader_name,
+    const std::string& glsl_source,
+    uint32_t num_bindings,
+    const DynamicArrayRef* arrays,
+    uint32_t workgroup_x,
+    uint32_t workgroup_y,
+    uint32_t workgroup_z,
+    const Stream& s) {
+  auto dispatch = dispatch_dynamic_compute_begin(
+      shader_name, glsl_source, num_bindings, arrays, 0, s);
+  vkCmdDispatch(dispatch.command_buffer, workgroup_x, workgroup_y, workgroup_z);
+  for (uint32_t i = 0; i < num_bindings; ++i) {
+    retain_array_for_stream(s, *arrays[i].arr);
+  }
+  end_command_recording(s.index);
 }
 
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -966,4 +966,49 @@ std::tuple<uint32_t, uint32_t, uint32_t> get_element_wise_grid_dims(
 // Logical tile size used by generic Vulkan indexing helpers.
 constexpr uint32_t VULKAN_INDEX_TILE_SIZE = 512;
 
+struct DynamicArrayRef {
+  const array* arr;
+  uint32_t binding;
+};
+
+struct DynamicComputeDispatch {
+  vk::CommandBuffer command_buffer;
+  ComputePipeline* pipeline;
+  std::vector<VkDescriptorBufferInfo> infos;
+  std::vector<VkWriteDescriptorSet> writes;
+  vk::DescriptorSet descriptor_set;
+};
+
+void write_descriptor_binding(
+    std::vector<VkDescriptorSetLayoutBinding>& bindings,
+    uint32_t binding);
+void write_descriptor_buffer(
+    const array& arr,
+    uint32_t binding,
+    VkDescriptorSet descriptor_set,
+    std::vector<VkDescriptorBufferInfo>& infos,
+    std::vector<VkWriteDescriptorSet>& writes);
+void ensure_dynamic_shader_registered(
+    const std::string& shader_name,
+    const std::string& glsl_source);
+bool is_vulkan_storage_array(const array& arr);
+
+DynamicComputeDispatch dispatch_dynamic_compute_begin(
+    const std::string& shader_name,
+    const std::string& glsl_source,
+    uint32_t num_bindings,
+    const DynamicArrayRef* arrays,
+    uint32_t push_constant_size,
+    const Stream& s);
+
+void dispatch_dynamic_compute(
+    const std::string& shader_name,
+    const std::string& glsl_source,
+    uint32_t num_bindings,
+    const DynamicArrayRef* arrays,
+    uint32_t workgroup_x,
+    uint32_t workgroup_y,
+    uint32_t workgroup_z,
+    const Stream& s);
+
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/shader_compiler.cpp
+++ b/mlx/backend/vulkan/shader_compiler.cpp
@@ -4,6 +4,8 @@
 
 #include <fmt/format.h>
 #include <shaderc/shaderc.hpp>
+#include <sstream>
+#include <stdexcept>
 
 namespace mlx::core::vulkan {
 
@@ -35,6 +37,142 @@ std::vector<uint32_t> compile_glsl_to_spirv(
   }
 
   return std::vector<uint32_t>(result.cbegin(), result.cend());
+}
+
+std::string dtype_to_glsl_storage_type(Dtype dtype) {
+  switch (dtype) {
+    case mlx::core::float32:
+      return "float";
+    case mlx::core::float16:
+      return "float16_t";
+    case mlx::core::bfloat16:
+      return "uint16_t";
+    case mlx::core::bool_:
+      return "uint8_t";
+    case mlx::core::uint16:
+      return "uint16_t";
+    case mlx::core::uint8:
+      return "uint8_t";
+    case mlx::core::int8:
+      return "int8_t";
+    case mlx::core::int16:
+      return "int16_t";
+    case mlx::core::int32:
+      return "int";
+    case mlx::core::uint32:
+      return "uint";
+    case mlx::core::uint64:
+      return "uint64_t";
+    case mlx::core::int64:
+      return "int64_t";
+    case mlx::core::complex64:
+      return "vec2";
+    default:
+      throw std::runtime_error(
+          "Unsupported dtype for Vulkan dynamic shader generation.");
+  }
+}
+
+bool uses_float16_extension(Dtype dtype) {
+  return dtype == mlx::core::float16;
+}
+
+bool uses_16bit_storage(Dtype dtype) {
+  return dtype == mlx::core::float16 || dtype == mlx::core::bfloat16 ||
+      dtype == mlx::core::int16 || dtype == mlx::core::uint16;
+}
+
+bool uses_8bit_storage(Dtype dtype) {
+  return dtype == mlx::core::bool_ || dtype == mlx::core::int8 ||
+      dtype == mlx::core::uint8;
+}
+
+std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output) {
+  std::ostringstream os;
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (needs_int64_output || dtype == mlx::core::int64 ||
+      dtype == mlx::core::uint64) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
+  }
+  if (uses_float16_extension(dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+  }
+  if (uses_16bit_storage(dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  if (uses_8bit_storage(dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
+    os << "#extension GL_EXT_shader_8bit_storage : require\n";
+  }
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  return os.str();
+}
+
+std::string emit_dynamic_shader_preamble(
+    Dtype in_dtype,
+    Dtype out_dtype,
+    bool needs_int64_output) {
+  std::ostringstream os;
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (needs_int64_output || in_dtype == mlx::core::int64 ||
+      in_dtype == mlx::core::uint64 || out_dtype == mlx::core::int64 ||
+      out_dtype == mlx::core::uint64) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
+  }
+  if (uses_float16_extension(in_dtype) || uses_float16_extension(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+  }
+  if (uses_16bit_storage(in_dtype) || uses_16bit_storage(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  if (uses_8bit_storage(in_dtype) || uses_8bit_storage(out_dtype)) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
+    os << "#extension GL_EXT_shader_8bit_storage : require\n";
+  }
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  return os.str();
+}
+
+std::string zero_literal_for_dtype(Dtype dtype) {
+  switch (dtype) {
+    case mlx::core::float32:
+      return "0.0";
+    case mlx::core::float16:
+      return "float16_t(0.0)";
+    case mlx::core::bool_:
+      return "uint8_t(0)";
+    case mlx::core::uint8:
+      return "uint8_t(0)";
+    case mlx::core::uint16:
+      return "uint16_t(0)";
+    case mlx::core::uint32:
+      return "uint(0)";
+    case mlx::core::uint64:
+      return "uint64_t(0)";
+    case mlx::core::int8:
+      return "int8_t(0)";
+    case mlx::core::int16:
+      return "int16_t(0)";
+    case mlx::core::int32:
+      return "int(0)";
+    case mlx::core::int64:
+      return "int64_t(0)";
+    default:
+      throw std::runtime_error(
+          "Unsupported dtype for Vulkan dynamic cast shader zero literal.");
+  }
+}
+
+std::string cast_expr_for_dtype(const std::string& expr, Dtype in, Dtype out) {
+  if (out == mlx::core::bool_) {
+    return "((" + expr + ") != " + zero_literal_for_dtype(in) +
+        " ? uint8_t(1) : uint8_t(0))";
+  }
+  return dtype_to_glsl_storage_type(out) + "(" + expr + ")";
 }
 
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/shader_compiler.h
+++ b/mlx/backend/vulkan/shader_compiler.h
@@ -3,8 +3,11 @@
 #pragma once
 
 #include <cstdint>
+#include <sstream>
 #include <string>
 #include <vector>
+
+#include "mlx/dtype.h"
 
 namespace mlx::core::vulkan {
 
@@ -13,5 +16,35 @@ namespace mlx::core::vulkan {
 std::vector<uint32_t> compile_glsl_to_spirv(
     const std::string& glsl_source,
     const std::string& shader_name);
+
+// Returns the GLSL storage type string for a dtype (e.g. "float", "uint16_t").
+std::string dtype_to_glsl_storage_type(Dtype dtype);
+
+// Returns true if the dtype requires the float16 GLSL extension.
+bool uses_float16_extension(Dtype dtype);
+
+// Returns true if the dtype requires 16-bit storage extensions.
+bool uses_16bit_storage(Dtype dtype);
+
+// Returns true if the dtype requires 8-bit storage extensions.
+bool uses_8bit_storage(Dtype dtype);
+
+// Emits a GLSL #version + extension preamble for a single-dtype shader.
+std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output);
+
+// Emits a GLSL #version + extension preamble for a cast shader (two dtypes).
+std::string emit_dynamic_shader_preamble(
+    Dtype in_dtype,
+    Dtype out_dtype,
+    bool needs_int64_output);
+
+// Returns a GLSL zero literal for the given dtype.
+std::string zero_literal_for_dtype(Dtype dtype);
+
+// Returns a GLSL cast expression, e.g. "float(x)" or "(x != 0 ? 1 : 0)".
+std::string cast_expr_for_dtype(
+    const std::string& expr,
+    Dtype in,
+    Dtype out);
 
 } // namespace mlx::core::vulkan

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -649,6 +649,15 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             gpu_out = self._run_on_device(mx.gpu, run_copy)
             self._assert_outputs_close(gpu_out, cpu_out, atol=0.0, rtol=0.0)
 
+    def test_gpu_source_unsupported_cast_copy_vulkan_gpu(self):
+        def run_copy():
+            src = mx.arange(0, 4096, dtype=mx.int64)
+            return src[64:2048].astype(mx.float16).astype(mx.float32)
+
+        cpu_out = self._run_on_device(mx.cpu, run_copy)
+        gpu_out = self._run_on_device(mx.gpu, run_copy)
+        self._assert_outputs_close(gpu_out, cpu_out, atol=0.0, rtol=0.0)
+
     def test_host_staging_arena_growth_and_reuse_vulkan_gpu(self):
         for cycle in range(3):
             host_srcs = [


### PR DESCRIPTION
## Summary
- Refactor `try_host_vector_cast_copy()` to remove blocking `synchronize_stream()` and use async completion callbacks for GPU readback.
- Route fallback readback/upload through owned staging helpers so the persistent staging arena allocation/release lifecycle is used.
- Add Vulkan regression coverage for unsupported GPU-source cast copy (`int64 -> float16`) parity against CPU.

Closes goniz/mlx-vulkan#30.

## Benchmark Results
### bf16
```text
Running Qwen3 benchmark with quantization: bf16
Fetching 9 files: 100%|██████████| 9/9 [00:00<00:00, 20460.02it/s]
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1461.781, generation_tps=11.168, peak_memory=2.061
Trial 2:  prompt_tps=1479.406, generation_tps=11.167, peak_memory=2.062
Trial 3:  prompt_tps=1473.193, generation_tps=10.989, peak_memory=2.062
Trial 4:  prompt_tps=1482.786, generation_tps=11.075, peak_memory=2.062
Trial 5:  prompt_tps=1465.952, generation_tps=11.233, peak_memory=2.063
Averages: prompt_tps=1472.624, generation_tps=11.126, peak_memory=2.062
```

### 8bit
```text
Running Qwen3 benchmark with quantization: 8bit
Fetching 9 files: 100%|██████████| 9/9 [00:00<00:00, 41120.63it/s]
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=882.081, generation_tps=6.328, peak_memory=1.393
Trial 2:  prompt_tps=871.976, generation_tps=6.465, peak_memory=1.394
Trial 3:  prompt_tps=881.327, generation_tps=6.459, peak_memory=1.394
Trial 4:  prompt_tps=862.224, generation_tps=6.469, peak_memory=1.394
Trial 5:  prompt_tps=874.173, generation_tps=6.404, peak_memory=1.394
Averages: prompt_tps=874.356, generation_tps=6.425, peak_memory=1.394
```