### PR TITLE
vulkan: add bfloat16 support for Log unary operation

### DIFF
--- a/mlx/backend/vulkan/primitives_utils.cpp
+++ b/mlx/backend/vulkan/primitives_utils.cpp
@@ -263,6 +263,7 @@ std::optional<vulkan::StaticShaderId> unary_shader_id(
   MLX_VK_UNARY_CASE(ErfInv, float32, erfinv_f32);
   MLX_VK_UNARY_CASE(Log, float32, log_f32);
   MLX_VK_UNARY_CASE(Log, float16, log_f16_rte);
+  MLX_VK_UNARY_CASE(Log, bfloat16, log_f32);
   MLX_VK_UNARY_CASE(Sin, float32, sin_f32);
   MLX_VK_UNARY_CASE(Square, float32, sqr_f32);
   MLX_VK_UNARY_CASE(Square, float16, sqr_f16);


### PR DESCRIPTION
## Summary

- Add bfloat16 support for the `Log` unary operation on the Vulkan backend by adding the missing `MLX_VK_UNARY_CASE(Log, bfloat16, log_f32)` entry in `unary_shader_id()`.
- Fixes a SIGABRT crash in `test_bf16::test_unary_ops` on the Vulkan backend (goniz/mlx-vulkan#37).

## Root Cause

The `Log` operation was missing a bfloat16 case in `unary_shader_id()`, causing `shader_id` to be `std::nullopt` for bf16 inputs. This triggered a `std::runtime_error` that manifested as a SIGABRT crash.

## Fix

Route bf16 log operations through the existing f32 shader with f32 staging I/O, matching the pattern already used by `Square`, `Sqrt`, and `Rsqrt`.

## Benchmark Results

### bf16 (Qwen3-0.6B)
```
Trial 1:  prompt_tps=1475.427, generation_tps=11.198, peak_memory=2.061
Trial 2:  prompt_tps=1475.565, generation_tps=11.211, peak_memory=2.062
Trial 3:  prompt_tps=1469.986, generation_tps=11.221, peak_memory=2.062
Trial 4:  prompt_tps=1474.564, generation_tps=11.137, peak_memory=2.062
Trial 5:  prompt_tps=1473.266, generation_tps=11.077, peak_memory=2.063
Averages: prompt_tps=1473.762, generation_tps=11.169, peak_memory=2.062
```

### 8bit (Qwen3-0.6B)
```
Trial 1:  prompt_tps=962.649, generation_tps=8.261, peak_memory=1.393
Trial 2:  prompt_tps=960.434, generation_tps=7.762, peak_memory=1.394
Trial 3:  prompt_tps=934.062, generation_tps=7.485, peak_memory=1.394
Trial 4:  prompt_tps=959.006, generation_tps=8.452, peak_memory=1.394
Trial 5:  prompt_tps=969.822, generation_tps=8.452, peak_memory=1.394
Averages: prompt_tps=957.195, generation_tps=8.082, peak_memory=1.394
```