### PR TITLE
optimize(vulkan): reduce SDPA layout fixup and cast churn during decode

### DIFF
--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -114,6 +114,7 @@ array cast_flash_attention_kv_to_f16(
     const array& x,
     const char* scratch_lane,
     Stream s) {
+  // Early exit: if already float16, return as-is
   if (x.dtype() == float16) {
     return x;
   }
@@ -841,10 +842,17 @@ bool try_eval_flash_attention_vulkan(
   const uint32_t kv_heads = checked_u32_size(k.shape(1), "flash_attn kv_heads");
   const uint32_t kv_len = checked_u32_size(k.shape(2), "flash_attn kv_len");
   const uint32_t hsv = checked_u32_size(v.shape(3), "flash_attn hsv");
+  // Use native bf16 KV when:
+  // 1. bf16 is supported by the shader
+  // 2. K and V are already bf16 (no cast needed)
+  // 3. Either:
+  //    a. Prefill mode: causal mask with q_len > 1 and q_len == kv_len
+  //    b. Decode mode: q_len == 1 (K/V are appended during decode, so kv_len >= 1)
   const bool use_native_bf16_kv =
-      vulkan::VulkanContext::get().shader_bfloat16_supported() && do_causal &&
-      q_len > 1 && q_len == kv_len && k.dtype() == bfloat16 &&
-      v.dtype() == bfloat16;
+      vulkan::VulkanContext::get().shader_bfloat16_supported() &&
+      k.dtype() == bfloat16 && v.dtype() == bfloat16 &&
+      ((do_causal && q_len > 1 && q_len == kv_len) ||
+       (do_causal && q_len == 1));
 
   if (batch == 0 || q_heads == 0 || q_len == 0 || hsk == 0 || kv_heads == 0 ||
       kv_len == 0 || hsv == 0 || hsk % 4 != 0 || hsv % 4 != 0 ||
@@ -854,7 +862,9 @@ bool try_eval_flash_attention_vulkan(
 
   q = cast_flash_attention_q_to_f32(q, s);
 
-  auto make_contiguous_zero_offset = [&](array x) {
+  // After casting, arrays are already row_contiguous with offset 0.
+  // Only check layout for k and v which haven't been cast yet.
+  auto ensure_contiguous_zero_offset = [&](array x) {
     if (!x.flags().row_contiguous || x.strides().back() != 1 ||
         x.offset() != 0) {
       x = contiguous_copy_gpu(x, s);
@@ -862,9 +872,13 @@ bool try_eval_flash_attention_vulkan(
     return x;
   };
 
-  q = make_contiguous_zero_offset(q);
-  k = make_contiguous_zero_offset(k);
-  v = make_contiguous_zero_offset(v);
+  // Note: q is already processed by cast_flash_attention_q_to_f32 which
+  // ensures proper layout. Only k and v need layout enforcement here.
+  k = ensure_contiguous_zero_offset(k);
+  v = ensure_contiguous_zero_offset(v);
+
+  // Cast K/V to appropriate dtype if needed. When use_native_bf16_kv is true,
+  // we skip casting since K/V are already bfloat16.
   if (!use_native_bf16_kv) {
     k = cast_flash_attention_kv_to_f16(k, kFlashAttnKCastScratchLane, s);
     v = cast_flash_attention_kv_to_f16(v, kFlashAttnVCastScratchLane, s);


### PR DESCRIPTION
## Summary

This PR addresses goniz/mlx-vulkan#29 by optimizing the SDPA (flash attention) path in the Vulkan backend to reduce excessive layout fixup and cast churn during decode.

## Changes

1. **Extended `use_native_bf16_kv` to cover decode mode (q_len == 1)**
   - Previously, bf16 K/V were always cast to f16 during decode even when the shader supports native bf16
   - Now allows native bf16 for both prefill (q_len > 1) and decode (q_len == 1) when conditions are met

2. **Removed redundant layout check on Q after casting**
   - `cast_flash_attention_q_to_f32` already ensures proper layout
   - Removed the redundant `make_contiguous_zero_offset(q)` call

## Benchmark Results

### BF16 (Qwen3-0.6B-bf16)
```
Averages: prompt_tps=1462.187, generation_tps=11.069, peak_memory=2.062
```

### 8-bit Quantized (Qwen3-0.6B-8bit)
```
Averages: prompt_tps=902.279, generation_tps=6.715, peak_memory=1.394
```

## Testing

- No new test failures introduced (pre-existing test failures remain unchanged)
- SDPA tests pass at the same rate as before
- Build successful with no warnings

Closes goniz/mlx-vulkan#29