### PR TITLE
fix(vulkan): add bf16 dynamic cast shaders and copy fallback tracing

### DIFF
--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -34,6 +34,7 @@ using vulkan::cast_expr_for_dtype;
 using vulkan::dtype_to_glsl_storage_type;
 using vulkan::emit_dynamic_shader_preamble;
 using vulkan::is_vulkan_storage_array;
+using vulkan::zero_literal_for_dtype;
 
 constexpr size_t kMinTransferQueueCopyBytes = 256 * 1024;
 
@@ -148,6 +149,7 @@ bool supports_dynamic_gpu_cast_dtype(Dtype dtype) {
     case mlx::core::int64:
     case mlx::core::float16:
     case mlx::core::float32:
+    case mlx::core::bfloat16:
       return true;
     default:
       return false;
@@ -391,9 +393,62 @@ bool dispatch_dynamic_general_copy(
   return true;
 }
 
+bool needs_bf16_helpers(Dtype in_dtype, Dtype out_dtype) {
+  return in_dtype == mlx::core::bfloat16 || out_dtype == mlx::core::bfloat16;
+}
+
+std::string emit_bf16_conversion_helpers() {
+  std::ostringstream os;
+  os << "uint fp32_to_bf16(float f) {\n";
+  os << "  uint u = floatBitsToUint(f);\n";
+  os << "  u = (u + (0x7fffu + ((u >> 16) & 1u))) >> 16;\n";
+  os << "  return u;\n";
+  os << "}\n\n";
+  os << "float bf16_to_fp32(uint u) {\n";
+  os << "  return uintBitsToFloat(u << 16);\n";
+  os << "}\n\n";
+  return os.str();
+}
+
+std::string
+bf16_cast_expr(const std::string& expr, Dtype in_dtype, Dtype out_dtype) {
+  const bool in_is_bf16 = in_dtype == mlx::core::bfloat16;
+  const bool out_is_bf16 = out_dtype == mlx::core::bfloat16;
+
+  if (in_is_bf16 && out_is_bf16) {
+    return expr;
+  }
+
+  if (in_is_bf16 && !out_is_bf16) {
+    std::string as_float = "bf16_to_fp32(uint(" + expr + "))";
+    if (out_dtype == mlx::core::bool_) {
+      return "(" + as_float + " != " + zero_literal_for_dtype(out_dtype) +
+          " ? uint8_t(1) : uint8_t(0))";
+    }
+    return dtype_to_glsl_storage_type(out_dtype) + "(" + as_float + ")";
+  }
+
+  if (!in_is_bf16 && out_is_bf16) {
+    std::string intermediate;
+    if (in_dtype == mlx::core::bool_) {
+      intermediate = "float(" + expr + ")";
+    } else {
+      intermediate = "float(" + expr + ")";
+    }
+    return "uint16_t(fp32_to_bf16(" + intermediate + "))";
+  }
+
+  return {};
+}
+
 std::string build_dynamic_vector_cast_shader(Dtype in_dtype, Dtype out_dtype) {
   std::ostringstream os;
   os << emit_dynamic_shader_preamble(in_dtype, out_dtype, false);
+
+  if (needs_bf16_helpers(in_dtype, out_dtype)) {
+    os << emit_bf16_conversion_helpers();
+  }
+
   os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
   os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
      << dtype_to_glsl_storage_type(in_dtype) << " data[];} input_buf;\n";
@@ -406,9 +461,17 @@ std::string build_dynamic_vector_cast_shader(Dtype in_dtype, Dtype out_dtype) {
   os << "  }\n";
   os << "  uint input_index = linear_idx + pc.in_offset;\n";
   os << "  uint output_index = linear_idx + pc.out_offset;\n";
-  os << "  output_buf.data[output_index] = "
-     << cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype)
-     << ";\n";
+
+  std::string cast_expr;
+  if (needs_bf16_helpers(in_dtype, out_dtype)) {
+    cast_expr =
+        bf16_cast_expr("input_buf.data[input_index]", in_dtype, out_dtype);
+  } else {
+    cast_expr =
+        cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype);
+  }
+
+  os << "  output_buf.data[output_index] = " << cast_expr << ";\n";
   os << "}\n";
   return os.str();
 }
@@ -628,6 +691,14 @@ void host_cast_copy_dispatch_src(
   }
 }
 
+bool trace_copy_fallback_enabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("MLX_VULKAN_TRACE_COPY_FALLBACK");
+    return env != nullptr && std::string(env) != "0";
+  }();
+  return enabled;
+}
+
 bool try_host_vector_cast_copy(
     const mlx::core::array& in,
     mlx::core::array& out,
@@ -636,6 +707,16 @@ bool try_host_vector_cast_copy(
     int64_t out_offset,
     const mlx::core::Stream& s) {
   const bool in_is_vulkan = mlx::core::vulkan::is_vulkan_buffer(in.buffer());
+
+  if (trace_copy_fallback_enabled() && in_is_vulkan) {
+    std::cerr << "[MLX_VULKAN_COPY_FALLBACK] cast-copy fallback triggered: "
+              << "in_dtype=" << copy_dtype_suffix(in.dtype()) << " "
+              << "out_dtype=" << copy_dtype_suffix(out.dtype()) << " "
+              << "size=" << size << " "
+              << "in_offset=" << in_offset << " "
+              << "out_offset=" << out_offset << std::endl;
+  }
+
   auto* out_buf =
       static_cast<mlx::core::vulkan::VulkanBuffer*>(out.buffer().ptr());
 
@@ -1197,8 +1278,9 @@ void copy_gpu_inplace(
     }
   }
 
-  // Fallback for Vector copies with dtype conversion when no shader exists.
-  // try_host_vector_cast_copy handles GPU readback -> CPU conversion -> upload.
+  // Fallback for Vector copies with dtype conversion when no static shader
+  // exists. try_host_vector_cast_copy dispatches a dynamic GPU cast shader or
+  // falls back to CPU conversion for non-Vulkan inputs.
   if (ctype == CopyType::Vector && !same_dtype && !shader_copy) {
     try {
       if (try_host_vector_cast_copy(

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -422,8 +422,7 @@ bf16_cast_expr(const std::string& expr, Dtype in_dtype, Dtype out_dtype) {
   if (in_is_bf16 && !out_is_bf16) {
     std::string as_float = "bf16_to_fp32(uint(" + expr + "))";
     if (out_dtype == mlx::core::bool_) {
-      return "(" + as_float + " != " + zero_literal_for_dtype(out_dtype) +
-          " ? uint8_t(1) : uint8_t(0))";
+      return "(" + as_float + " != 0.0 ? uint8_t(1) : uint8_t(0))";
     }
     return dtype_to_glsl_storage_type(out_dtype) + "(" + as_float + ")";
   }

--- a/mlx/backend/vulkan/shader_compiler.cpp
+++ b/mlx/backend/vulkan/shader_compiler.cpp
@@ -161,6 +161,8 @@ std::string zero_literal_for_dtype(Dtype dtype) {
       return "int(0)";
     case mlx::core::int64:
       return "int64_t(0)";
+    case mlx::core::bfloat16:
+      return "uint16_t(0)";
     default:
       throw std::runtime_error(
           "Unsupported dtype for Vulkan dynamic cast shader zero literal.");


### PR DESCRIPTION
## Summary

- Add `bfloat16` to `supports_dynamic_gpu_cast_dtype` enabling GPU-native dynamic vector cast for bf16↔f32/f16 conversions
- Emit proper `fp32_to_bf16` / `bf16_to_fp32` GLSL bit-manipulation helpers in dynamic vector cast shaders (matching the approach in static `.comp` shaders)
- Add `MLX_VULKAN_TRACE_COPY_FALLBACK=1` env var to log when cast-copy fallback path is triggered during Vulkan execution
- Add `bfloat16` case to `zero_literal_for_dtype`
- Update stale comment about GPU readback (sync path was removed in `3a018e1c`)

Closes goniz/mlx-vulkan#28

## Context

Issue #28 described a catastrophic fallback path with `synchronize_stream()` that killed throughput. That path was already removed in `3a018e1c`. This PR addresses the remaining gaps: bfloat16 was missing from the dynamic GPU cast path, and there was no way to trace when fallbacks occur.

## Benchmark Results

### bf16
```
Trial 1:  prompt_tps=1486.722, generation_tps=11.117, peak_memory=2.061
Trial 2:  prompt_tps=1464.991, generation_tps=11.135, peak_memory=2.062
Trial 3:  prompt_tps=1478.316, generation_tps=11.151, peak_memory=2.062
Trial 4:  prompt_tps=1459.290, generation_tps=11.083, peak_memory=2.062
Trial 5:  prompt_tps=1477.200, generation_tps=11.113, peak_memory=2.063
Averages: prompt_tps=1473.304, generation_tps=11.120, peak_memory=2.062
```

### 8bit
```
Trial 1:  prompt_tps=876.631, generation_tps=6.482, peak_memory=1.393
Trial 2:  prompt_tps=899.003, generation_tps=6.414, peak_memory=1.394
Trial 3:  prompt_tps=884.989, generation_tps=6.448, peak_memory=1.394
Trial 4:  prompt_tps=872.936, generation_tps=6.377, peak_memory=1.394
Trial 5:  prompt_tps=892.522, generation_tps=6.750, peak_memory=1.394
Averages: prompt_tps=885.216, generation_tps=6.494, peak_memory=1.394
```

## Testing

- All bf16 tests pass (`test_bf16.py` excluding pre-existing `test_unary_ops` crash filed as goniz/mlx-vulkan#37)
- No `[MLX_VULKAN_COPY_FALLBACK]` traces during bf16 conversion tests — all decode-critical paths use static shaders
- bf16↔f32, bf16↔f16 dynamic vector casts verified working via GPU-native shaders