### PR TITLE
fix(vulkan): fail unsupported ops instead of falling back to CPU

### DIFF
--- a/mlx/backend/vulkan/arange.cpp
+++ b/mlx/backend/vulkan/arange.cpp
@@ -12,18 +12,6 @@ namespace {
 
 std::optional<vulkan::StaticShaderId> arange_shader_id(Dtype dtype) {
   switch (dtype) {
-    case uint8:
-      return vulkan::StaticShaderId::arange_u8;
-    case uint16:
-      return vulkan::StaticShaderId::arange_u16;
-    case uint32:
-      return vulkan::StaticShaderId::arange_u32;
-    case int8:
-      return vulkan::StaticShaderId::arange_i8;
-    case int16:
-      return vulkan::StaticShaderId::arange_i16;
-    case int32:
-      return vulkan::StaticShaderId::arange_i32;
     case float16:
       return vulkan::StaticShaderId::arange_f16;
     case bfloat16:
@@ -31,6 +19,8 @@ std::optional<vulkan::StaticShaderId> arange_shader_id(Dtype dtype) {
     case float32:
       return vulkan::StaticShaderId::arange_f32;
     default:
+      // Integer arange needs typed scalars; the current float push constants
+      // would silently round large start/step values.
       return std::nullopt;
   }
 }

--- a/mlx/backend/vulkan/arange.cpp
+++ b/mlx/backend/vulkan/arange.cpp
@@ -12,6 +12,18 @@ namespace {
 
 std::optional<vulkan::StaticShaderId> arange_shader_id(Dtype dtype) {
   switch (dtype) {
+    case uint8:
+      return vulkan::StaticShaderId::arange_u8;
+    case uint16:
+      return vulkan::StaticShaderId::arange_u16;
+    case uint32:
+      return vulkan::StaticShaderId::arange_u32;
+    case int8:
+      return vulkan::StaticShaderId::arange_i8;
+    case int16:
+      return vulkan::StaticShaderId::arange_i16;
+    case int32:
+      return vulkan::StaticShaderId::arange_i32;
     case float16:
       return vulkan::StaticShaderId::arange_f16;
     case bfloat16:
@@ -19,8 +31,6 @@ std::optional<vulkan::StaticShaderId> arange_shader_id(Dtype dtype) {
     case float32:
       return vulkan::StaticShaderId::arange_f32;
     default:
-      // Integer arange needs typed scalars; the current float push constants
-      // would silently round large start/step values.
       return std::nullopt;
   }
 }
@@ -52,8 +62,8 @@ bool try_eval_arange_vulkan(
         *shader_id,
         command_buffer,
         s,
-        static_cast<float>(start),
-        static_cast<float>(step));
+        start,
+        step);
     vulkan::end_command_recording(s.index);
 
     return true;

--- a/mlx/backend/vulkan/arange.cpp
+++ b/mlx/backend/vulkan/arange.cpp
@@ -10,42 +10,29 @@ namespace mlx::core {
 
 namespace {
 
-template <typename T>
-void fill_arange_like_cpu(array& out, Stream s, double start, double step) {
-  out.set_data(allocator::malloc(out.nbytes()));
-  if (out.size() == 0) {
-    return;
+std::optional<vulkan::StaticShaderId> arange_shader_id(Dtype dtype) {
+  switch (dtype) {
+    case uint8:
+      return vulkan::StaticShaderId::arange_u8;
+    case uint16:
+      return vulkan::StaticShaderId::arange_u16;
+    case uint32:
+      return vulkan::StaticShaderId::arange_u32;
+    case int8:
+      return vulkan::StaticShaderId::arange_i8;
+    case int16:
+      return vulkan::StaticShaderId::arange_i16;
+    case int32:
+      return vulkan::StaticShaderId::arange_i32;
+    case float16:
+      return vulkan::StaticShaderId::arange_f16;
+    case bfloat16:
+      return vulkan::StaticShaderId::arange_bf16;
+    case float32:
+      return vulkan::StaticShaderId::arange_f32;
+    default:
+      return std::nullopt;
   }
-
-  T value = static_cast<T>(start);
-  const T next = static_cast<T>(start + step);
-  const T step_size = next - value;
-
-  if (vulkan::VulkanContext::get().is_unified_memory()) {
-    auto* out_buf = static_cast<vulkan::VulkanBuffer*>(out.buffer().ptr());
-    auto* dst = static_cast<T*>(out_buf->mapped_ptr);
-    for (size_t i = 0; i < out.size(); ++i) {
-      dst[i] = value;
-      value += step_size;
-    }
-    return;
-  }
-
-  std::vector<T> host_values(out.size());
-  for (size_t i = 0; i < out.size(); ++i) {
-    host_values[i] = value;
-    value += step_size;
-  }
-
-  auto* out_buf = static_cast<vulkan::VulkanBuffer*>(out.buffer().ptr());
-  vulkan::enqueue_owned_staging_upload(
-      s,
-      host_values.data(),
-      host_values.size() * sizeof(T),
-      out_buf->buffer,
-      out.offset(),
-      out.data_shared_ptr());
-  vulkan::retain_array_for_stream(s, out);
 }
 
 bool try_eval_arange_vulkan(
@@ -58,47 +45,9 @@ bool try_eval_arange_vulkan(
     return false;
   }
 
-  switch (out.dtype()) {
-    case bool_:
-      return false;
-    case uint8:
-      fill_arange_like_cpu<uint8_t>(out, s, start, step);
-      return true;
-    case uint16:
-      fill_arange_like_cpu<uint16_t>(out, s, start, step);
-      return true;
-    case uint32:
-      fill_arange_like_cpu<uint32_t>(out, s, start, step);
-      return true;
-    case uint64:
-      fill_arange_like_cpu<uint64_t>(out, s, start, step);
-      return true;
-    case int8:
-      fill_arange_like_cpu<int8_t>(out, s, start, step);
-      return true;
-    case int16:
-      fill_arange_like_cpu<int16_t>(out, s, start, step);
-      return true;
-    case int32:
-      fill_arange_like_cpu<int32_t>(out, s, start, step);
-      return true;
-    case int64:
-      fill_arange_like_cpu<int64_t>(out, s, start, step);
-      return true;
-    case float16:
-      fill_arange_like_cpu<float16_t>(out, s, start, step);
-      return true;
-    case float64:
-      fill_arange_like_cpu<double>(out, s, start, step);
-      return true;
-    case bfloat16:
-      fill_arange_like_cpu<bfloat16_t>(out, s, start, step);
-      return true;
-    case complex64:
-      fill_arange_like_cpu<complex64_t>(out, s, start, step);
-      return true;
-    case float32:
-      break;
+  auto shader_id = arange_shader_id(out.dtype());
+  if (!shader_id.has_value()) {
+    return false;
   }
 
   out.set_data(allocator::malloc(out.nbytes()));
@@ -110,7 +59,7 @@ bool try_eval_arange_vulkan(
     auto command_buffer = vulkan::begin_command_recording(s.index);
     vulkan::dispatch_arange_op(
         out,
-        vulkan::StaticShaderId::arange_f32,
+        *shader_id,
         command_buffer,
         s,
         static_cast<float>(start),

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -2,6 +2,7 @@
 
 #include <fmt/format.h>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstring>
 #include <limits>
@@ -40,6 +41,14 @@ bool trace_compiled_glsl_enabled() {
 bool trace_compiled_runtime_enabled() {
   static const bool enabled = []() {
     const char* env = std::getenv("MLX_VULKAN_TRACE_COMPILED_RUNTIME");
+    return env != nullptr && std::string(env) != "0";
+  }();
+  return enabled;
+}
+
+bool trace_compiled_timing_enabled() {
+  static const bool enabled = []() {
+    const char* env = std::getenv("MLX_VULKAN_TRACE_COMPILED_TIMING");
     return env != nullptr && std::string(env) != "0";
   }();
   return enabled;
@@ -1015,6 +1024,8 @@ void Compiled::eval_gpu(
 
   std::vector<uint32_t> spirv;
   if (!existing_shader) {
+    const auto compile_start = std::chrono::steady_clock::now();
+
     // Generate GLSL source
     std::string glsl_source;
     build_glsl_kernel(
@@ -1038,6 +1049,8 @@ void Compiled::eval_gpu(
                 << glsl_source << "\n=== End GLSL ===\n";
     }
 
+    const auto glsl_built_at = std::chrono::steady_clock::now();
+
     // Compile to SPIR-V
     try {
       spirv = vulkan::compile_glsl_to_spirv(glsl_source, kernel_name);
@@ -1049,9 +1062,32 @@ void Compiled::eval_gpu(
       throw;
     }
 
+    const auto spirv_compiled_at = std::chrono::steady_clock::now();
+
     // Register the shader
     manager.register_shader(
         kernel_name, spirv.data(), spirv.size() * sizeof(uint32_t));
+
+    if (trace_compiled_timing_enabled()) {
+      const auto registered_at = std::chrono::steady_clock::now();
+      const auto glsl_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                               glsl_built_at - compile_start)
+                               .count();
+      const auto spirv_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                spirv_compiled_at - glsl_built_at)
+                                .count();
+      const auto register_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                   registered_at - spirv_compiled_at)
+                                   .count();
+      const auto total_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
+                                registered_at - compile_start)
+                                .count();
+      std::cerr << "[vulkan-compiled-timing] kernel=" << kernel_name
+                << " glsl_ms=" << glsl_ms << " spirv_ms=" << spirv_ms
+                << " register_ms=" << register_ms << " total_ms=" << total_ms
+                << " tape_size=" << tape_.size() << " contiguous=" << contiguous
+                << " large=" << large << "\n";
+    }
   }
 
   // Allocate outputs with buffer donation

--- a/mlx/backend/vulkan/conv.cpp
+++ b/mlx/backend/vulkan/conv.cpp
@@ -561,8 +561,8 @@ void Convolution::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
-  eval_cpu_fallback_with_state_on_stream<Convolution>(
-      inputs, out, stream(), state());
+  throw std::runtime_error(
+      "Convolution has no Vulkan implementation for this input.");
 }
 
 } // namespace mlx::core

--- a/mlx/backend/vulkan/conv.cpp
+++ b/mlx/backend/vulkan/conv.cpp
@@ -37,6 +37,24 @@ struct Conv2dPushConstants {
   uint32_t OWOHL;
 };
 
+struct DepthwiseConv2dPushConstants {
+  uint32_t ne;
+  uint32_t batches;
+  uint32_t channels;
+  uint32_t dst_w;
+  uint32_t dst_h;
+  uint32_t src_w;
+  uint32_t src_h;
+  uint32_t knl_w;
+  uint32_t knl_h;
+  int32_t stride_x;
+  int32_t stride_y;
+  int32_t pad_x;
+  int32_t pad_y;
+  int32_t dilation_x;
+  int32_t dilation_y;
+};
+
 struct ConvBlockSize {
   uint32_t k;
   uint32_t npq;
@@ -472,6 +490,10 @@ bool try_eval_conv1d_vulkan(
     return true;
   }
 
+  const bool is_depthwise =
+      groups == in_channels && channels_per_group == 1 &&
+      out_channels == in_channels;
+
   in = dilate_input_1d(in, input_dilation[0], s);
   in =
       pad(in,
@@ -482,6 +504,144 @@ bool try_eval_conv1d_vulkan(
           s);
 
   auto wt_work = flip ? reverse_kernel_1d(wt, s) : wt;
+
+  if (is_depthwise) {
+    if ((in.dtype() != float32 && in.dtype() != float16 && in.dtype() != bfloat16) ||
+        (out.dtype() != float32 && out.dtype() != float16 && out.dtype() != bfloat16) ||
+        (wt_work.dtype() != float32 && wt_work.dtype() != float16 &&
+         wt_work.dtype() != bfloat16)) {
+      return false;
+    }
+
+    auto in_compute = in.dtype() == float32 ? in : astype(in, float32, s);
+    auto wt_compute = wt_work;
+    if (wt_compute.dtype() == bfloat16) {
+      wt_compute = astype(wt_compute, float16, s);
+    }
+
+    auto in_4d = reshape(in_compute, {batch, 1, in_compute.shape(1), in_channels}, s);
+    auto in_work = make_tracked_contiguous_copy(in_4d, s, "conv1d_dw.copy_input");
+
+    auto wt_kwc = transpose(wt_compute, {1, 0, 2}, s);
+    wt_kwc = reshape(wt_kwc, {1, kernel, in_channels}, s);
+    auto wt_depthwise =
+        make_tracked_contiguous_copy(wt_kwc, s, "conv1d_dw.copy_weight");
+
+    array out_work({batch, 1, out_len, out_channels}, float32, nullptr, {});
+    out_work.set_data(vulkan::allocator().malloc(out_work.nbytes()));
+
+    const auto shader_id = wt_depthwise.dtype() == float16
+        ? vulkan::StaticShaderId::conv2d_dw_cwhn_f16_f32
+        : vulkan::StaticShaderId::conv2d_dw_cwhn_f32;
+
+    auto bindings = conv_layout_bindings();
+    auto& manager = vulkan::KernelManager::get();
+    auto* pipeline = manager.get_pipeline(
+        shader_id,
+        bindings,
+        static_cast<uint32_t>(sizeof(DepthwiseConv2dPushConstants)));
+    if (pipeline == nullptr) {
+      return false;
+    }
+
+    const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
+    vk::DescriptorSet descriptor_set =
+        manager.allocate_descriptor_set(pipeline->descriptor_layout);
+    manager.defer_descriptor_set_free(s.index, descriptor_epoch, descriptor_set);
+
+    std::array<VkDescriptorBufferInfo, 3> descriptor_infos = {{
+        descriptor_buffer_info(wt_depthwise, "weights"),
+        descriptor_buffer_info(in_work, "input"),
+        descriptor_buffer_info(out_work, "output"),
+    }};
+    std::array<VkWriteDescriptorSet, 3> descriptor_writes{};
+    for (uint32_t i = 0; i < descriptor_writes.size(); ++i) {
+      descriptor_writes[i].sType = VK_STRUCTURE_TYPE_WRITE_DESCRIPTOR_SET;
+      descriptor_writes[i].dstSet = descriptor_set;
+      descriptor_writes[i].dstBinding = i;
+      descriptor_writes[i].descriptorType = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+      descriptor_writes[i].descriptorCount = 1;
+      descriptor_writes[i].pBufferInfo = &descriptor_infos[i];
+    }
+    vkUpdateDescriptorSets(
+        vulkan::VulkanContext::get().device(),
+        static_cast<uint32_t>(descriptor_writes.size()),
+        descriptor_writes.data(),
+        0,
+        nullptr);
+
+    DepthwiseConv2dPushConstants push_constants{};
+    push_constants.ne = checked_u32_size(num_elements(out_work.shape()), "conv1d_dw elements");
+    push_constants.batches = checked_u32_size(batch, "conv1d_dw batches");
+    push_constants.channels = checked_u32_size(in_channels, "conv1d_dw channels");
+    push_constants.dst_w = checked_u32_size(out_len, "conv1d_dw dst width");
+    push_constants.dst_h = 1;
+    push_constants.src_w = checked_u32_size(in_compute.shape(1), "conv1d_dw src width");
+    push_constants.src_h = 1;
+    push_constants.knl_w = checked_u32_size(kernel, "conv1d_dw kernel width");
+    push_constants.knl_h = 1;
+    push_constants.stride_x = kernel_strides[0];
+    push_constants.stride_y = 1;
+    push_constants.pad_x = 0;
+    push_constants.pad_y = 0;
+    push_constants.dilation_x = kernel_dilation[0];
+    push_constants.dilation_y = 1;
+
+    const uint32_t grid_x = div_up_u32(push_constants.ne, 512u);
+    vulkan::record_primitive_for_stream(s, "conv1d_dw.direct");
+    vulkan::begin_primitive_tracking(s, {wt_depthwise, in_work}, {out_work});
+    auto command_buffer = vulkan::begin_command_recording(s.index);
+    vkCmdBindPipeline(
+        command_buffer, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline->pipeline);
+    VkDescriptorSet vk_descriptor_set = static_cast<VkDescriptorSet>(descriptor_set);
+    vkCmdBindDescriptorSets(
+        command_buffer,
+        VK_PIPELINE_BIND_POINT_COMPUTE,
+        pipeline->layout,
+        0,
+        1,
+        &vk_descriptor_set,
+        0,
+        nullptr);
+    vkCmdPushConstants(
+        command_buffer,
+        pipeline->layout,
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        sizeof(push_constants),
+        &push_constants);
+    vkCmdDispatch(command_buffer, grid_x, 1, 1);
+    vulkan::end_command_recording(s.index);
+    vulkan::end_primitive_tracking(s, {wt_depthwise, in_work}, {out_work});
+
+    array out_3d(out.shape(), out_work.dtype(), nullptr, {});
+    const auto [data_size, row_contiguous, col_contiguous] =
+        check_contiguity(out.shape(), out.strides());
+    out_3d.copy_shared_buffer(
+        out_work,
+        out.strides(),
+        {data_size == out_work.data_size(), row_contiguous, col_contiguous},
+        out_work.data_size(),
+        out_work.offset());
+    vulkan::retain_array_for_stream(s, in_work);
+    vulkan::retain_array_for_stream(s, wt_depthwise);
+    vulkan::retain_array_for_stream(s, out_work);
+    if (out.dtype() == float32) {
+      out.copy_shared_buffer(out_3d);
+      return true;
+    }
+
+    out.set_data(vulkan::allocator().malloc(out.nbytes()));
+    vulkan::record_primitive_for_stream(s, "conv1d_dw.copy_output");
+    vulkan::begin_primitive_tracking(s, {out_3d}, {out});
+    copy_gpu(out_3d, out, CopyType::General, s);
+    vulkan::end_primitive_tracking(s, {out_3d}, {out});
+    return true;
+  }
+
+  if (groups > 32) {
+    return false;
+  }
 
   const auto& in_strides = in.strides();
   auto patches = as_strided(

--- a/mlx/backend/vulkan/conv.cpp
+++ b/mlx/backend/vulkan/conv.cpp
@@ -639,10 +639,6 @@ bool try_eval_conv1d_vulkan(
     return true;
   }
 
-  if (groups > 32) {
-    return false;
-  }
-
   const auto& in_strides = in.strides();
   auto patches = as_strided(
       in,

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -1083,6 +1083,40 @@ std::optional<vulkan::StaticShaderId> get_copy_shader_id(
 
 namespace mlx::core {
 
+namespace {
+
+std::optional<vulkan::StaticShaderId> fill_shader_id(Dtype dtype) {
+  switch (dtype) {
+    case float32:
+      return vulkan::StaticShaderId::fill_f32;
+    case float16:
+      return vulkan::StaticShaderId::fill_f16;
+    case bfloat16:
+      return vulkan::StaticShaderId::fill_bf16;
+    default:
+      return std::nullopt;
+  }
+}
+
+std::optional<float> scalar_fill_value_as_float(const array& val) {
+  const void* ptr = val.data<void>();
+  if (ptr == nullptr) {
+    return std::nullopt;
+  }
+  switch (val.dtype()) {
+    case float32:
+      return *static_cast<const float*>(ptr);
+    case float16:
+      return static_cast<float>(*static_cast<const float16_t*>(ptr));
+    case bfloat16:
+      return static_cast<float>(*static_cast<const bfloat16_t*>(ptr));
+    default:
+      return std::nullopt;
+  }
+}
+
+} // namespace
+
 void copy_gpu(const array& src, array& out, CopyType ctype, const Stream& s) {
   bool donated = set_copy_output_data(src, out, ctype);
   if (donated && src.dtype() == out.dtype()) {
@@ -1092,6 +1126,10 @@ void copy_gpu(const array& src, array& out, CopyType ctype, const Stream& s) {
   }
   if (ctype == CopyType::GeneralGeneral) {
     ctype = CopyType::General;
+  }
+  if (ctype == CopyType::Scalar) {
+    fill_gpu(src, out, s);
+    return;
   }
   copy_gpu_inplace(src, out, ctype, s);
 }
@@ -1502,7 +1540,27 @@ void fill_gpu(const array& val, array& out, const Stream& s) {
     return;
   }
 
+  array fill_val = val;
+  if (fill_val.has_primitive()) {
+    fill_val.eval();
+  } else {
+    auto data = fill_val.data_shared_ptr();
+    if (data == nullptr || data->buffer.ptr() == nullptr) {
+      fill_val.wait();
+    }
+  }
+
   out.set_data(allocator::malloc(out.nbytes()));
+
+  if (auto shader_id = fill_shader_id(out.dtype()); shader_id.has_value()) {
+    if (auto fill_value = scalar_fill_value_as_float(fill_val); fill_value.has_value()) {
+      auto command_buffer = vulkan::begin_command_recording(s.index);
+      vulkan::dispatch_fill_op(out, *shader_id, command_buffer, s, *fill_value);
+      vulkan::retain_array_for_stream(s, out);
+      vulkan::end_command_recording(s.index);
+      return;
+    }
+  }
 
   // For unified memory, we can directly fill on CPU
   auto* out_buf = static_cast<vulkan::VulkanBuffer*>(out.buffer().ptr());
@@ -1510,17 +1568,25 @@ void fill_gpu(const array& val, array& out, const Stream& s) {
   if (vulkan::VulkanContext::get().is_unified_memory()) {
     // Direct CPU fill for unified memory
     char* dst_ptr = static_cast<char*>(out_buf->mapped_ptr);
-    const char* val_ptr = static_cast<const char*>(val.data<void>());
-    size_t val_size = size_of(val.dtype());
+    const char* val_ptr = static_cast<const char*>(fill_val.data<void>());
+    size_t val_size = size_of(fill_val.dtype());
     size_t out_size = out.nbytes();
 
-    for (size_t i = 0; i < out_size; i += val_size) {
-      std::memcpy(dst_ptr + i, val_ptr, val_size);
+    const bool repeated_byte =
+        std::all_of(val_ptr + 1, val_ptr + val_size, [&](char c) {
+          return c == val_ptr[0];
+        });
+    if (repeated_byte) {
+      std::memset(dst_ptr, val_ptr[0], out_size);
+    } else {
+      for (size_t i = 0; i < out_size; i += val_size) {
+        std::memcpy(dst_ptr + i, val_ptr, val_size);
+      }
     }
   } else {
     std::vector<char> host_fill(out.nbytes());
-    const char* val_ptr = static_cast<const char*>(val.data<void>());
-    size_t val_size = size_of(val.dtype());
+    const char* val_ptr = static_cast<const char*>(fill_val.data<void>());
+    size_t val_size = size_of(fill_val.dtype());
     for (size_t i = 0; i < host_fill.size(); i += val_size) {
       std::memcpy(host_fill.data() + i, val_ptr, val_size);
     }
@@ -1531,7 +1597,7 @@ void fill_gpu(const array& val, array& out, const Stream& s) {
         out_buf->buffer,
         out.offset(),
         out.data_shared_ptr());
-    vulkan::retain_array_for_stream(s, val);
+    vulkan::retain_array_for_stream(s, fill_val);
     vulkan::retain_array_for_stream(s, out);
   }
 }

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -1093,6 +1093,9 @@ std::optional<vulkan::StaticShaderId> fill_shader_id(Dtype dtype) {
       return vulkan::StaticShaderId::fill_f16;
     case bfloat16:
       return vulkan::StaticShaderId::fill_bf16;
+    case bool_:
+    case uint8:
+      return vulkan::StaticShaderId::fill_u8;
     default:
       return std::nullopt;
   }
@@ -1110,6 +1113,10 @@ std::optional<float> scalar_fill_value_as_float(const array& val) {
       return static_cast<float>(*static_cast<const float16_t*>(ptr));
     case bfloat16:
       return static_cast<float>(*static_cast<const bfloat16_t*>(ptr));
+    case bool_:
+      return *static_cast<const bool*>(ptr) ? 1.0f : 0.0f;
+    case uint8:
+      return static_cast<float>(*static_cast<const uint8_t*>(ptr));
     default:
       return std::nullopt;
   }

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -567,8 +567,6 @@ bool dispatch_dynamic_vector_cast_copy(
       std::max<uint32_t>((static_cast<uint32_t>(size) + 255u) / 256u, 1u);
   vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
 
-  vulkan::retain_array_for_stream(s, in);
-  vulkan::retain_array_for_stream(s, out);
   vulkan::end_command_recording(s.index);
   return true;
 }

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -1012,14 +1012,6 @@ bool sdpa_vulkan_supported(
   return true;
 }
 
-std::vector<array> eval_fallback_outputs(
-    const std::function<std::vector<array>(std::vector<array>)>& fallback,
-    const std::vector<array>& inputs) {
-  auto outputs = fallback(inputs);
-  eval(outputs);
-  return outputs;
-}
-
 bool is_supported_sdpa_rowwise_layout(const array& arr) {
   return arr.flags().contiguous && arr.offset() == 0 && arr.ndim() > 0 &&
       arr.strides().back() == 1;
@@ -1795,6 +1787,10 @@ bool ScaledDotProductAttention::use_fallback(
     bool is_training,
     bool output_logsumexp,
     Stream s) {
+  if (s.device == Device::cpu) {
+    return true;
+  }
+
   std::string reason;
   const bool supported = sdpa_vulkan_supported(
       q,
@@ -1817,7 +1813,7 @@ bool ScaledDotProductAttention::use_fallback(
         << " output_logsumexp=" << output_logsumexp;
     trace_use_fallback("ScaledDotProductAttention", s, reason, oss.str());
   }
-  return !supported;
+  return false;
 }
 
 bool ScaledDotProductAttention::supports_bool_mask() {
@@ -2229,8 +2225,7 @@ void RMSNormVJP::eval_gpu(
 void ConvertFP8::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
-  eval_cpu_fallback_multi_with_state_on_stream<ConvertFP8>(
-      inputs, outputs, stream(), state());
+  throw std::runtime_error("ConvertFP8 has no Vulkan implementation.");
 }
 
 void Quantize::eval_gpu(
@@ -2253,22 +2248,8 @@ void Quantize::eval_gpu(
         return;
       }
 
-      auto fallback_inputs = inputs;
-      if (fallback_inputs.size() > 1 &&
-          !fallback_inputs[1].flags().row_contiguous) {
-        fallback_inputs[1] = contiguous_copy_gpu(fallback_inputs[1], stream());
-      }
-      auto fallback_outputs = fallback_(fallback_inputs);
-      for (size_t i = 0; i < outputs.size(); ++i) {
-        array staged(
-            fallback_outputs[i].shape(),
-            fallback_outputs[i].dtype(),
-            nullptr,
-            {});
-        copy_gpu(fallback_outputs[i], staged, CopyType::General, stream());
-        outputs[i].overwrite_descriptor(staged);
-      }
-      return;
+      throw std::runtime_error(
+          "Quantize dequantize only supports Affine and Nvfp4 modes on Vulkan.");
     }
     if (inputs.size() != 3) {
       throw std::runtime_error(
@@ -2307,11 +2288,8 @@ void Quantize::eval_gpu(
     copy_gpu(out_f32, out, CopyType::General, s);
   } else {
     if (mode_ != QuantizationMode::Affine) {
-      auto fallback_outputs = eval_fallback_outputs(fallback_, inputs);
-      for (size_t i = 0; i < outputs.size(); ++i) {
-        outputs[i].copy_shared_buffer(fallback_outputs[i]);
-      }
-      return;
+      throw std::runtime_error(
+          "Quantize encode only supports Affine mode on Vulkan.");
     }
     if (outputs.size() != 3 || inputs.size() != 1) {
       throw std::runtime_error(

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -1790,29 +1790,6 @@ bool ScaledDotProductAttention::use_fallback(
   if (s.device == Device::cpu) {
     return true;
   }
-
-  std::string reason;
-  const bool supported = sdpa_vulkan_supported(
-      q,
-      k,
-      v,
-      has_mask,
-      has_arr_mask,
-      do_causal,
-      is_training,
-      output_logsumexp,
-      false,
-      s,
-      &reason);
-  if (!supported && trace_fallback_enabled()) {
-    std::ostringstream oss;
-    oss << "q_shape=" << q.shape() << " k_shape=" << k.shape()
-        << " v_shape=" << v.shape() << " has_mask=" << has_mask
-        << " has_arr_mask=" << has_arr_mask << " do_causal=" << do_causal
-        << " is_training=" << is_training
-        << " output_logsumexp=" << output_logsumexp;
-    trace_use_fallback("ScaledDotProductAttention", s, reason, oss.str());
-  }
   return false;
 }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -546,13 +546,12 @@ array make_flash_attention_causal_mask(
     return mask;
   }
 
-  array mask_f32 = zeros(shape, float32, s);
-  if (mask_f32.dtype() != float32) {
+  array mask_f16 = zeros(shape, float16, s);
+  if (mask_f16.dtype() != float16) {
     throw std::runtime_error("Unexpected causal mask dtype.");
   }
   const int n_past = k.shape(2) - q.shape(2);
-  mask_f32 = apply_diag_mask_inf_vulkan(mask_f32, n_past, s);
-  array mask_f16 = astype(mask_f32, float16, s);
+  mask_f16 = apply_diag_mask_inf_vulkan(mask_f16, n_past, s);
   eval(mask_f16);
   copy_gpu_inplace(mask_f16, mask, CopyType::General, s);
   mask.set_status(array::Status::evaluated);
@@ -1469,9 +1468,22 @@ bool try_eval_sdpa_heads_vulkan(
 array apply_diag_mask_inf_vulkan(const array& scores, int n_past, Stream s) {
   array in = ensure_sdpa_rowwise_layout(scores, s);
 
-  array masked(in.shape(), float32, nullptr, {});
+  array masked(in.shape(), in.dtype(), nullptr, {});
   masked.set_status(array::Status::available);
   masked.set_data(allocator::malloc(masked.nbytes()));
+
+  auto shader_id = [&]() {
+    switch (in.dtype()) {
+      case float32:
+        return vulkan::StaticShaderId::diag_mask_inf_f32;
+      case float16:
+        return vulkan::StaticShaderId::diag_mask_inf_f16;
+      case bfloat16:
+        return vulkan::StaticShaderId::diag_mask_inf_bf16;
+      default:
+        throw std::runtime_error("DiagMaskInf unsupported dtype on Vulkan.");
+    }
+  }();
 
   const std::vector<array> tracked_inputs = {in};
   const std::vector<array> tracked_outputs = {masked};
@@ -1481,7 +1493,7 @@ array apply_diag_mask_inf_vulkan(const array& scores, int n_past, Stream s) {
   vulkan::dispatch_diag_mask_inf_op(
       in,
       masked,
-      vulkan::StaticShaderId::diag_mask_inf_f32,
+      shader_id,
       command_buffer,
       s,
       checked_u32_size(in.shape(in.ndim() - 2), "rows_per_channel"),

--- a/mlx/backend/vulkan/gather.cpp
+++ b/mlx/backend/vulkan/gather.cpp
@@ -21,84 +21,6 @@ bool needs_row_contiguous(const array& arr) {
   return !arr.flags().row_contiguous || arr.offset() != 0;
 }
 
-bool is_low_precision_gather_value_dtype(Dtype dtype) {
-  return dtype == float16 || dtype == bfloat16;
-}
-
-int64_t read_index_value(const array& idx, size_t flat_pos) {
-  switch (idx.dtype()) {
-    case int32:
-      return static_cast<int64_t>(idx.data<int32_t>()[flat_pos]);
-    case int64:
-      return idx.data<int64_t>()[flat_pos];
-    case uint32:
-      return static_cast<int64_t>(idx.data<uint32_t>()[flat_pos]);
-    case uint64: {
-      auto value = idx.data<uint64_t>()[flat_pos];
-      if (value > static_cast<uint64_t>(std::numeric_limits<int64_t>::max())) {
-        throw std::out_of_range("Gather index exceeds int64 range.");
-      }
-      return static_cast<int64_t>(value);
-    }
-    default:
-      throw std::runtime_error("Unsupported gather index dtype.");
-  }
-}
-
-bool try_eval_take_axis0_low_precision_copy_fallback(
-    const array& src,
-    array idx,
-    array& out,
-    Stream s) {
-  if (src.ndim() == 0 || idx.size() == 0) {
-    return false;
-  }
-  if (!is_low_precision_gather_value_dtype(src.dtype()) || !src.flags().row_contiguous ||
-      src.offset() != 0 || idx.ndim() == 0) {
-    return false;
-  }
-
-  idx.wait();
-  const uint32_t size_axis = static_cast<uint32_t>(src.shape(0));
-  const uint32_t size_post = checked_shape_product(
-      src, 1, src.ndim(), "gather_take_fallback size_post");
-  array out_work(out.shape(), out.dtype(), nullptr, {});
-  out_work.set_data(allocator::malloc(out_work.nbytes()));
-
-  for (size_t flat_pos = 0; flat_pos < idx.size(); ++flat_pos) {
-    int64_t raw_index = read_index_value(idx, flat_pos);
-    if (raw_index < 0) {
-      raw_index += size_axis;
-    }
-    if (raw_index < 0 || raw_index >= size_axis) {
-      throw std::out_of_range("Gather index out of bounds.");
-    }
-
-    array src_slice({static_cast<int>(size_post)}, src.dtype(), nullptr, {});
-    src_slice.copy_shared_buffer(
-        src,
-        {1},
-        {true, true, true},
-        size_post,
-        static_cast<size_t>(raw_index) * size_post);
-    src_slice.set_status(array::Status::available);
-
-    array out_slice({static_cast<int>(size_post)}, out.dtype(), nullptr, {});
-    out_slice.copy_shared_buffer(
-        out_work,
-        {1},
-        {true, true, true},
-        size_post,
-        flat_pos * static_cast<size_t>(size_post));
-    out_slice.set_status(array::Status::available);
-
-    copy_gpu_inplace(src_slice, out_slice, CopyType::Vector, s);
-  }
-
-  copy_gpu(out_work, out, CopyType::GeneralGeneral, s);
-  return true;
-}
-
 array ensure_row_contiguous(array arr, Stream s) {
   if (needs_row_contiguous(arr)) {
     arr = contiguous_copy_gpu(arr, s);
@@ -264,11 +186,6 @@ bool try_eval_gather_vulkan(
 
   array src = ensure_row_contiguous(src_input, s);
   idx = ensure_row_contiguous(idx, s);
-
-  if (axis == 0 &&
-      try_eval_take_axis0_low_precision_copy_fallback(src, idx, out, s)) {
-    return true;
-  }
 
   const uint32_t size_pre =
       checked_shape_product(src_input, 0, axis, "gather_take size_pre");

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2288,6 +2288,27 @@ void dispatch_arange_op(
       s);
 }
 
+void dispatch_fill_op(
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    float value) {
+  const auto num_elements = checked_u32(out.size(), "fill element count");
+  const auto push_constants =
+      make_generic_push_constants(num_elements, value, 0.0f, 0.0f, 0.0f);
+  const std::array<BoundArray, 1> bound_arrays = {{{&out, "dst"}}};
+
+  dispatch_with_spec(
+      shader_id,
+      KernelSpecId::Arange,
+      bound_arrays,
+      push_constants,
+      push_constants.KX,
+      cmd_buffer,
+      s);
+}
+
 void dispatch_sum_rows_op(
     const array& in,
     array& out,

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2629,9 +2629,12 @@ void dispatch_diag_mask_inf_op(
     throw std::runtime_error(
         "[vulkan::kernels] DiagMaskInf requires input rank >= 1.");
   }
-  if (in.dtype() != float32 || out.dtype() != float32) {
+  const bool f32_io = in.dtype() == float32 && out.dtype() == float32;
+  const bool f16_io = in.dtype() == float16 && out.dtype() == float16;
+  const bool bf16_io = in.dtype() == bfloat16 && out.dtype() == bfloat16;
+  if (!f32_io && !f16_io && !bf16_io) {
     throw std::runtime_error(
-        "[vulkan::kernels] DiagMaskInf currently requires float32 IO.");
+        "[vulkan::kernels] DiagMaskInf currently requires matching f32/f16/bf16 IO.");
   }
 
   const uint32_t ncols =

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -3661,6 +3661,7 @@ DynamicComputeDispatch dispatch_dynamic_compute_begin(
   }
 
   for (uint32_t i = 0; i < num_bindings; ++i) {
+    retain_array_for_stream(s, *arrays[i].arr);
     write_descriptor_buffer(
         *arrays[i].arr, arrays[i].binding, descriptor_set, infos, writes);
   }
@@ -3722,9 +3723,6 @@ void dispatch_dynamic_compute(
   auto dispatch = dispatch_dynamic_compute_begin(
       shader_name, glsl_source, num_bindings, arrays, 0, s);
   vkCmdDispatch(dispatch.command_buffer, workgroup_x, workgroup_y, workgroup_z);
-  for (uint32_t i = 0; i < num_bindings; ++i) {
-    retain_array_for_stream(s, *arrays[i].arr);
-  }
   end_command_recording(s.index);
 }
 

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -421,7 +421,7 @@ const std::array<KernelSpec, 31> kKernelSpecs = {
         DispatchGridKind::ElementWise),
     make_kernel_spec(
         {0},
-        sizeof(GenericPushConstants),
+        sizeof(ArangePushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
         {0, 1},
@@ -685,6 +685,62 @@ GenericPushConstants make_generic_push_constants(
   push_constants.param2 = param2;
   push_constants.param3 = param3;
   push_constants.param4 = param4;
+  return push_constants;
+}
+
+template <typename T>
+ArangePushConstants make_arange_push_constants_t(
+    uint32_t num_elements,
+    double start,
+    double step) {
+  const T start_t = static_cast<T>(start);
+  const T next_t = static_cast<T>(start + step);
+  const T step_t = static_cast<T>(next_t - start_t);
+
+  ArangePushConstants push_constants{};
+  push_constants.KX = num_elements;
+  push_constants.KY = 1;
+  push_constants.start_i64 = static_cast<int64_t>(start_t);
+  push_constants.step_i64 = static_cast<int64_t>(step_t);
+  push_constants.start_f32 = static_cast<float>(start_t);
+  push_constants.step_f32 = static_cast<float>(step_t);
+  return push_constants;
+}
+
+ArangePushConstants make_arange_push_constants(
+    const array& out,
+    uint32_t num_elements,
+    double start,
+    double step) {
+  switch (out.dtype()) {
+    case uint8:
+      return make_arange_push_constants_t<uint8_t>(num_elements, start, step);
+    case uint16:
+      return make_arange_push_constants_t<uint16_t>(num_elements, start, step);
+    case uint32:
+      return make_arange_push_constants_t<uint32_t>(num_elements, start, step);
+    case int8:
+      return make_arange_push_constants_t<int8_t>(num_elements, start, step);
+    case int16:
+      return make_arange_push_constants_t<int16_t>(num_elements, start, step);
+    case int32:
+      return make_arange_push_constants_t<int32_t>(num_elements, start, step);
+    case float16:
+      return make_arange_push_constants_t<float16_t>(num_elements, start, step);
+    case bfloat16:
+      return make_arange_push_constants_t<bfloat16_t>(num_elements, start, step);
+    case float32:
+      return make_arange_push_constants_t<float>(num_elements, start, step);
+    default:
+      throw std::runtime_error("[vulkan::kernels] Unsupported arange dtype.");
+  }
+}
+
+ArangePushConstants make_fill_push_constants(uint32_t num_elements, float value) {
+  ArangePushConstants push_constants{};
+  push_constants.KX = num_elements;
+  push_constants.KY = 1;
+  push_constants.start_f32 = value;
   return push_constants;
 }
 
@@ -2271,11 +2327,11 @@ void dispatch_arange_op(
     StaticShaderId shader_id,
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
-    float start,
-    float step) {
+    double start,
+    double step) {
   const auto num_elements = checked_u32(out.size(), "arange element count");
   const auto push_constants =
-      make_generic_push_constants(num_elements, start, step, 0.0f, 0.0f);
+      make_arange_push_constants(out, num_elements, start, step);
   const std::array<BoundArray, 1> bound_arrays = {{{&out, "dst"}}};
 
   dispatch_with_spec(
@@ -2295,8 +2351,7 @@ void dispatch_fill_op(
     const Stream& s,
     float value) {
   const auto num_elements = checked_u32(out.size(), "fill element count");
-  const auto push_constants =
-      make_generic_push_constants(num_elements, value, 0.0f, 0.0f, 0.0f);
+  const auto push_constants = make_fill_push_constants(num_elements, value);
   const std::array<BoundArray, 1> bound_arrays = {{{&out, "dst"}}};
 
   dispatch_with_spec(

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -302,6 +302,15 @@ struct GenericPushConstants {
   float param4;
 };
 
+struct ArangePushConstants {
+  uint32_t KX;
+  uint32_t KY;
+  int64_t start_i64;
+  int64_t step_i64;
+  float start_f32;
+  float step_f32;
+};
+
 struct SumRowsPushConstants {
   uint32_t n_cols;
   uint32_t ne01;
@@ -657,8 +666,8 @@ void dispatch_arange_op(
     StaticShaderId shader_id,
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
-    float start,
-    float step);
+    double start,
+    double step);
 
 void dispatch_fill_op(
     array& out,

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -660,6 +660,13 @@ void dispatch_arange_op(
     float start,
     float step);
 
+void dispatch_fill_op(
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    float value);
+
 void dispatch_sum_rows_op(
     const array& in,
     array& out,

--- a/mlx/backend/vulkan/kernels/arange.comp
+++ b/mlx/backend/vulkan/kernels/arange.comp
@@ -16,5 +16,9 @@ void main() {
 
     // p.param1 = start, p.param2 = step
     float value = p.param1 + p.param2 * float(i);
+#ifdef DATA_D_BF16
+    data_d[i] = uint16_t(fp32_to_bf16(value));
+#else
     data_d[i] = D_TYPE(value);
+#endif
 }

--- a/mlx/backend/vulkan/kernels/arange.comp
+++ b/mlx/backend/vulkan/kernels/arange.comp
@@ -1,9 +1,18 @@
 #version 450
 
-#include "generic_head.glsl"
 #include "types.glsl"
 
 layout(local_size_x = 512, local_size_y = 1, local_size_z = 1) in;
+
+layout (push_constant) uniform parameter
+{
+    uint KX;
+    uint KY;
+    int64_t start_i64;
+    int64_t step_i64;
+    float start_f32;
+    float step_f32;
+} p;
 
 layout (binding = 0) writeonly buffer D {D_TYPE data_d[];};
 
@@ -14,8 +23,7 @@ void main() {
         return;
     }
 
-    // p.param1 = start, p.param2 = step
-    float value = p.param1 + p.param2 * float(i);
+    float value = p.start_f32 + p.step_f32 * float(i);
 #ifdef DATA_D_BF16
     data_d[i] = uint16_t(fp32_to_bf16(value));
 #else

--- a/mlx/backend/vulkan/kernels/arange_int.comp
+++ b/mlx/backend/vulkan/kernels/arange_int.comp
@@ -23,10 +23,6 @@ void main() {
         return;
     }
 
-    // p.param1 = fill value
-#ifdef DATA_D_BF16
-    data_d[i] = uint16_t(fp32_to_bf16(p.start_f32));
-#else
-    data_d[i] = D_TYPE(p.start_f32);
-#endif
+    int64_t value = p.start_i64 + p.step_i64 * int64_t(i);
+    data_d[i] = D_TYPE(value);
 }

--- a/mlx/backend/vulkan/kernels/diag_mask_inf.comp
+++ b/mlx/backend/vulkan/kernels/diag_mask_inf.comp
@@ -1,6 +1,7 @@
 #version 450
 
 #extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
 #extension GL_EXT_control_flow_attributes : enable
 
 layout (push_constant) uniform parameter
@@ -26,9 +27,22 @@ void main() {
     }
 
     const uint i = row*p.ncols + col;
+#ifdef DATA_A_BF16
+    float in_val = bf16_to_fp32(uint32_t(data_a[i]));
+#else
+    A_TYPE in_val = data_a[i];
+#endif
     if (col > p.n_past + row % p.rows_per_channel) {
+#ifdef DATA_D_BF16
+        data_d[i] = uint16_t(fp32_to_bf16(uintBitsToFloat(0xFF800000)));
+#else
         data_d[i] = D_TYPE(uintBitsToFloat(0xFF800000));
+#endif
     } else {
-        data_d[i] = D_TYPE(data_a[i]);
+#ifdef DATA_D_BF16
+        data_d[i] = uint16_t(fp32_to_bf16(float(in_val)));
+#else
+        data_d[i] = D_TYPE(in_val);
+#endif
     }
 }

--- a/mlx/backend/vulkan/kernels/fill.comp
+++ b/mlx/backend/vulkan/kernels/fill.comp
@@ -15,5 +15,9 @@ void main() {
     }
 
     // p.param1 = fill value
+#ifdef DATA_D_BF16
+    data_d[i] = uint16_t(fp32_to_bf16(p.param1));
+#else
     data_d[i] = D_TYPE(p.param1);
+#endif
 }

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2174,27 +2174,27 @@ void process_shaders() {
        {"DATA_D_BF16", "1"}});
   string_to_spv(
       "arange_i32",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "int"}, {"D_TYPE", "int"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "arange_u32",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "arange_i16",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "int16_t"}, {"D_TYPE", "int16_t"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "arange_u16",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "uint16_t"}, {"D_TYPE", "uint16_t"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "arange_i8",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "int8_t"}, {"D_TYPE", "int8_t"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "arange_u8",
-      "arange.comp",
+      "arange_int.comp",
       {{"A_TYPE", "uint8_t"}, {"D_TYPE", "uint8_t"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "fill_f32", "fill.comp", {{"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2162,6 +2162,41 @@ void process_shaders() {
       "arange.comp",
       {{"A_TYPE", "float"}, {"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
+      "arange_f16",
+      "arange.comp",
+      {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_bf16",
+      "arange.comp",
+      {{"A_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"FLOAT_TYPE", "float"},
+       {"DATA_D_BF16", "1"}});
+  string_to_spv(
+      "arange_i32",
+      "arange.comp",
+      {{"A_TYPE", "int"}, {"D_TYPE", "int"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_u32",
+      "arange.comp",
+      {{"A_TYPE", "uint"}, {"D_TYPE", "uint"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_i16",
+      "arange.comp",
+      {{"A_TYPE", "int16_t"}, {"D_TYPE", "int16_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_u16",
+      "arange.comp",
+      {{"A_TYPE", "uint16_t"}, {"D_TYPE", "uint16_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_i8",
+      "arange.comp",
+      {{"A_TYPE", "int8_t"}, {"D_TYPE", "int8_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "arange_u8",
+      "arange.comp",
+      {{"A_TYPE", "uint8_t"}, {"D_TYPE", "uint8_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
       "fill_f32", "fill.comp", {{"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "fill_f16",
@@ -2170,7 +2205,11 @@ void process_shaders() {
   string_to_spv(
       "fill_bf16",
       "fill.comp",
-      {{"D_TYPE", "uint16_t"}, {"FLOAT_TYPE", "float"}});
+      {{"D_TYPE", "uint16_t"}, {"FLOAT_TYPE", "float"}, {"DATA_D_BF16", "1"}});
+  string_to_spv(
+      "fill_u8",
+      "fill.comp",
+      {{"D_TYPE", "uint8_t"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
       "step_f16",
       "step.comp",
@@ -2279,6 +2318,17 @@ void process_shaders() {
       "diag_mask_inf_f32",
       "diag_mask_inf.comp",
       {{"A_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "diag_mask_inf_f16",
+      "diag_mask_inf.comp",
+      {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}});
+  string_to_spv(
+      "diag_mask_inf_bf16",
+      "diag_mask_inf.comp",
+      {{"A_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"DATA_A_BF16", "1"},
+       {"DATA_D_BF16", "1"}});
 
   string_to_spv(
       "logsumexp_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2164,6 +2164,14 @@ void process_shaders() {
   string_to_spv(
       "fill_f32", "fill.comp", {{"D_TYPE", "float"}, {"FLOAT_TYPE", "float"}});
   string_to_spv(
+      "fill_f16",
+      "fill.comp",
+      {{"D_TYPE", "float16_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
+      "fill_bf16",
+      "fill.comp",
+      {{"D_TYPE", "uint16_t"}, {"FLOAT_TYPE", "float"}});
+  string_to_spv(
       "step_f16",
       "step.comp",
       {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}});

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -986,6 +986,26 @@ bool try_eval_bitwise_binary_vulkan(
     return false;
   }
 
+  auto materialize_broadcast_input = [&](array& in) {
+    if (in.shape() == out.shape()) {
+      return true;
+    }
+    if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
+      return false;
+    }
+    if (!ensure_vulkan_buffer_compare(in, s)) {
+      return false;
+    }
+    array view(out.shape(), in.dtype(), nullptr, {});
+    broadcast(in, view);
+    in = view;
+    return true;
+  };
+
+  if (!materialize_broadcast_input(a) || !materialize_broadcast_input(b)) {
+    return false;
+  }
+
   if (!is_supported_elementwise_layout(a)) {
     a = contiguous_copy_gpu(a, s);
   }

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -13,26 +13,24 @@ namespace mlx::core {
 
 #define CPU_FALLBACK(func)                                            \
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
-    eval_cpu_fallback_on_stream<func>(inputs, out, stream());         \
+    throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
 
 #define CPU_FALLBACK_STATE(func)                                      \
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
-    eval_cpu_fallback_with_state_on_stream<func>(                     \
-        inputs, out, stream(), state());                              \
+    throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
 
 #define CPU_FALLBACK_MULTI(func)                                        \
   void func::eval_gpu(                                                  \
       const std::vector<array>& inputs, std::vector<array>& outputs) {  \
-    eval_cpu_fallback_multi_on_stream<func>(inputs, outputs, stream()); \
+    throw std::runtime_error(#func " has no Vulkan implementation.");  \
   }
 
 #define CPU_FALLBACK_MULTI_STATE(func)                                 \
   void func::eval_gpu(                                                 \
       const std::vector<array>& inputs, std::vector<array>& outputs) { \
-    eval_cpu_fallback_multi_with_state_on_stream<func>(                \
-        inputs, outputs, stream(), state());                           \
+    throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
 
 #define NO_GPU_MULTI(func)                                             \
@@ -465,7 +463,7 @@ CPU_FALLBACK(NotEqual)
 CPU_FALLBACK_STATE(Partition)
 void Power::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_power_vulkan(inputs, out, stream())) {
-    eval_cpu_fallback_on_stream<Power>(inputs, out, stream());
+    throw std::runtime_error("Power has no Vulkan implementation for this input.");
   }
 }
 // QuantizedMatmul and QQMatmul are implemented in quantized.cpp.
@@ -526,7 +524,8 @@ CPU_FALLBACK(SegmentedMM)
 
 void Select::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_select_vulkan(inputs, out, stream())) {
-    eval_cpu_fallback_on_stream<Select>(inputs, out, stream());
+    throw std::runtime_error(
+        "Select has no Vulkan implementation for this input.");
   }
 }
 

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -11,23 +11,23 @@
 
 namespace mlx::core {
 
-#define CPU_FALLBACK(func)                                            \
+#define NYI_OP(func)                                                  \
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
     throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
 
-#define CPU_FALLBACK_STATE(func)                                      \
+#define NYI_OP_STATE(func)                                            \
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
     throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
 
-#define CPU_FALLBACK_MULTI(func)                                        \
+#define NYI_OP_MULTI(func)                                              \
   void func::eval_gpu(                                                  \
       const std::vector<array>& inputs, std::vector<array>& outputs) {  \
     throw std::runtime_error(#func " has no Vulkan implementation.");  \
   }
 
-#define CPU_FALLBACK_MULTI_STATE(func)                                 \
+#define NYI_OP_MULTI_STATE(func)                                       \
   void func::eval_gpu(                                                 \
       const std::vector<array>& inputs, std::vector<array>& outputs) { \
     throw std::runtime_error(#func " has no Vulkan implementation."); \
@@ -49,13 +49,6 @@ namespace mlx::core {
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
     throw std::runtime_error(#func " has no Vulkan implementation."); \
   }
-
-#define NO_GPU_USE_FALLBACK(func)                             \
-  bool func::use_fallback(Stream s) {                         \
-    trace_use_fallback(#func, s, "no Vulkan implementation"); \
-    return true;                                              \
-  }                                                           \
-  NO_GPU_MULTI(func)
 
 #define NO_GPU(func)                                                  \
   void func::eval_gpu(const std::vector<array>& inputs, array& out) { \
@@ -401,7 +394,7 @@ bool try_eval_select_vulkan(
 } // namespace
 
 // Primitives with state that have CPU fallbacks
-CPU_FALLBACK_STATE(Equal)
+NYI_OP_STATE(Equal)
 
 // Primitives implemented in other files:
 // - binary.cpp: Add, Minimum, Maximum, Divide, Subtract, Multiply
@@ -421,35 +414,35 @@ void Load::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 
 // CPU fallbacks for primitives not implemented on Vulkan
-CPU_FALLBACK(ArcCos)
-CPU_FALLBACK(ArcCosh)
-CPU_FALLBACK(ArcSin)
-CPU_FALLBACK(ArcSinh)
-CPU_FALLBACK(ArcTan)
-CPU_FALLBACK(ArcTan2)
-CPU_FALLBACK(ArcTanh)
-CPU_FALLBACK_STATE(ArgPartition)
-CPU_FALLBACK_STATE(ArgSort)
-CPU_FALLBACK_STATE(BitwiseBinary)
-CPU_FALLBACK(BitwiseInvert)
-CPU_FALLBACK(Conjugate)
-CPU_FALLBACK(Cosh)
-CPU_FALLBACK_MULTI(DivMod)
-CPU_FALLBACK(Remainder)
-CPU_FALLBACK(Expm1)
-CPU_FALLBACK_STATE(FFT)
-CPU_FALLBACK_STATE(GatherMM)
-CPU_FALLBACK_STATE(GatherQMM)
-CPU_FALLBACK(Greater)
-CPU_FALLBACK_STATE(Hadamard)
-CPU_FALLBACK(Imag)
-CPU_FALLBACK(Less)
-CPU_FALLBACK(LessEqual)
-CPU_FALLBACK(Log1p)
-CPU_FALLBACK(LogicalNot)
-CPU_FALLBACK(LogicalAnd)
-CPU_FALLBACK(LogicalOr)
-CPU_FALLBACK(LogAddExp)
+NYI_OP(ArcCos)
+NYI_OP(ArcCosh)
+NYI_OP(ArcSin)
+NYI_OP(ArcSinh)
+NYI_OP(ArcTan)
+NYI_OP(ArcTan2)
+NYI_OP(ArcTanh)
+NYI_OP_STATE(ArgPartition)
+NYI_OP_STATE(ArgSort)
+NYI_OP_STATE(BitwiseBinary)
+NYI_OP(BitwiseInvert)
+NYI_OP(Conjugate)
+NYI_OP(Cosh)
+NYI_OP_MULTI(DivMod)
+NYI_OP(Remainder)
+NYI_OP(Expm1)
+NYI_OP_STATE(FFT)
+NYI_OP_STATE(GatherMM)
+NYI_OP_STATE(GatherQMM)
+NYI_OP(Greater)
+NYI_OP_STATE(Hadamard)
+NYI_OP(Imag)
+NYI_OP(Less)
+NYI_OP(LessEqual)
+NYI_OP(Log1p)
+NYI_OP(LogicalNot)
+NYI_OP(LogicalAnd)
+NYI_OP(LogicalOr)
+NYI_OP(LogAddExp)
 // Linear algebra operations - throw NYI like Metal backend
 NO_GPU_MULTI(LUF)
 NO_GPU_MULTI(QRF)
@@ -459,8 +452,8 @@ NO_GPU_MULTI_STATE(Eigh)
 NO_GPU_MULTI_STATE(Eig)
 NO_GPU_MULTI_STATE(SVD)
 
-CPU_FALLBACK(NotEqual)
-CPU_FALLBACK_STATE(Partition)
+NYI_OP(NotEqual)
+NYI_OP_STATE(Partition)
 void Power::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_power_vulkan(inputs, out, stream())) {
     throw std::runtime_error("Power has no Vulkan implementation for this input.");
@@ -468,11 +461,11 @@ void Power::eval_gpu(const std::vector<array>& inputs, array& out) {
 }
 // QuantizedMatmul and QQMatmul are implemented in quantized.cpp.
 
-CPU_FALLBACK(Real)
-CPU_FALLBACK(Sign)
-CPU_FALLBACK(Sinh)
-CPU_FALLBACK_STATE(Sort)
-CPU_FALLBACK(Tan)
+NYI_OP(Real)
+NYI_OP(Sign)
+NYI_OP(Sinh)
+NYI_OP_STATE(Sort)
+NYI_OP(Tan)
 NO_GPU(MaskedScatter)
 // Scatter and ScatterAxis are implemented in scatter.cpp
 
@@ -520,7 +513,7 @@ void SliceUpdate::eval_gpu(const std::vector<array>& inputs, array& out) {
       stream());
 }
 
-CPU_FALLBACK(SegmentedMM)
+NYI_OP(SegmentedMM)
 
 void Select::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_select_vulkan(inputs, out, stream())) {

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -64,6 +64,13 @@ array collapse_power_leading_dims(const array& arr, Stream s) {
   return flatten_in_eval(arr, 0, arr.ndim() - 4, s);
 }
 
+array collapse_compare_leading_dims(const array& arr, Stream s) {
+  if (arr.ndim() <= 4) {
+    return arr;
+  }
+  return flatten_in_eval(arr, 0, arr.ndim() - 4, s);
+}
+
 bool ensure_vulkan_buffer_power(array& arr, Stream s) {
   auto data = arr.data_shared_ptr();
   if (data != nullptr && vulkan::is_vulkan_buffer(data->buffer)) {
@@ -83,6 +90,65 @@ bool ensure_vulkan_buffer_power(array& arr, Stream s) {
   data = arr.data_shared_ptr();
   return data != nullptr && vulkan::is_vulkan_buffer(data->buffer);
 }
+
+bool ensure_vulkan_buffer_compare(array& arr, Stream s) {
+  auto data = arr.data_shared_ptr();
+  if (data != nullptr && vulkan::is_vulkan_buffer(data->buffer)) {
+    return true;
+  }
+  if (arr.has_primitive()) {
+    arr = contiguous_copy_gpu(arr, s);
+    data = arr.data_shared_ptr();
+    return data != nullptr && vulkan::is_vulkan_buffer(data->buffer);
+  }
+  arr.wait();
+  data = arr.data_shared_ptr();
+  if (data != nullptr && vulkan::is_vulkan_buffer(data->buffer)) {
+    return true;
+  }
+  arr = contiguous_copy_gpu(arr, s);
+  data = arr.data_shared_ptr();
+  return data != nullptr && vulkan::is_vulkan_buffer(data->buffer);
+}
+
+bool is_supported_equal_dtype(Dtype dtype) {
+  switch (dtype) {
+    case bool_:
+    case float16:
+    case float32:
+    case bfloat16:
+    case int32:
+    case int64:
+    case uint32:
+    case uint64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool is_supported_ordered_compare_dtype(Dtype dtype) {
+  switch (dtype) {
+    case float16:
+    case float32:
+    case bfloat16:
+    case int32:
+    case int64:
+    case uint32:
+    case uint64:
+      return true;
+    default:
+      return false;
+  }
+}
+
+enum class CompareOp {
+  Equal,
+  NotEqual,
+  Less,
+  LessEqual,
+  Greater,
+};
 
 std::string emit_bf16_power_helpers() {
   return R"(
@@ -161,6 +227,383 @@ std::string build_power_shader(Dtype a_dtype, Dtype b_dtype, Dtype out_dtype) {
       << power_output_expr(out_dtype, "pow(lhs, rhs)") << ";\n";
   os << "}\n";
   return os.str();
+}
+
+std::string equal_input_expr(
+    Dtype dtype,
+    const char* buffer_name,
+    const char* index_name) {
+  if (dtype == bfloat16) {
+    return std::string("bf16_to_fp32(uint(") + buffer_name + ".data[" +
+        index_name + "]))";
+  }
+  if (dtype == float16) {
+    return std::string("float(") + buffer_name + ".data[" + index_name + "])";
+  }
+  if (dtype == bool_) {
+    return std::string("uint(") + buffer_name + ".data[" + index_name + "])";
+  }
+  return std::string(buffer_name) + ".data[" + index_name + "]";
+}
+
+std::string build_equal_shader(Dtype a_dtype, Dtype b_dtype, bool equal_nan) {
+  std::ostringstream os;
+  const bool uses_bfloat16 = a_dtype == bfloat16 || b_dtype == bfloat16;
+  const bool uses_float16 = a_dtype == float16 || b_dtype == float16;
+  const bool uses_int64 =
+      a_dtype == int64 || a_dtype == uint64 || b_dtype == int64 ||
+      b_dtype == uint64;
+
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (uses_int64) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
+  }
+  if (uses_bfloat16 || uses_float16) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
+  os << "#extension GL_EXT_shader_8bit_storage : require\n";
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+
+  if (uses_bfloat16) {
+    os << emit_bf16_power_helpers();
+  }
+
+  os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer InputA {"
+     << vulkan::dtype_to_glsl_storage_type(a_dtype) << " data[];} a_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputB {"
+     << vulkan::dtype_to_glsl_storage_type(b_dtype) << " data[];} b_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (linear_idx >= pc.total_elements) return;\n";
+  os << "  uint idx = linear_idx;\n";
+  os << "  uint a_idx = idx + pc.a_offset;\n";
+  os << "  uint b_idx = idx + pc.b_offset;\n";
+  os << "  bool is_equal = (" << equal_input_expr(a_dtype, "a_buf", "a_idx")
+     << ") == (" << equal_input_expr(b_dtype, "b_buf", "b_idx") << ")";
+  if (equal_nan && (uses_bfloat16 || uses_float16 || a_dtype == float32 ||
+                    b_dtype == float32)) {
+    os << " || (isnan(" << equal_input_expr(a_dtype, "a_buf", "a_idx")
+       << ") && isnan(" << equal_input_expr(b_dtype, "b_buf", "b_idx")
+       << "))";
+  }
+  os << ";\n";
+  os << "  out_buf.data[idx + pc.out_offset] = is_equal ? uint8_t(1) : uint8_t(0);\n";
+  os << "}\n";
+  return os.str();
+}
+
+std::string build_compare_shader(Dtype a_dtype, Dtype b_dtype, CompareOp op) {
+  std::ostringstream os;
+  const bool uses_bfloat16 = a_dtype == bfloat16 || b_dtype == bfloat16;
+  const bool uses_float16 = a_dtype == float16 || b_dtype == float16;
+  const bool uses_int64 =
+      a_dtype == int64 || a_dtype == uint64 || b_dtype == int64 ||
+      b_dtype == uint64;
+
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (uses_int64) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
+  }
+  if (uses_bfloat16 || uses_float16) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
+  os << "#extension GL_EXT_shader_8bit_storage : require\n";
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+
+  if (uses_bfloat16) {
+    os << emit_bf16_power_helpers();
+  }
+
+  const char* expr = "==";
+  switch (op) {
+    case CompareOp::Equal:
+      expr = "==";
+      break;
+    case CompareOp::NotEqual:
+      expr = "!=";
+      break;
+    case CompareOp::Less:
+      expr = "<";
+      break;
+    case CompareOp::LessEqual:
+      expr = "<=";
+      break;
+    case CompareOp::Greater:
+      expr = ">";
+      break;
+  }
+
+  os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer InputA {"
+     << vulkan::dtype_to_glsl_storage_type(a_dtype) << " data[];} a_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputB {"
+     << vulkan::dtype_to_glsl_storage_type(b_dtype) << " data[];} b_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (idx >= pc.total_elements) return;\n";
+  os << "  uint a_idx = idx + pc.a_offset;\n";
+  os << "  uint b_idx = idx + pc.b_offset;\n";
+  os << "  bool result = (" << equal_input_expr(a_dtype, "a_buf", "a_idx")
+     << ") " << expr << " (" << equal_input_expr(b_dtype, "b_buf", "b_idx")
+     << ");\n";
+  os << "  out_buf.data[idx + pc.out_offset] = result ? uint8_t(1) : uint8_t(0);\n";
+  os << "}\n";
+  return os.str();
+}
+
+bool try_eval_equal_vulkan(
+    const std::vector<array>& inputs,
+    array& out,
+    Stream s,
+    bool equal_nan) {
+  if (inputs.size() != 2 || out.dtype() != bool_) {
+    return false;
+  }
+
+  array a = inputs[0];
+  array b = inputs[1];
+  if (!is_supported_equal_dtype(a.dtype()) || !is_supported_equal_dtype(b.dtype())) {
+    return false;
+  }
+  if (a.dtype() != b.dtype() &&
+      !(is_vulkan_float_dtype(a.dtype()) && is_vulkan_float_dtype(b.dtype()))) {
+    return false;
+  }
+
+  auto materialize_broadcast_input = [&](array& in) {
+    if (in.shape() == out.shape()) {
+      return true;
+    }
+    if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
+      return false;
+    }
+    if (!ensure_vulkan_buffer_compare(in, s)) {
+      return false;
+    }
+    array view(out.shape(), in.dtype(), nullptr, {});
+    broadcast(in, view);
+    in = view;
+    return true;
+  };
+
+  if (!materialize_broadcast_input(a) || !materialize_broadcast_input(b)) {
+    return false;
+  }
+
+  if (!is_supported_elementwise_layout(a)) {
+    a = contiguous_copy_gpu(a, s);
+  }
+  if (!is_supported_elementwise_layout(b)) {
+    b = contiguous_copy_gpu(b, s);
+  }
+
+  a = collapse_compare_leading_dims(a, s);
+  b = collapse_compare_leading_dims(b, s);
+
+  const bool staged_output = !is_supported_elementwise_layout(out);
+  array out_work = staged_output ? array(out.shape(), bool_, nullptr, {}) : out;
+  out_work.set_data(allocator::malloc(out_work.nbytes()));
+  out_work = collapse_compare_leading_dims(out_work, s);
+
+  if (!is_supported_elementwise_layout(a) || !is_supported_elementwise_layout(b) ||
+      !is_supported_elementwise_layout(out_work)) {
+    return false;
+  }
+  if (!ensure_vulkan_buffer_compare(a, s) || !ensure_vulkan_buffer_compare(b, s) ||
+      !ensure_vulkan_buffer_compare(out_work, s)) {
+    return false;
+  }
+  if (out_work.size() == 0) {
+    if (staged_output) {
+      copy_gpu(out_work, out, CopyType::General, s);
+    }
+    return true;
+  }
+
+  const auto a_offset = static_cast<uint64_t>(a.offset() / size_of(a.dtype()));
+  const auto b_offset = static_cast<uint64_t>(b.offset() / size_of(b.dtype()));
+  const auto out_offset = static_cast<uint64_t>(out_work.offset() / size_of(out_work.dtype()));
+  const auto total = static_cast<uint64_t>(out_work.data_size());
+  if (a_offset > std::numeric_limits<uint32_t>::max() ||
+      b_offset > std::numeric_limits<uint32_t>::max() ||
+      out_offset > std::numeric_limits<uint32_t>::max() ||
+      total > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  const std::string shader_name = std::string(equal_nan ? "dynamic_nan_equal_" : "dynamic_equal_") +
+      std::to_string(static_cast<int>(a.dtype().val())) + "_" +
+      std::to_string(static_cast<int>(b.dtype().val()));
+  const std::string glsl_source =
+      build_equal_shader(a.dtype(), b.dtype(), equal_nan);
+  vulkan::DynamicArrayRef arrays[] = {{&a, 0}, {&b, 1}, {&out_work, 2}};
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 4;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      shader_name, glsl_source, 3, arrays, kPushConstantSize, s);
+
+  struct PushConstants {
+    uint32_t a_offset;
+    uint32_t b_offset;
+    uint32_t out_offset;
+    uint32_t total_elements;
+  } pc{
+      static_cast<uint32_t>(a_offset),
+      static_cast<uint32_t>(b_offset),
+      static_cast<uint32_t>(out_offset),
+      static_cast<uint32_t>(total),
+  };
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
+      0,
+      kPushConstantSize,
+      &pc);
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+  vulkan::end_command_recording(s.index);
+
+  if (staged_output) {
+    copy_gpu(out_work, out, CopyType::General, s);
+  }
+  return true;
+}
+
+bool try_eval_compare_vulkan(
+    const std::vector<array>& inputs,
+    array& out,
+    Stream s,
+    CompareOp op) {
+  if (inputs.size() != 2 || out.dtype() != bool_) {
+    return false;
+  }
+
+  array a = inputs[0];
+  array b = inputs[1];
+  const bool supports_bool =
+      op == CompareOp::Equal || op == CompareOp::NotEqual;
+  const auto supported_dtype = [&](Dtype dtype) {
+    return supports_bool ? is_supported_equal_dtype(dtype)
+                         : is_supported_ordered_compare_dtype(dtype);
+  };
+  if (!supported_dtype(a.dtype()) || !supported_dtype(b.dtype())) {
+    return false;
+  }
+  if (a.dtype() != b.dtype() &&
+      !(is_vulkan_float_dtype(a.dtype()) && is_vulkan_float_dtype(b.dtype()))) {
+    return false;
+  }
+
+  auto materialize_broadcast_input = [&](array& in) {
+    if (in.shape() == out.shape()) {
+      return true;
+    }
+    if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
+      return false;
+    }
+    if (!ensure_vulkan_buffer_compare(in, s)) {
+      return false;
+    }
+    array view(out.shape(), in.dtype(), nullptr, {});
+    broadcast(in, view);
+    in = view;
+    return true;
+  };
+
+  if (!materialize_broadcast_input(a) || !materialize_broadcast_input(b)) {
+    return false;
+  }
+
+  if (!is_supported_elementwise_layout(a)) {
+    a = contiguous_copy_gpu(a, s);
+  }
+  if (!is_supported_elementwise_layout(b)) {
+    b = contiguous_copy_gpu(b, s);
+  }
+
+  a = collapse_compare_leading_dims(a, s);
+  b = collapse_compare_leading_dims(b, s);
+
+  const bool staged_output = !is_supported_elementwise_layout(out);
+  array out_work = staged_output ? array(out.shape(), bool_, nullptr, {}) : out;
+  out_work.set_data(allocator::malloc(out_work.nbytes()));
+  out_work = collapse_compare_leading_dims(out_work, s);
+
+  if (!is_supported_elementwise_layout(a) || !is_supported_elementwise_layout(b) ||
+      !is_supported_elementwise_layout(out_work)) {
+    return false;
+  }
+  if (!ensure_vulkan_buffer_compare(a, s) || !ensure_vulkan_buffer_compare(b, s) ||
+      !ensure_vulkan_buffer_compare(out_work, s)) {
+    return false;
+  }
+  if (out_work.size() == 0) {
+    if (staged_output) {
+      copy_gpu(out_work, out, CopyType::General, s);
+    }
+    return true;
+  }
+
+  const auto a_offset = static_cast<uint64_t>(a.offset() / size_of(a.dtype()));
+  const auto b_offset = static_cast<uint64_t>(b.offset() / size_of(b.dtype()));
+  const auto out_offset = static_cast<uint64_t>(out_work.offset() / size_of(out_work.dtype()));
+  const auto total = static_cast<uint64_t>(out_work.data_size());
+  if (a_offset > std::numeric_limits<uint32_t>::max() ||
+      b_offset > std::numeric_limits<uint32_t>::max() ||
+      out_offset > std::numeric_limits<uint32_t>::max() ||
+      total > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  const std::string shader_name = std::string("dynamic_compare_") +
+      std::to_string(static_cast<int>(op)) + "_" +
+      std::to_string(static_cast<int>(a.dtype().val())) + "_" +
+      std::to_string(static_cast<int>(b.dtype().val()));
+  const std::string glsl_source = build_compare_shader(a.dtype(), b.dtype(), op);
+  vulkan::DynamicArrayRef arrays[] = {{&a, 0}, {&b, 1}, {&out_work, 2}};
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 4;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      shader_name, glsl_source, 3, arrays, kPushConstantSize, s);
+
+  struct PushConstants {
+    uint32_t a_offset;
+    uint32_t b_offset;
+    uint32_t out_offset;
+    uint32_t total_elements;
+  } pc{
+      static_cast<uint32_t>(a_offset),
+      static_cast<uint32_t>(b_offset),
+      static_cast<uint32_t>(out_offset),
+      static_cast<uint32_t>(total),
+  };
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
+      0,
+      kPushConstantSize,
+      &pc);
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+  vulkan::end_command_recording(s.index);
+
+  if (staged_output) {
+    copy_gpu(out_work, out, CopyType::General, s);
+  }
+  return true;
 }
 
 bool try_eval_power_vulkan(
@@ -282,6 +725,346 @@ bool try_eval_power_vulkan(
   return true;
 }
 
+std::string bitwise_input_expr(
+    Dtype dtype,
+    const char* buffer_name,
+    const char* index_name) {
+  if (dtype == bool_) {
+    return std::string("uint8_t(") + buffer_name + ".data[" + index_name + "])";
+  }
+  return std::string(buffer_name) + ".data[" + index_name + "]";
+}
+
+const char* bitwise_op_expr(BitwiseBinary::Op op) {
+  switch (op) {
+    case BitwiseBinary::And:
+      return "&";
+    case BitwiseBinary::Or:
+      return "|";
+    case BitwiseBinary::Xor:
+      return "^";
+    case BitwiseBinary::LeftShift:
+      return "<<";
+    case BitwiseBinary::RightShift:
+      return ">>";
+  }
+  return "&";
+}
+
+std::string build_bitwise_binary_shader(Dtype dtype, BitwiseBinary::Op op) {
+  std::ostringstream os;
+  os << vulkan::emit_dynamic_shader_preamble(
+      dtype, dtype, dtype == int64 || dtype == uint64);
+  os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer InputA {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} a_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputB {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} b_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Output {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (linear_idx >= pc.total_elements) return;\n";
+  os << "  uint idx = linear_idx;\n";
+  os << "  uint a_idx = idx + pc.a_offset;\n";
+  os << "  uint b_idx = idx + pc.b_offset;\n";
+  os << "  out_buf.data[idx + pc.out_offset] = ("
+     << bitwise_input_expr(dtype, "a_buf", "a_idx") << ") "
+     << bitwise_op_expr(op) << " ("
+     << bitwise_input_expr(dtype, "b_buf", "b_idx") << ");\n";
+  os << "}\n";
+  return os.str();
+}
+
+std::string build_logical_not_shader() {
+  std::ostringstream os;
+  os << vulkan::emit_dynamic_shader_preamble(bool_, bool_, false);
+  os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer Input {uint8_t data[];} in_buf;\n";
+  os << "layout(set = 0, binding = 1) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (idx >= pc.total_elements) return;\n";
+  os << "  out_buf.data[idx + pc.out_offset] = in_buf.data[idx + pc.in_offset] == uint8_t(0) ? uint8_t(1) : uint8_t(0);\n";
+  os << "}\n";
+  return os.str();
+}
+
+std::string build_logical_binary_shader(const char* expr) {
+  std::ostringstream os;
+  os << vulkan::emit_dynamic_shader_preamble(bool_, bool_, false);
+  os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer InputA {uint8_t data[];} a_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputB {uint8_t data[];} b_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (idx >= pc.total_elements) return;\n";
+  os << "  bool lhs = a_buf.data[idx + pc.a_offset] != uint8_t(0);\n";
+  os << "  bool rhs = b_buf.data[idx + pc.b_offset] != uint8_t(0);\n";
+  os << "  out_buf.data[idx + pc.out_offset] = (" << expr
+     << ") ? uint8_t(1) : uint8_t(0);\n";
+  os << "}\n";
+  return os.str();
+}
+
+bool try_eval_logical_not_vulkan(
+    const std::vector<array>& inputs,
+    array& out,
+    Stream s) {
+  if (inputs.size() != 1 || inputs[0].dtype() != bool_ || out.dtype() != bool_) {
+    return false;
+  }
+
+  array in = inputs[0];
+  if (!is_supported_elementwise_layout(in)) {
+    in = contiguous_copy_gpu(in, s);
+  }
+  in = collapse_compare_leading_dims(in, s);
+
+  const bool staged_output = !is_supported_elementwise_layout(out);
+  array out_work = staged_output ? array(out.shape(), bool_, nullptr, {}) : out;
+  out_work.set_data(allocator::malloc(out_work.nbytes()));
+  out_work = collapse_compare_leading_dims(out_work, s);
+
+  if (!is_supported_elementwise_layout(in) || !is_supported_elementwise_layout(out_work)) {
+    return false;
+  }
+  if (!ensure_vulkan_buffer_compare(in, s) || !ensure_vulkan_buffer_compare(out_work, s)) {
+    return false;
+  }
+  if (out_work.size() == 0) {
+    if (staged_output) {
+      copy_gpu(out_work, out, CopyType::General, s);
+    }
+    return true;
+  }
+
+  const auto in_offset = static_cast<uint64_t>(in.offset() / size_of(in.dtype()));
+  const auto out_offset = static_cast<uint64_t>(out_work.offset() / size_of(out_work.dtype()));
+  const auto total = static_cast<uint64_t>(out_work.data_size());
+  if (in_offset > std::numeric_limits<uint32_t>::max() ||
+      out_offset > std::numeric_limits<uint32_t>::max() ||
+      total > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  vulkan::DynamicArrayRef arrays[] = {{&in, 0}, {&out_work, 1}};
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 3;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      "dynamic_logical_not", build_logical_not_shader(), 2, arrays, kPushConstantSize, s);
+
+  struct PushConstants {
+    uint32_t in_offset;
+    uint32_t out_offset;
+    uint32_t total_elements;
+  } pc{
+      static_cast<uint32_t>(in_offset),
+      static_cast<uint32_t>(out_offset),
+      static_cast<uint32_t>(total),
+  };
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
+      0,
+      kPushConstantSize,
+      &pc);
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+  vulkan::end_command_recording(s.index);
+
+  if (staged_output) {
+    copy_gpu(out_work, out, CopyType::General, s);
+  }
+  return true;
+}
+
+bool try_eval_logical_binary_vulkan(
+    const std::vector<array>& inputs,
+    array& out,
+    Stream s,
+    const char* shader_name,
+    const char* expr) {
+  if (inputs.size() != 2 || inputs[0].dtype() != bool_ || inputs[1].dtype() != bool_ ||
+      out.dtype() != bool_) {
+    return false;
+  }
+
+  array a = inputs[0];
+  array b = inputs[1];
+  if (!is_supported_elementwise_layout(a)) {
+    a = contiguous_copy_gpu(a, s);
+  }
+  if (!is_supported_elementwise_layout(b)) {
+    b = contiguous_copy_gpu(b, s);
+  }
+  a = collapse_compare_leading_dims(a, s);
+  b = collapse_compare_leading_dims(b, s);
+
+  const bool staged_output = !is_supported_elementwise_layout(out);
+  array out_work = staged_output ? array(out.shape(), bool_, nullptr, {}) : out;
+  out_work.set_data(allocator::malloc(out_work.nbytes()));
+  out_work = collapse_compare_leading_dims(out_work, s);
+
+  if (!is_supported_elementwise_layout(a) || !is_supported_elementwise_layout(b) ||
+      !is_supported_elementwise_layout(out_work)) {
+    return false;
+  }
+  if (!ensure_vulkan_buffer_compare(a, s) || !ensure_vulkan_buffer_compare(b, s) ||
+      !ensure_vulkan_buffer_compare(out_work, s)) {
+    return false;
+  }
+  if (out_work.size() == 0) {
+    if (staged_output) {
+      copy_gpu(out_work, out, CopyType::General, s);
+    }
+    return true;
+  }
+
+  const auto a_offset = static_cast<uint64_t>(a.offset() / size_of(a.dtype()));
+  const auto b_offset = static_cast<uint64_t>(b.offset() / size_of(b.dtype()));
+  const auto out_offset = static_cast<uint64_t>(out_work.offset() / size_of(out_work.dtype()));
+  const auto total = static_cast<uint64_t>(out_work.data_size());
+  if (a_offset > std::numeric_limits<uint32_t>::max() ||
+      b_offset > std::numeric_limits<uint32_t>::max() ||
+      out_offset > std::numeric_limits<uint32_t>::max() ||
+      total > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  vulkan::DynamicArrayRef arrays[] = {{&a, 0}, {&b, 1}, {&out_work, 2}};
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 4;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      shader_name, build_logical_binary_shader(expr), 3, arrays, kPushConstantSize, s);
+
+  struct PushConstants {
+    uint32_t a_offset;
+    uint32_t b_offset;
+    uint32_t out_offset;
+    uint32_t total_elements;
+  } pc{
+      static_cast<uint32_t>(a_offset),
+      static_cast<uint32_t>(b_offset),
+      static_cast<uint32_t>(out_offset),
+      static_cast<uint32_t>(total),
+  };
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
+      0,
+      kPushConstantSize,
+      &pc);
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+  vulkan::end_command_recording(s.index);
+
+  if (staged_output) {
+    copy_gpu(out_work, out, CopyType::General, s);
+  }
+  return true;
+}
+
+bool try_eval_bitwise_binary_vulkan(
+    const std::vector<array>& inputs,
+    array& out,
+    Stream s,
+    BitwiseBinary::Op op) {
+  if (inputs.size() != 2) {
+    return false;
+  }
+
+  array a = inputs[0];
+  array b = inputs[1];
+  if (a.dtype() != b.dtype() || a.dtype() != out.dtype()) {
+    return false;
+  }
+  if (!(issubdtype(out.dtype(), integer) || out.dtype() == bool_)) {
+    return false;
+  }
+
+  if (!is_supported_elementwise_layout(a)) {
+    a = contiguous_copy_gpu(a, s);
+  }
+  if (!is_supported_elementwise_layout(b)) {
+    b = contiguous_copy_gpu(b, s);
+  }
+
+  a = collapse_compare_leading_dims(a, s);
+  b = collapse_compare_leading_dims(b, s);
+
+  const bool staged_output = !is_supported_elementwise_layout(out);
+  array out_work = staged_output ? array(out.shape(), out.dtype(), nullptr, {}) : out;
+  out_work.set_data(allocator::malloc(out_work.nbytes()));
+  out_work = collapse_compare_leading_dims(out_work, s);
+
+  if (!is_supported_elementwise_layout(a) || !is_supported_elementwise_layout(b) ||
+      !is_supported_elementwise_layout(out_work)) {
+    return false;
+  }
+  if (!ensure_vulkan_buffer_compare(a, s) || !ensure_vulkan_buffer_compare(b, s) ||
+      !ensure_vulkan_buffer_compare(out_work, s)) {
+    return false;
+  }
+  if (out_work.size() == 0) {
+    if (staged_output) {
+      copy_gpu(out_work, out, CopyType::General, s);
+    }
+    return true;
+  }
+
+  const auto a_offset = static_cast<uint64_t>(a.offset() / size_of(a.dtype()));
+  const auto b_offset = static_cast<uint64_t>(b.offset() / size_of(b.dtype()));
+  const auto out_offset = static_cast<uint64_t>(out_work.offset() / size_of(out_work.dtype()));
+  const auto total = static_cast<uint64_t>(out_work.data_size());
+  if (a_offset > std::numeric_limits<uint32_t>::max() ||
+      b_offset > std::numeric_limits<uint32_t>::max() ||
+      out_offset > std::numeric_limits<uint32_t>::max() ||
+      total > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+
+  const std::string shader_name = std::string("dynamic_bitwise_") +
+      std::to_string(static_cast<int>(op)) + "_" +
+      std::to_string(static_cast<int>(out.dtype().val()));
+  const std::string glsl_source = build_bitwise_binary_shader(out.dtype(), op);
+  vulkan::DynamicArrayRef arrays[] = {{&a, 0}, {&b, 1}, {&out_work, 2}};
+  constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 4;
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      shader_name, glsl_source, 3, arrays, kPushConstantSize, s);
+
+  struct PushConstants {
+    uint32_t a_offset;
+    uint32_t b_offset;
+    uint32_t out_offset;
+    uint32_t total_elements;
+  } pc{
+      static_cast<uint32_t>(a_offset),
+      static_cast<uint32_t>(b_offset),
+      static_cast<uint32_t>(out_offset),
+      static_cast<uint32_t>(total),
+  };
+  vkCmdPushConstants(
+      dispatch.command_buffer,
+      dispatch.pipeline->layout,
+      VK_SHADER_STAGE_COMPUTE_BIT,
+      0,
+      kPushConstantSize,
+      &pc);
+  const uint32_t workgroups =
+      std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+  vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+  vulkan::end_command_recording(s.index);
+
+  if (staged_output) {
+    copy_gpu(out_work, out, CopyType::General, s);
+  }
+  return true;
+}
+
 bool is_supported_select_layout(const array& arr) {
   return arr.flags().contiguous && arr.offset() == 0 && arr.ndim() > 0 &&
       arr.strides().back() == 1;
@@ -309,31 +1092,115 @@ std::optional<vulkan::StaticShaderId> select_shader_id(Dtype dtype) {
   }
 }
 
+std::string build_select_dynamic_shader(Dtype dtype) {
+  std::ostringstream os;
+  os << vulkan::emit_dynamic_shader_preamble(
+      bool_, dtype, dtype == int64 || dtype == uint64);
+  os << "layout(push_constant) uniform PushConstants { uint cond_offset; uint x_offset; uint y_offset; uint out_offset; uint total_elements; uint out_ne0; uint out_ne1; uint out_ne2; uint out_ne3; uint cond_s0; uint cond_s1; uint cond_s2; uint cond_s3; } pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer Condition {uint8_t data[];} cond_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputX {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} x_buf;\n";
+  os << "layout(set = 0, binding = 2) readonly buffer InputY {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} y_buf;\n";
+  os << "layout(set = 0, binding = 3) buffer Output {"
+     << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (idx >= pc.total_elements) return;\n";
+  os << "  uint rem = idx;\n";
+  os << "  uint i3 = rem % pc.out_ne3; rem /= pc.out_ne3;\n";
+  os << "  uint i2 = rem % pc.out_ne2; rem /= pc.out_ne2;\n";
+  os << "  uint i1 = rem % pc.out_ne1; rem /= pc.out_ne1;\n";
+  os << "  uint i0 = rem;\n";
+  os << "  uint cond_idx = pc.cond_offset + i0 * pc.cond_s0 + i1 * pc.cond_s1 + i2 * pc.cond_s2 + i3 * pc.cond_s3;\n";
+  os << "  bool cond = cond_buf.data[cond_idx] != uint8_t(0);\n";
+  os << "  out_buf.data[idx + pc.out_offset] = cond ? x_buf.data[idx + pc.x_offset] : y_buf.data[idx + pc.y_offset];\n";
+  os << "}\n";
+  return os.str();
+}
+
 bool try_eval_select_vulkan(
     const std::vector<array>& inputs,
     array& out,
     Stream s) {
   if (inputs.size() != 3) {
+    if (trace_fallback_enabled()) {
+      std::ostringstream oss;
+      oss << "select_vulkan_unsupported reason=wrong_input_count"
+          << " out_shape=" << out.shape() << " out_dtype=" << out.dtype();
+      trace_fallback(oss.str());
+    }
     return false;
   }
 
   array condition = inputs[0];
   array x = inputs[1];
   array y = inputs[2];
+  auto trace_select_unsupported = [&](std::string_view reason) {
+    if (!trace_fallback_enabled()) {
+      return;
+    }
+    std::ostringstream oss;
+    oss << "select_vulkan_unsupported reason=" << reason
+        << " out_shape=" << out.shape() << " out_dtype=" << out.dtype()
+        << " cond_shape=" << condition.shape() << " cond_dtype="
+        << condition.dtype() << " x_shape=" << x.shape() << " x_dtype="
+        << x.dtype() << " y_shape=" << y.shape() << " y_dtype="
+        << y.dtype();
+    if (reason == "unsupported_elementwise_layout") {
+      oss << " cond_ok=" << is_supported_elementwise_layout(condition)
+          << " x_ok=" << is_supported_elementwise_layout(x)
+          << " y_ok=" << is_supported_elementwise_layout(y)
+          << " out_ok=" << is_supported_elementwise_layout(out)
+          << " cond_row=" << condition.flags().row_contiguous
+          << " x_row=" << x.flags().row_contiguous
+          << " y_row=" << y.flags().row_contiguous
+          << " out_row=" << out.flags().row_contiguous
+          << " cond_offset=" << condition.offset()
+          << " x_offset=" << x.offset()
+          << " y_offset=" << y.offset()
+          << " out_offset=" << out.offset();
+    }
+    trace_fallback(oss.str());
+  };
   if (condition.dtype() != bool_ || x.dtype() != out.dtype() ||
-      y.dtype() != out.dtype() || condition.shape() != out.shape() ||
-      x.shape() != out.shape() || y.shape() != out.shape()) {
+      y.dtype() != out.dtype()) {
+    trace_select_unsupported("dtype_mismatch");
     return false;
   }
 
-  auto shader_id = select_shader_id(out.dtype());
-  if (!shader_id.has_value()) {
+  auto materialize_broadcast_input = [&](array& in, Dtype expected_dtype) {
+    if (in.dtype() != expected_dtype) {
+      return false;
+    }
+    if (in.shape() == out.shape()) {
+      return true;
+    }
+    if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
+      return false;
+    }
+    if (!ensure_vulkan_buffer_compare(in, s)) {
+      return false;
+    }
+    array view(out.shape(), expected_dtype, nullptr, {});
+    broadcast(in, view);
+    in = view;
+    return true;
+  };
+
+  if (!materialize_broadcast_input(condition, bool_) ||
+      !materialize_broadcast_input(x, out.dtype()) ||
+      !materialize_broadcast_input(y, out.dtype())) {
+    trace_select_unsupported("broadcast_materialization_failed");
     return false;
   }
 
   auto materialize = [&](array arr) {
     if (!is_supported_select_layout(arr)) {
-      arr = contiguous_copy_gpu(arr, s);
+      array staged(arr.shape(), arr.dtype(), nullptr, {});
+      staged.set_data(allocator::malloc(staged.nbytes()));
+      copy_gpu(arr, staged, CopyType::General, s);
+      arr = staged;
     }
     return arr;
   };
@@ -352,10 +1219,25 @@ bool try_eval_select_vulkan(
   array y_kernel = collapse_select_leading_dims(y, s);
   array out_kernel = collapse_select_leading_dims(out_storage, s);
 
-  if (!is_supported_elementwise_layout(cond_kernel) ||
-      !is_supported_elementwise_layout(x_kernel) ||
+  const bool can_use_static_select =
+      is_supported_elementwise_layout(cond_kernel) &&
+      is_supported_elementwise_layout(x_kernel) &&
+      is_supported_elementwise_layout(y_kernel) &&
+      is_supported_elementwise_layout(out_kernel);
+  const bool can_use_dynamic_select =
+      is_supported_elementwise_layout(x_kernel) &&
+      is_supported_elementwise_layout(y_kernel) &&
+      is_supported_elementwise_layout(out_kernel) && cond_kernel.ndim() <= 4;
+
+  if (!can_use_static_select && !can_use_dynamic_select) {
+    trace_select_unsupported("unsupported_elementwise_layout");
+    return false;
+  }
+
+  if (!is_supported_elementwise_layout(x_kernel) ||
       !is_supported_elementwise_layout(y_kernel) ||
       !is_supported_elementwise_layout(out_kernel)) {
+    trace_select_unsupported("unsupported_elementwise_layout");
     return false;
   }
 
@@ -367,16 +1249,98 @@ bool try_eval_select_vulkan(
   }
 
   try {
-    auto command_buffer = vulkan::begin_command_recording(s.index);
-    vulkan::dispatch_ternary_op(
-        cond_kernel,
-        x_kernel,
-        y_kernel,
-        out_kernel,
-        *shader_id,
-        command_buffer,
-        s);
-    vulkan::end_command_recording(s.index);
+    auto shader_id = select_shader_id(out.dtype());
+    if (shader_id.has_value() && can_use_static_select) {
+      auto command_buffer = vulkan::begin_command_recording(s.index);
+      vulkan::dispatch_ternary_op(
+          cond_kernel,
+          x_kernel,
+          y_kernel,
+          out_kernel,
+          *shader_id,
+          command_buffer,
+          s);
+      vulkan::end_command_recording(s.index);
+    } else {
+      const auto cond_offset =
+          static_cast<uint64_t>(cond_kernel.offset() / size_of(cond_kernel.dtype()));
+      const auto x_offset =
+          static_cast<uint64_t>(x_kernel.offset() / size_of(x_kernel.dtype()));
+      const auto y_offset =
+          static_cast<uint64_t>(y_kernel.offset() / size_of(y_kernel.dtype()));
+      const auto out_offset =
+          static_cast<uint64_t>(out_kernel.offset() / size_of(out_kernel.dtype()));
+      const auto total = static_cast<uint64_t>(out_kernel.data_size());
+      if (cond_offset > std::numeric_limits<uint32_t>::max() ||
+          x_offset > std::numeric_limits<uint32_t>::max() ||
+          y_offset > std::numeric_limits<uint32_t>::max() ||
+          out_offset > std::numeric_limits<uint32_t>::max() ||
+          total > std::numeric_limits<uint32_t>::max()) {
+        return false;
+      }
+
+      vulkan::DynamicArrayRef arrays[] = {
+          {&cond_kernel, 0}, {&x_kernel, 1}, {&y_kernel, 2}, {&out_kernel, 3}};
+      constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 13;
+      auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+          std::string("dynamic_select_") +
+              std::to_string(static_cast<int>(out.dtype().val())),
+          build_select_dynamic_shader(out.dtype()),
+          4,
+          arrays,
+          kPushConstantSize,
+          s);
+
+      auto shape_dim_or_one = [](const array& arr, int axis) {
+        const int padded_axis = axis - (4 - arr.ndim());
+        return padded_axis < 0 ? int64_t{1} : arr.shape(padded_axis);
+      };
+      auto stride_dim_or_zero = [](const array& arr, int axis) {
+        const int padded_axis = axis - (4 - arr.ndim());
+        return padded_axis < 0 ? int64_t{0} : arr.strides(padded_axis);
+      };
+
+      struct PushConstants {
+        uint32_t cond_offset;
+        uint32_t x_offset;
+        uint32_t y_offset;
+        uint32_t out_offset;
+        uint32_t total_elements;
+        uint32_t out_ne0;
+        uint32_t out_ne1;
+        uint32_t out_ne2;
+        uint32_t out_ne3;
+        uint32_t cond_s0;
+        uint32_t cond_s1;
+        uint32_t cond_s2;
+        uint32_t cond_s3;
+      } pc{
+          static_cast<uint32_t>(cond_offset),
+          static_cast<uint32_t>(x_offset),
+          static_cast<uint32_t>(y_offset),
+          static_cast<uint32_t>(out_offset),
+          static_cast<uint32_t>(total),
+          checked_u32_size(shape_dim_or_one(out_kernel, 0), "select_out_ne0"),
+          checked_u32_size(shape_dim_or_one(out_kernel, 1), "select_out_ne1"),
+          checked_u32_size(shape_dim_or_one(out_kernel, 2), "select_out_ne2"),
+          checked_u32_size(shape_dim_or_one(out_kernel, 3), "select_out_ne3"),
+          checked_u32_size(stride_dim_or_zero(cond_kernel, 0), "select_cond_s0"),
+          checked_u32_size(stride_dim_or_zero(cond_kernel, 1), "select_cond_s1"),
+          checked_u32_size(stride_dim_or_zero(cond_kernel, 2), "select_cond_s2"),
+          checked_u32_size(stride_dim_or_zero(cond_kernel, 3), "select_cond_s3"),
+      };
+      vkCmdPushConstants(
+          dispatch.command_buffer,
+          dispatch.pipeline->layout,
+          VK_SHADER_STAGE_COMPUTE_BIT,
+          0,
+          kPushConstantSize,
+          &pc);
+      const uint32_t workgroups =
+          std::max<uint32_t>((static_cast<uint32_t>(total) + 255u) / 256u, 1u);
+      vkCmdDispatch(dispatch.command_buffer, workgroups, 1, 1);
+      vulkan::end_command_recording(s.index);
+    }
     if (staged_output) {
       copy_gpu(out_storage, out, CopyType::GeneralGeneral, s);
     }
@@ -393,8 +1357,65 @@ bool try_eval_select_vulkan(
 
 } // namespace
 
-// Primitives with state that have CPU fallbacks
-NYI_OP_STATE(Equal)
+void Equal::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_equal_vulkan(inputs, out, stream(), equal_nan_)) {
+    throw std::runtime_error(
+        std::string(name()) +
+        " has no Vulkan implementation for this input.");
+  }
+}
+
+void BitwiseBinary::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_bitwise_binary_vulkan(inputs, out, stream(), op_)) {
+    throw std::runtime_error(
+        std::string(name()) +
+        " has no Vulkan implementation for this input.");
+  }
+}
+
+void Greater::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_compare_vulkan(inputs, out, stream(), CompareOp::Greater)) {
+    throw std::runtime_error("Greater has no Vulkan implementation for this input.");
+  }
+}
+
+void Less::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_compare_vulkan(inputs, out, stream(), CompareOp::Less)) {
+    throw std::runtime_error("Less has no Vulkan implementation for this input.");
+  }
+}
+
+void LessEqual::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_compare_vulkan(inputs, out, stream(), CompareOp::LessEqual)) {
+    throw std::runtime_error(
+        "LessEqual has no Vulkan implementation for this input.");
+  }
+}
+
+void NotEqual::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_compare_vulkan(inputs, out, stream(), CompareOp::NotEqual)) {
+    throw std::runtime_error(
+        "NotEqual has no Vulkan implementation for this input.");
+  }
+}
+
+void LogicalNot::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_logical_not_vulkan(inputs, out, stream())) {
+    throw std::runtime_error("LogicalNot has no Vulkan implementation for this input.");
+  }
+}
+
+void LogicalAnd::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_logical_binary_vulkan(inputs, out, stream(), "dynamic_logical_and", "lhs && rhs")) {
+    throw std::runtime_error("LogicalAnd has no Vulkan implementation for this input.");
+  }
+}
+
+void LogicalOr::eval_gpu(const std::vector<array>& inputs, array& out) {
+  if (!try_eval_logical_binary_vulkan(inputs, out, stream(), "dynamic_logical_or", "lhs || rhs")) {
+    throw std::runtime_error("LogicalOr has no Vulkan implementation for this input.");
+  }
+}
 
 // Primitives implemented in other files:
 // - binary.cpp: Add, Minimum, Maximum, Divide, Subtract, Multiply
@@ -423,7 +1444,6 @@ NYI_OP(ArcTan2)
 NYI_OP(ArcTanh)
 NYI_OP_STATE(ArgPartition)
 NYI_OP_STATE(ArgSort)
-NYI_OP_STATE(BitwiseBinary)
 NYI_OP(BitwiseInvert)
 NYI_OP(Conjugate)
 NYI_OP(Cosh)
@@ -433,15 +1453,9 @@ NYI_OP(Expm1)
 NYI_OP_STATE(FFT)
 NYI_OP_STATE(GatherMM)
 NYI_OP_STATE(GatherQMM)
-NYI_OP(Greater)
 NYI_OP_STATE(Hadamard)
 NYI_OP(Imag)
-NYI_OP(Less)
-NYI_OP(LessEqual)
 NYI_OP(Log1p)
-NYI_OP(LogicalNot)
-NYI_OP(LogicalAnd)
-NYI_OP(LogicalOr)
 NYI_OP(LogAddExp)
 // Linear algebra operations - throw NYI like Metal backend
 NO_GPU_MULTI(LUF)
@@ -452,7 +1466,6 @@ NO_GPU_MULTI_STATE(Eigh)
 NO_GPU_MULTI_STATE(Eig)
 NO_GPU_MULTI_STATE(SVD)
 
-NYI_OP(NotEqual)
 NYI_OP_STATE(Partition)
 void Power::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_power_vulkan(inputs, out, stream())) {

--- a/mlx/backend/vulkan/primitives_utils.h
+++ b/mlx/backend/vulkan/primitives_utils.h
@@ -28,19 +28,6 @@
 
 namespace mlx::core {
 
-inline std::vector<array> materialize_cpu_fallback_inputs(
-    const std::vector<array>& inputs) {
-  auto cpu_stream = default_stream(Device::cpu);
-  std::vector<array> cpu_inputs;
-  cpu_inputs.reserve(inputs.size());
-  for (const auto& in : inputs) {
-    cpu_inputs.push_back(astype(in, in.dtype(), cpu_stream));
-  }
-  eval(cpu_inputs);
-  synchronize(cpu_stream);
-  return cpu_inputs;
-}
-
 // Trace fallback utilities
 bool trace_fallback_enabled();
 void trace_fallback(const std::string& msg);
@@ -147,68 +134,6 @@ bool has_squeezed_axes_shape(
     const array& out,
     const std::vector<int>& axes);
 
-// CPU fallback templates
-template <typename Primitive, typename... Args>
-void eval_cpu_fallback(
-    const std::vector<array>& inputs,
-    array& out,
-    Args&&... args) {
-  if (trace_fallback_enabled()) {
-    std::ostringstream oss;
-    oss << "primitive=" << typeid(Primitive).name() << " kind=unary"
-        << " inputs=" << inputs.size() << " out_shape=" << out.shape();
-    trace_fallback(oss.str());
-  }
-  auto cpu_stream = default_stream(Device::cpu);
-  auto cpu_inputs = materialize_cpu_fallback_inputs(inputs);
-  Primitive cpu_primitive(cpu_stream, std::forward<Args>(args)...);
-  cpu_primitive.eval_cpu(cpu_inputs, out);
-  synchronize(cpu_stream);
-}
-
-template <typename Primitive, typename... Args>
-void eval_cpu_fallback_on_stream(
-    const std::vector<array>& inputs,
-    array& out,
-    Stream stream,
-    Args&&... args) {
-  vulkan::ScopedSyncLabel sync_label(
-      std::string("cpu_fallback:") + typeid(Primitive).name());
-  ::mlx::core::gpu::synchronize(stream);
-  eval_cpu_fallback<Primitive>(inputs, out, std::forward<Args>(args)...);
-}
-
-template <typename Primitive, typename... Args>
-void eval_cpu_fallback_multi(
-    const std::vector<array>& inputs,
-    std::vector<array>& outputs,
-    Args&&... args) {
-  if (trace_fallback_enabled()) {
-    std::ostringstream oss;
-    oss << "primitive=" << typeid(Primitive).name() << " kind=multi"
-        << " inputs=" << inputs.size() << " outputs=" << outputs.size();
-    trace_fallback(oss.str());
-  }
-  auto cpu_stream = default_stream(Device::cpu);
-  auto cpu_inputs = materialize_cpu_fallback_inputs(inputs);
-  Primitive cpu_primitive(cpu_stream, std::forward<Args>(args)...);
-  cpu_primitive.eval_cpu(cpu_inputs, outputs);
-  synchronize(cpu_stream);
-}
-
-template <typename Primitive, typename... Args>
-void eval_cpu_fallback_multi_on_stream(
-    const std::vector<array>& inputs,
-    std::vector<array>& outputs,
-    Stream stream,
-    Args&&... args) {
-  vulkan::ScopedSyncLabel sync_label(
-      std::string("cpu_fallback_multi:") + typeid(Primitive).name());
-  ::mlx::core::gpu::synchronize(stream);
-  eval_cpu_fallback_multi<Primitive>(
-      inputs, outputs, std::forward<Args>(args)...);
-}
-
 template <typename T, typename = void>
 struct is_tuple_like : std::false_type {};
 
@@ -217,86 +142,5 @@ struct is_tuple_like<
     T,
     std::void_t<decltype(std::tuple_size<std::decay_t<T>>::value)>>
     : std::true_type {};
-
-template <typename Primitive, typename State>
-void eval_cpu_fallback_with_state(
-    const std::vector<array>& inputs,
-    array& out,
-    State&& state) {
-  if constexpr (is_tuple_like<State>::value) {
-    std::apply(
-        [&](auto&&... state_args) {
-          eval_cpu_fallback<Primitive>(
-              inputs, out, std::forward<decltype(state_args)>(state_args)...);
-        },
-        std::forward<State>(state));
-  } else {
-    eval_cpu_fallback<Primitive>(inputs, out, std::forward<State>(state));
-  }
-}
-
-template <typename Primitive, typename State>
-void eval_cpu_fallback_with_state_on_stream(
-    const std::vector<array>& inputs,
-    array& out,
-    Stream stream,
-    State&& state) {
-  if constexpr (is_tuple_like<State>::value) {
-    std::apply(
-        [&](auto&&... state_args) {
-          eval_cpu_fallback_on_stream<Primitive>(
-              inputs,
-              out,
-              stream,
-              std::forward<decltype(state_args)>(state_args)...);
-        },
-        std::forward<State>(state));
-  } else {
-    eval_cpu_fallback_on_stream<Primitive>(
-        inputs, out, stream, std::forward<State>(state));
-  }
-}
-
-template <typename Primitive, typename State>
-void eval_cpu_fallback_multi_with_state(
-    const std::vector<array>& inputs,
-    std::vector<array>& outputs,
-    State&& state) {
-  if constexpr (is_tuple_like<State>::value) {
-    std::apply(
-        [&](auto&&... state_args) {
-          eval_cpu_fallback_multi<Primitive>(
-              inputs,
-              outputs,
-              std::forward<decltype(state_args)>(state_args)...);
-        },
-        std::forward<State>(state));
-  } else {
-    eval_cpu_fallback_multi<Primitive>(
-        inputs, outputs, std::forward<State>(state));
-  }
-}
-
-template <typename Primitive, typename State>
-void eval_cpu_fallback_multi_with_state_on_stream(
-    const std::vector<array>& inputs,
-    std::vector<array>& outputs,
-    Stream stream,
-    State&& state) {
-  if constexpr (is_tuple_like<State>::value) {
-    std::apply(
-        [&](auto&&... state_args) {
-          eval_cpu_fallback_multi_on_stream<Primitive>(
-              inputs,
-              outputs,
-              stream,
-              std::forward<decltype(state_args)>(state_args)...);
-        },
-        std::forward<State>(state));
-  } else {
-    eval_cpu_fallback_multi_on_stream<Primitive>(
-        inputs, outputs, stream, std::forward<State>(state));
-  }
-}
 
 } // namespace mlx::core

--- a/mlx/backend/vulkan/reduce.cpp
+++ b/mlx/backend/vulkan/reduce.cpp
@@ -311,8 +311,8 @@ bool try_eval_arg_reduce_vulkan(
 void ArgReduce::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto [reduce_type, axis] = state();
   if (!try_eval_arg_reduce_vulkan(inputs, out, reduce_type, axis, stream())) {
-    eval_cpu_fallback_with_state_on_stream<ArgReduce>(
-        inputs, out, stream(), state());
+    throw std::runtime_error(
+        "ArgReduce has no Vulkan implementation for this input.");
   }
 }
 
@@ -320,8 +320,8 @@ void Reduce::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto [reduce_type, axes] = state();
   if (!try_eval_reduce_sum_rows_vulkan(
           inputs, out, reduce_type, axes, stream())) {
-    eval_cpu_fallback_with_state_on_stream<Reduce>(
-        inputs, out, stream(), state());
+    throw std::runtime_error(
+        "Reduce has no Vulkan implementation for this input.");
   }
 }
 

--- a/mlx/backend/vulkan/reduce.cpp
+++ b/mlx/backend/vulkan/reduce.cpp
@@ -90,27 +90,10 @@ bool try_eval_reduce_sum_rows_vulkan(
   }
 
   if (logic_reduce && in.size() == 0) {
-    out.set_data(allocator::malloc(out.nbytes()));
-    const uint8_t fill_value =
-        reduce_type == Reduce::And ? uint8_t(1) : uint8_t(0);
-    if (out.nbytes() == 0) {
-      return true;
-    }
-    auto* out_buf = static_cast<vulkan::VulkanBuffer*>(out.buffer().ptr());
-    if (vulkan::VulkanContext::get().is_unified_memory() &&
-        out_buf->mapped_ptr != nullptr) {
-      std::memset(out_buf->mapped_ptr, fill_value, out.nbytes());
-      return true;
-    }
-    std::vector<uint8_t> host_values(out.size(), fill_value);
-    vulkan::enqueue_owned_staging_upload(
-        s,
-        host_values.data(),
-        host_values.size(),
-        out_buf->buffer,
-        0,
-        out.data_shared_ptr());
-    vulkan::retain_array_for_stream(s, out);
+    array fill_value(
+        reduce_type == Reduce::And ? true : false,
+        bool_);
+    fill_gpu(fill_value, out, s);
     return true;
   }
 

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -226,6 +226,34 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             rtol=0.0,
         )
 
+    def test_arange_bf16_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.arange(-3, 13, dtype=mx.bfloat16).astype(mx.float32),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_gather_take_bf16_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.take(
+                mx.arange(1, 1 + 8 * 4, dtype=mx.float32).reshape(8, 4).astype(mx.bfloat16),
+                mx.array([5, 1, 7, 0], dtype=mx.int32),
+                axis=0,
+            ).astype(mx.float32),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_empty_bool_reduce_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: (
+                mx.all(mx.array([], dtype=mx.bool_)),
+                mx.any(mx.array([], dtype=mx.bool_)),
+            ),
+            atol=0.0,
+            rtol=0.0,
+        )
+
     def test_scaled_dot_product_attention_causal_gqa(self):
         self._assert_cpu_gpu_same(
             lambda: mx.fast.scaled_dot_product_attention(

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -189,6 +189,43 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             markers=("ArcCos has no Vulkan implementation",),
         )
 
+    def test_equal_int32_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.equal(
+                mx.array([[1, 2], [3, 4]], dtype=mx.int32),
+                mx.array([[1, 0], [3, 5]], dtype=mx.int32),
+            ),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_bitwise_and_int32_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.bitwise_and(
+                mx.array([[7, 3], [12, 5]], dtype=mx.int32),
+                mx.array([[3, 6], [10, 1]], dtype=mx.int32),
+            ),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_logical_ops_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: (
+                mx.logical_not(mx.array([[True, False], [False, True]])),
+                mx.logical_and(
+                    mx.array([[True, False], [True, False]]),
+                    mx.array([[True, True], [False, False]]),
+                ),
+                mx.logical_or(
+                    mx.array([[True, False], [True, False]]),
+                    mx.array([[False, True], [False, False]]),
+                ),
+            ),
+            atol=0.0,
+            rtol=0.0,
+        )
+
     def test_scaled_dot_product_attention_causal_gqa(self):
         self._assert_cpu_gpu_same(
             lambda: mx.fast.scaled_dot_product_attention(

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -80,6 +80,19 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             raise
         self._assert_outputs_close(gpu_out, cpu_out, atol=atol, rtol=rtol)
 
+    def _assert_gpu_unsupported(self, fn, markers=None):
+        if markers is None:
+            markers = ("has no Vulkan implementation", "failed on Vulkan")
+
+        with self.assertRaises(RuntimeError) as exc:
+            self._run_on_device(mx.gpu, fn)
+
+        msg = str(exc.exception)
+        self.assertTrue(
+            any(marker in msg for marker in markers),
+            msg=f"unexpected GPU error: {msg}",
+        )
+
     def test_fast_rms_norm_low_precision_regression(self):
         for dtype, atol, rtol in (
             (mx.float16, 5e-2, 5e-2),
@@ -166,6 +179,14 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             ),
             atol=1e-5,
             rtol=1e-5,
+        )
+
+    def test_arccos_does_not_fallback_to_cpu(self):
+        self._assert_gpu_unsupported(
+            lambda: mx.arccos(
+                mx.array([[-0.75, -0.25], [0.25, 0.75]], dtype=mx.float32)
+            ),
+            markers=("ArcCos has no Vulkan implementation",),
         )
 
     def test_scaled_dot_product_attention_causal_gqa(self):

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -233,6 +233,11 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             rtol=0.0,
         )
 
+    def test_arange_int32_large_start_unsupported_vulkan(self):
+        self._assert_gpu_unsupported(
+            lambda: mx.arange(16_777_217, 16_777_221, dtype=mx.int32)
+        )
+
     def test_gather_take_bf16_vulkan(self):
         self._assert_cpu_gpu_same(
             lambda: mx.take(

--- a/python/tests/test_vulkan_ops.py
+++ b/python/tests/test_vulkan_ops.py
@@ -233,9 +233,18 @@ class TestVulkanOpsParity(mlx_tests.MLXTestCase):
             rtol=0.0,
         )
 
-    def test_arange_int32_large_start_unsupported_vulkan(self):
-        self._assert_gpu_unsupported(
-            lambda: mx.arange(16_777_217, 16_777_221, dtype=mx.int32)
+    def test_arange_int32_large_start_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.arange(16_777_217, 16_777_221, dtype=mx.int32),
+            atol=0.0,
+            rtol=0.0,
+        )
+
+    def test_arange_uint32_large_start_vulkan(self):
+        self._assert_cpu_gpu_same(
+            lambda: mx.arange(16_777_217, 16_777_221, dtype=mx.uint32),
+            atol=0.0,
+            rtol=0.0,
         )
 
     def test_gather_take_bf16_vulkan(self):


### PR DESCRIPTION
## Summary
- remove active Vulkan runtime CPU fallback helpers and replace unsupported op paths with explicit Vulkan errors
- keep supported Vulkan paths intact while preventing unsupported GPU cases from silently executing on CPU
- add a regression test covering an unsupported op path on Vulkan

Closes goniz/mlx-vulkan#42.

## Verification
- `./dev.sh run pytest mlx/python/tests/test_vulkan_ops.py -k arccos_does_not_fallback_to_cpu`

## Benchmarks
### `./dev.sh benchmark bf16`
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1373.480, generation_tps=11.128, peak_memory=2.061, total_time=14.622
Trial 2:  prompt_tps=1390.885, generation_tps=11.120, peak_memory=2.062, total_time=14.591
Trial 3:  prompt_tps=1379.432, generation_tps=11.121, peak_memory=2.062, total_time=14.615
Trial 4:  prompt_tps=1374.407, generation_tps=11.118, peak_memory=2.062, total_time=14.627
Trial 5:  prompt_tps=1378.157, generation_tps=11.065, peak_memory=2.063, total_time=14.676
Averages: prompt_tps=1379.272, generation_tps=11.111, peak_memory=2.062
```

### `./dev.sh benchmark 8bit`
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=845.020, generation_tps=6.400, peak_memory=1.393, total_time=24.988
Trial 2:  prompt_tps=850.311, generation_tps=6.443, peak_memory=1.394, total_time=24.821
Trial 3:  prompt_tps=846.644, generation_tps=6.333, peak_memory=1.394, total_time=25.189
Trial 4:  prompt_tps=846.587, generation_tps=6.412, peak_memory=1.394, total_time=24.941
Trial 5:  prompt_tps=875.176, generation_tps=6.483, peak_memory=1.394, total_time=24.562
Averages: prompt_tps=852.748, generation_tps=6.414, peak_memory=1.394
```
