### PR TITLE
fix(vulkan): keep non-decode deferred barriers

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -1558,7 +1558,8 @@ class VulkanDevice {
     }
 
     if (barrier_between_deferred_ops()) {
-      if (stream->last_decode_resource_summary.safe_to_skip_tail_barrier()) {
+      if (should_prefer_long_decode_recording(stream) &&
+          stream->last_decode_resource_summary.safe_to_skip_tail_barrier()) {
         if (trace_batch_enabled()) {
           std::ostringstream oss;
           oss << "decode-tail action=skip stream=" << stream->stream_index


### PR DESCRIPTION
## Summary
- Keep the decode tail-barrier skip limited to decode-like deferred recordings.
- Preserve barriers for non-decode deferred ops so slice/JVP equality checks do not race under long deferred command buffers.

Closes goniz/mlx-vulkan#44.

## Verification
- `./dev.sh build`
- `DEVICE=gpu MLX_VULKAN_DEFERRED_SUBMISSION=1 MLX_VULKAN_SUBMIT_ON_HAZARD=0 MLX_VULKAN_MAX_DEFERRED_OPS=100000 MLX_VULKAN_MAX_ADAPTIVE_DEFERRED_OPS=100000 MLX_VULKAN_MAX_DEFERRED_TOTAL_BYTES=1073741824 MLX_VULKAN_MAX_DEFERRED_HEAVY_BYTES=1073741824 MLX_VULKAN_MAX_DEFERRED_COMPILED_BYTES=1073741824 ./dev.sh test-cpp --test-case="test slice grads"` passed 5 consecutive runs
- `./dev.sh test-cpp --test-case="test slice grads"`
- `./dev.sh generate`

## Benchmarks
### bf16
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1499.709, generation_tps=11.381, peak_memory=1.860, total_time=14.124
Trial 2:  prompt_tps=1549.931, generation_tps=11.502, peak_memory=1.860, total_time=13.915
Trial 3:  prompt_tps=1533.150, generation_tps=11.380, peak_memory=1.861, total_time=14.056
Trial 4:  prompt_tps=1499.752, generation_tps=11.401, peak_memory=1.861, total_time=14.105
Trial 5:  prompt_tps=1535.673, generation_tps=11.456, peak_memory=1.861, total_time=13.984
Averages: prompt_tps=1523.643, generation_tps=11.424, peak_memory=1.861
```

### 8bit
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1077.954, generation_tps=8.593, peak_memory=1.302, total_time=18.864
Trial 2:  prompt_tps=1076.405, generation_tps=8.412, peak_memory=1.303, total_time=19.172
Trial 3:  prompt_tps=1065.968, generation_tps=8.446, peak_memory=1.303, total_time=19.152
Trial 4:  prompt_tps=1073.510, generation_tps=8.397, peak_memory=1.303, total_time=19.217
Trial 5:  prompt_tps=1078.662, generation_tps=10.054, peak_memory=1.304, total_time=16.697
Averages: prompt_tps=1074.500, generation_tps=8.780, peak_memory=1.303
```