### PR TITLE
vulkan: reduce unnecessary deferred decode barriers

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -1510,9 +1510,26 @@ class VulkanDevice {
     }
 
     if (barrier_between_deferred_ops()) {
-      trace_sync("barrier action=recording-tail reason=deferred-op-boundary");
-      insert_memory_barrier(
-          stream->recording_resources->compute_command_buffer);
+      if (stream->last_decode_resource_summary.safe_to_skip_tail_barrier()) {
+        if (trace_batch_enabled()) {
+          std::ostringstream oss;
+          oss << "decode-tail action=skip stream=" << stream->stream_index
+              << " rec_ops=" << stream->recorded_ops << " weights="
+              << stream->last_decode_resource_summary.read_only_weights
+              << " kv_writes="
+              << stream->last_decode_resource_summary.append_only_kv_writes
+              << " scratch="
+              << stream->last_decode_resource_summary.token_scratch
+              << " persistent="
+              << stream->last_decode_resource_summary.persistent_outputs
+              << " generic=" << stream->last_decode_resource_summary.generic;
+          trace_batch(oss.str());
+        }
+      } else {
+        trace_sync("barrier action=recording-tail reason=deferred-op-boundary");
+        insert_memory_barrier(
+            stream->recording_resources->compute_command_buffer);
+      }
     }
   }
 
@@ -1701,6 +1718,8 @@ class VulkanDevice {
       StreamData* stream,
       const std::vector<BufferAccessRange>& reads,
       const std::vector<BufferAccessRange>& writes) {
+    const bool decode_mode = should_prefer_long_decode_recording(stream);
+
     for (const auto& w : writes) {
       for (const auto& prev_w : stream->unsynced_writes) {
         if (overlaps(w, prev_w)) {
@@ -1724,15 +1743,28 @@ class VulkanDevice {
       }
     }
 
-    for (const auto& r : reads) {
-      for (const auto& prev_w : stream->unsynced_writes) {
-        if (overlaps(r, prev_w)) {
-          if (trace_sync_enabled()) {
+    if (!decode_mode) {
+      for (const auto& r : reads) {
+        for (const auto& prev_w : stream->unsynced_writes) {
+          if (overlaps(r, prev_w)) {
+            if (trace_sync_enabled()) {
+              trace_sync(
+                  "hazard raw current=" + format_access_range(r) +
+                  " previous=" + format_access_range(prev_w));
+            }
+            return true;
+          }
+        }
+      }
+    } else if (trace_sync_enabled()) {
+      for (const auto& r : reads) {
+        for (const auto& prev_w : stream->unsynced_writes) {
+          if (overlaps(r, prev_w)) {
             trace_sync(
-                "hazard raw current=" + format_access_range(r) +
+                "hazard raw skipped (decode) current=" +
+                format_access_range(r) +
                 " previous=" + format_access_range(prev_w));
           }
-          return true;
         }
       }
     }

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -1718,8 +1718,6 @@ class VulkanDevice {
       StreamData* stream,
       const std::vector<BufferAccessRange>& reads,
       const std::vector<BufferAccessRange>& writes) {
-    const bool decode_mode = should_prefer_long_decode_recording(stream);
-
     for (const auto& w : writes) {
       for (const auto& prev_w : stream->unsynced_writes) {
         if (overlaps(w, prev_w)) {
@@ -1743,28 +1741,15 @@ class VulkanDevice {
       }
     }
 
-    if (!decode_mode) {
-      for (const auto& r : reads) {
-        for (const auto& prev_w : stream->unsynced_writes) {
-          if (overlaps(r, prev_w)) {
-            if (trace_sync_enabled()) {
-              trace_sync(
-                  "hazard raw current=" + format_access_range(r) +
-                  " previous=" + format_access_range(prev_w));
-            }
-            return true;
-          }
-        }
-      }
-    } else if (trace_sync_enabled()) {
-      for (const auto& r : reads) {
-        for (const auto& prev_w : stream->unsynced_writes) {
-          if (overlaps(r, prev_w)) {
+    for (const auto& r : reads) {
+      for (const auto& prev_w : stream->unsynced_writes) {
+        if (overlaps(r, prev_w)) {
+          if (trace_sync_enabled()) {
             trace_sync(
-                "hazard raw skipped (decode) current=" +
-                format_access_range(r) +
+                "hazard raw current=" + format_access_range(r) +
                 " previous=" + format_access_range(prev_w));
           }
+          return true;
         }
       }
     }

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -491,8 +491,13 @@ struct DecodeResourceSummary {
     }
   }
 
+  // Vulkan submission order keeps commands ordered, but RAW/WAW hazards still
+  // need an explicit memory dependency for availability and visibility. Only
+  // skip the deferred tail barrier when the recorded decode op touched no
+  // scratch storage and produced no generic or persistent outputs.
   bool safe_to_skip_tail_barrier() const {
-    return seen_resource && persistent_outputs == 0 && generic == 0;
+    return seen_resource && token_scratch == 0 && persistent_outputs == 0 &&
+        generic == 0;
   }
 
   void reset() {
@@ -1718,6 +1723,9 @@ class VulkanDevice {
       StreamData* stream,
       const std::vector<BufferAccessRange>& reads,
       const std::vector<BufferAccessRange>& writes) {
+    // Commands recorded to the same queue have a defined submission order, but
+    // that order alone is not a memory dependency. Keep RAW/WAW overlap checks
+    // conservative so shader writes become visible to later reads/writes.
     for (const auto& w : writes) {
       for (const auto& prev_w : stream->unsynced_writes) {
         if (overlaps(w, prev_w)) {


### PR DESCRIPTION
## Summary

Reduces unnecessary Vulkan deferred barriers while preserving required decode synchronization.

This PR makes one safe change in `mlx/backend/vulkan/device.cpp`:

1. Extend the existing `safe_to_skip_tail_barrier()` path to the general deferred-submission tail path, so we skip the tail barrier when the most recent decode resource summary contains only read-only weights and append-only KV writes.

A follow-up change in this branch explicitly keeps RAW (read-after-write) hazard handling enabled during decode recording. That barrier is required to make KV-cache writes visible to later dispatches that read the updated KV region within the same command buffer.

Closes goniz/mlx-vulkan#32

## Correctness Note

An earlier version of this branch tried to suppress decode RAW hazards entirely. That was reverted after review because Vulkan command ordering alone is not sufficient to guarantee shader-write visibility to a later dispatch without an explicit memory dependency. The final branch state preserves those RAW hazard barriers.

## Benchmark Results

### bf16

```
Running Qwen3 benchmark with quantization: bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1467.953, generation_tps=11.085, peak_memory=2.061
Trial 2:  prompt_tps=1456.214, generation_tps=11.113, peak_memory=2.062
Trial 3:  prompt_tps=1481.606, generation_tps=11.062, peak_memory=2.062
Trial 4:  prompt_tps=1478.818, generation_tps=11.067, peak_memory=2.062
Trial 5:  prompt_tps=1474.806, generation_tps=11.151, peak_memory=2.063
Averages: prompt_tps=1471.879, generation_tps=11.095, peak_memory=2.062
```

### 8bit

```
Running Qwen3 benchmark with quantization: 8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=892.003, generation_tps=6.482, peak_memory=1.393
Trial 2:  prompt_tps=875.386, generation_tps=6.560, peak_memory=1.394
Trial 3:  prompt_tps=917.020, generation_tps=7.010, peak_memory=1.394
Trial 4:  prompt_tps=926.701, generation_tps=6.974, peak_memory=1.394
Trial 5:  prompt_tps=928.300, generation_tps=6.962, peak_memory=1.394
Averages: prompt_tps=907.882, generation_tps=6.798, peak_memory=1.394
```

## Validation

- Rebuilt with `./dev.sh build`
- Restored RAW hazard barriers confirmed via `MLX_VULKAN_TRACE_SYNC=1`
- Targeted Vulkan matmul smoke test passed via `./dev.sh run python3 -c ...`