### PR TITLE
vulkan: improve dynamic shader compilation

### DIFF
--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -93,51 +93,11 @@ std::string join_primitive_names(const std::vector<array>& arrays) {
 }
 
 std::string dtype_to_glsl_storage(Dtype d) {
-  switch (d) {
-    case float32:
-      return "float";
-    case float16:
-      return "float16_t";
-    case bfloat16:
-      return "uint16_t";
-    case complex64:
-      return "vec2";
-    case int32:
-      return "int";
-    case uint32:
-      return "uint";
-    case int64:
-      return "int64_t";
-    case uint64:
-      return "uint64_t";
-    case int16:
-      return "int16_t";
-    case uint16:
-      return "uint16_t";
-    case int8:
-      return "int8_t";
-    case uint8:
-      return "uint8_t";
-    case bool_:
-      return "uint8_t";
-    default:
-      throw std::runtime_error(
-          fmt::format(
-              "Unsupported dtype for Vulkan compiled: {}", dtype_to_string(d)));
-  }
+  return vulkan::dtype_to_glsl_storage_type(d);
 }
 
 std::string dtype_to_glsl_compute(Dtype d) {
-  switch (d) {
-    case bfloat16:
-      return "float";
-    case complex64:
-      return "vec2";
-    case bool_:
-      return "bool";
-    default:
-      return dtype_to_glsl_storage(d);
-  }
+  return vulkan::dtype_to_glsl_compute_type(d);
 }
 
 bool has_dtype(const std::vector<array>& arrays, Dtype dtype) {
@@ -1082,116 +1042,96 @@ void Compiled::eval_gpu(
               << "\n";
   }
 
-  std::vector<uint32_t> spirv;
   if (!existing_shader) {
-    const auto compile_start = std::chrono::steady_clock::now();
+    manager.get_or_register_dynamic_shader(kernel_name, [&]() {
+      const auto compile_start = std::chrono::steady_clock::now();
 
-    // Generate GLSL source
-    std::string glsl_source;
-    uint32_t params_binding = 0;
-    for (size_t i = 0; i < inputs_.size(); ++i) {
-      if (!is_constant_(i)) {
-        params_binding++;
+      // Generate GLSL source
+      std::string glsl_source;
+      uint32_t params_binding = 0;
+      for (size_t i = 0; i < inputs_.size(); ++i) {
+        if (!is_constant_(i)) {
+          params_binding++;
+        }
       }
-    }
-    params_binding += static_cast<uint32_t>(outputs_.size());
-    build_glsl_kernel(
-        glsl_source,
-        kernel_name,
-        inputs_,
-        outputs_,
-        tape_,
-        is_constant_,
-        constant_ids_,
-        contiguous,
-        static_cast<int>(shape.size()),
-        work_per_thread,
-        params_binding);
+      params_binding += static_cast<uint32_t>(outputs_.size());
+      build_glsl_kernel(
+          glsl_source,
+          kernel_name,
+          inputs_,
+          outputs_,
+          tape_,
+          is_constant_,
+          constant_ids_,
+          contiguous,
+          static_cast<int>(shape.size()),
+          work_per_thread,
+          params_binding);
 
-    if (trace_compiled_glsl_enabled()) {
-      std::cerr << "=== Vulkan compiled GLSL: " << kernel_name << " ===\n"
-                << glsl_source << "\n=== End GLSL ===\n";
-    }
+      if (trace_compiled_glsl_enabled()) {
+        std::cerr << "=== Vulkan compiled GLSL: " << kernel_name << " ===\n"
+                  << glsl_source << "\n=== End GLSL ===\n";
+      }
 
-    if (trace_compiled_compile_flow_enabled()) {
+      if (trace_compiled_compile_flow_enabled()) {
+        const auto glsl_built_at = std::chrono::steady_clock::now();
+        const auto glsl_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                glsl_built_at - compile_start)
+                .count();
+        std::cerr << "[vulkan-compiled-flow] glsl_generated: " << kernel_name
+                  << " glsl_bytes=" << glsl_source.size() << " ms=" << glsl_ms
+                  << "\n";
+      }
+
       const auto glsl_built_at = std::chrono::steady_clock::now();
-      const auto glsl_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              glsl_built_at - compile_start)
-              .count();
-      std::cerr << "[vulkan-compiled-flow] glsl_generated: " << kernel_name
-                << " glsl_bytes=" << glsl_source.size() << " ms=" << glsl_ms
-                << "\n";
-    }
+      std::vector<uint32_t> spirv;
 
-    const auto glsl_built_at = std::chrono::steady_clock::now();
+      // Compile to SPIR-V
+      try {
+        spirv = vulkan::compile_glsl_to_spirv(glsl_source, kernel_name);
+      } catch (const std::exception& e) {
+        std::cerr << "=== FAILED GLSL for: " << kernel_name
+                  << " ===" << std::endl;
+        std::cerr << glsl_source << std::endl;
+        std::cerr << "=== End GLSL ===" << std::endl;
+        throw;
+      }
 
-    // Compile to SPIR-V
-    try {
-      spirv = vulkan::compile_glsl_to_spirv(glsl_source, kernel_name);
-    } catch (const std::exception& e) {
-      std::cerr << "=== FAILED GLSL for: " << kernel_name
-                << " ===" << std::endl;
-      std::cerr << glsl_source << std::endl;
-      std::cerr << "=== End GLSL ===" << std::endl;
-      throw;
-    }
+      const auto spirv_compiled_at = std::chrono::steady_clock::now();
 
-    const auto spirv_compiled_at = std::chrono::steady_clock::now();
+      if (trace_compiled_compile_flow_enabled()) {
+        const auto spirv_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                spirv_compiled_at - glsl_built_at)
+                .count();
+        std::cerr << "[vulkan-compiled-flow] spirv_compiled: " << kernel_name
+                  << " spirv_words=" << spirv.size() << " ms=" << spirv_ms
+                  << "\n";
+      }
 
-    if (trace_compiled_compile_flow_enabled()) {
-      const auto spirv_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              spirv_compiled_at - glsl_built_at)
-              .count();
-      std::cerr << "[vulkan-compiled-flow] spirv_compiled: " << kernel_name
-                << " spirv_words=" << spirv.size() << " ms=" << spirv_ms
-                << "\n";
-    }
-
-    // Register the shader
-    manager.register_shader(
-        kernel_name, spirv.data(), spirv.size() * sizeof(uint32_t));
-
-    if (trace_compiled_compile_flow_enabled()) {
-      const auto registered_at = std::chrono::steady_clock::now();
-      const auto register_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              registered_at - spirv_compiled_at)
-              .count();
-      const auto total_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              registered_at - compile_start)
-              .count();
-      std::cerr << "[vulkan-compiled-flow] registered: " << kernel_name
-                << " register_ms=" << register_ms << " total_ms=" << total_ms
-                << "\n";
-    }
-
-    if (trace_compiled_timing_enabled()) {
-      const auto registered_at = std::chrono::steady_clock::now();
-      const auto glsl_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              glsl_built_at - compile_start)
-              .count();
-      const auto spirv_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              spirv_compiled_at - glsl_built_at)
-              .count();
-      const auto register_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              registered_at - spirv_compiled_at)
-              .count();
-      const auto total_ms =
-          std::chrono::duration_cast<std::chrono::milliseconds>(
-              registered_at - compile_start)
-              .count();
-      std::cerr << "[vulkan-compiled-timing] kernel=" << kernel_name
-                << " glsl_ms=" << glsl_ms << " spirv_ms=" << spirv_ms
-                << " register_ms=" << register_ms << " total_ms=" << total_ms
-                << " tape_size=" << tape_.size() << " contiguous=" << contiguous
-                << " large=" << large << "\n";
-    }
+      if (trace_compiled_timing_enabled()) {
+        const auto ready_at = std::chrono::steady_clock::now();
+        const auto glsl_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                glsl_built_at - compile_start)
+                .count();
+        const auto spirv_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                spirv_compiled_at - glsl_built_at)
+                .count();
+        const auto total_ms =
+            std::chrono::duration_cast<std::chrono::milliseconds>(
+                ready_at - compile_start)
+                .count();
+        std::cerr << "[vulkan-compiled-timing] kernel=" << kernel_name
+                  << " glsl_ms=" << glsl_ms << " spirv_ms=" << spirv_ms
+                  << " total_ms=" << total_ms << " tape_size=" << tape_.size()
+                  << " contiguous=" << contiguous << " large=" << large
+                  << "\n";
+      }
+      return spirv;
+    });
   }
 
   // Allocate outputs with buffer donation

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -33,8 +33,11 @@ namespace vulkan = mlx::core::vulkan;
 
 using vulkan::cast_expr_for_dtype;
 using vulkan::dtype_to_glsl_storage_type;
+using vulkan::emit_bf16_conversion_helpers;
 using vulkan::emit_dynamic_shader_preamble;
 using vulkan::is_vulkan_storage_array;
+using vulkan::needs_bf16_conversion_helpers;
+using vulkan::storage_buffer_layout_for_dtype;
 using vulkan::zero_literal_for_dtype;
 
 constexpr size_t kMinTransferQueueCopyBytes = 256 * 1024;
@@ -45,10 +48,6 @@ bool has_vulkan_storage(const array& arr) {
 }
 
 std::string copy_dtype_suffix(Dtype dtype);
-bool needs_bf16_helpers(Dtype in_dtype, Dtype out_dtype);
-std::string emit_bf16_conversion_helpers();
-std::string
-bf16_cast_expr(const std::string& expr, Dtype in_dtype, Dtype out_dtype);
 
 bool has_row_contiguous_strides(const mlx::core::array& arr) {
   if (arr.ndim() == 0) {
@@ -200,6 +199,35 @@ void validate_dynamic_offset_array(
   }
 }
 
+bool index_bounds_fit_u32(
+    int64_t base,
+    const Shape& shape,
+    const Strides& strides) {
+  if (base < 0 || base > std::numeric_limits<uint32_t>::max()) {
+    return false;
+  }
+  uint64_t max_index = static_cast<uint64_t>(base);
+  for (size_t i = 0; i < shape.size(); ++i) {
+    if (strides[i] < 0) {
+      return false;
+    }
+    if (shape[i] <= 1) {
+      continue;
+    }
+    const uint64_t extent = static_cast<uint64_t>(shape[i] - 1);
+    const uint64_t stride = static_cast<uint64_t>(strides[i]);
+    if (stride != 0 && extent > std::numeric_limits<uint64_t>::max() / stride) {
+      return false;
+    }
+    const uint64_t term = extent * stride;
+    if (term > std::numeric_limits<uint32_t>::max() - max_index) {
+      return false;
+    }
+    max_index += term;
+  }
+  return true;
+}
+
 std::string build_dynamic_offset_shader(
     Dtype dtype,
     int64_t indices_base_offset,
@@ -231,7 +259,8 @@ std::string build_dynamic_general_copy_shader(
     const Strides& i_strides,
     const Strides& o_strides,
     bool has_dynamic_i_offset,
-    bool has_dynamic_o_offset) {
+    bool has_dynamic_o_offset,
+    bool use_u32_indices) {
   auto glsl_i64_literal = [](int64_t value) {
     if (value < 0) {
       return std::string("(-") + std::to_string(static_cast<uint64_t>(-value)) +
@@ -240,20 +269,27 @@ std::string build_dynamic_general_copy_shader(
     return std::to_string(static_cast<uint64_t>(value)) + "l";
   };
   std::ostringstream os;
-  os << emit_dynamic_shader_preamble(in_dtype, out_dtype, true);
-  if (needs_bf16_helpers(in_dtype, out_dtype)) {
+  os << emit_dynamic_shader_preamble(in_dtype, out_dtype, !use_u32_indices);
+  if (needs_bf16_conversion_helpers(in_dtype, out_dtype)) {
     os << emit_bf16_conversion_helpers();
   }
   os << "layout(push_constant) uniform PushConstants {\n";
   os << "  uint total_elements;\n";
-  os << "  int64_t input_base;\n";
-  os << "  int64_t output_base;\n";
-  os << "  int64_t dynamic_i_base;\n";
-  os << "  int64_t dynamic_o_base;\n";
+  if (use_u32_indices) {
+    os << "  uint input_base;\n";
+    os << "  uint output_base;\n";
+  } else {
+    os << "  int64_t input_base;\n";
+    os << "  int64_t output_base;\n";
+    os << "  int64_t dynamic_i_base;\n";
+    os << "  int64_t dynamic_o_base;\n";
+  }
   os << "} pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
+  os << storage_buffer_layout_for_dtype(in_dtype, 0)
+     << " readonly buffer InputBuffer {"
      << dtype_to_glsl_storage_type(in_dtype) << " data[];} input_buf;\n";
-  os << "layout(set = 0, binding = 1) buffer OutputBuffer {"
+  os << storage_buffer_layout_for_dtype(out_dtype, 1)
+     << " buffer OutputBuffer {"
      << dtype_to_glsl_storage_type(out_dtype) << " data[];} output_buf;\n";
   if (has_dynamic_i_offset) {
     os << "layout(set = 0, binding = 2) readonly buffer DynamicInputOffset {int64_t data[];} dynamic_i_offset_buf;\n";
@@ -266,8 +302,10 @@ std::string build_dynamic_general_copy_shader(
   os << "  if (linear_idx >= pc.total_elements) {\n";
   os << "    return;\n";
   os << "  }\n";
-  os << "  int64_t input_index = pc.input_base;\n";
-  os << "  int64_t output_index = pc.output_base;\n";
+  os << "  " << (use_u32_indices ? "uint" : "int64_t")
+     << " input_index = pc.input_base;\n";
+  os << "  " << (use_u32_indices ? "uint" : "int64_t")
+     << " output_index = pc.output_base;\n";
   if (has_dynamic_i_offset) {
     os << "  input_index += dynamic_i_offset_buf.data[uint(pc.dynamic_i_base)];\n";
   }
@@ -281,29 +319,40 @@ std::string build_dynamic_general_copy_shader(
       os << "    uint coord = remaining % " << static_cast<uint32_t>(shape[dim])
          << "u;\n";
       os << "    remaining /= " << static_cast<uint32_t>(shape[dim]) << "u;\n";
-      os << "    input_index += int64_t(coord) * "
-         << glsl_i64_literal(i_strides[dim]) << ";\n";
-      os << "    output_index += int64_t(coord) * "
-         << glsl_i64_literal(o_strides[dim]) << ";\n";
+      if (use_u32_indices) {
+        os << "    input_index += coord * "
+           << static_cast<uint32_t>(i_strides[dim]) << "u;\n";
+        os << "    output_index += coord * "
+           << static_cast<uint32_t>(o_strides[dim]) << "u;\n";
+      } else {
+        os << "    input_index += int64_t(coord) * "
+           << glsl_i64_literal(i_strides[dim]) << ";\n";
+        os << "    output_index += int64_t(coord) * "
+           << glsl_i64_literal(o_strides[dim]) << ";\n";
+      }
       os << "  }\n";
     }
   }
+  const std::string input_index_expr =
+      use_u32_indices ? "input_index" : "uint(input_index)";
+  const std::string output_index_expr =
+      use_u32_indices ? "output_index" : "uint(output_index)";
   std::string cast_expr;
-  if (needs_bf16_helpers(in_dtype, out_dtype)) {
-    cast_expr = bf16_cast_expr(
-        "input_buf.data[uint(input_index)]", in_dtype, out_dtype);
+  if (needs_bf16_conversion_helpers(in_dtype, out_dtype)) {
+    cast_expr = cast_expr_for_dtype(
+        "input_buf.data[" + input_index_expr + "]", in_dtype, out_dtype);
   } else if (
       in_dtype == mlx::core::complex64 && out_dtype == mlx::core::float32) {
-    cast_expr = "input_buf.data[input_index].x";
+    cast_expr = "input_buf.data[" + input_index_expr + "].x";
   } else if (
       in_dtype == mlx::core::float32 && out_dtype == mlx::core::complex64) {
-    cast_expr =
-        "vec2(" + std::string("input_buf.data[uint(input_index)]") + ", 0.0)";
+    cast_expr = "vec2(input_buf.data[" + input_index_expr + "], 0.0)";
   } else {
     cast_expr = cast_expr_for_dtype(
-        "input_buf.data[uint(input_index)]", in_dtype, out_dtype);
+        "input_buf.data[" + input_index_expr + "]", in_dtype, out_dtype);
   }
-  os << "  output_buf.data[uint(output_index)] = " << cast_expr << ";\n";
+  os << "  output_buf.data[" << output_index_expr << "] = " << cast_expr
+     << ";\n";
   os << "}\n";
   return os.str();
 }
@@ -397,9 +446,16 @@ bool dispatch_dynamic_general_copy(
       dynamic_i_offset.has_value() ? element_offset(*dynamic_i_offset) : 0;
   const int64_t dynamic_o_base_offset =
       dynamic_o_offset.has_value() ? element_offset(*dynamic_o_offset) : 0;
+  const int64_t input_base = in_base_offset + i_offset;
+  const int64_t output_base = out_base_offset + o_offset;
+  const bool use_u32_indices = !dynamic_i_offset.has_value() &&
+      !dynamic_o_offset.has_value() &&
+      index_bounds_fit_u32(input_base, shape, i_strides) &&
+      index_bounds_fit_u32(output_base, shape, o_strides);
 
   std::ostringstream layout_key;
   layout_key << static_cast<int>(in.dtype().val()) << ':'
+             << use_u32_indices << ':'
              << dynamic_i_offset.has_value() << ':'
              << dynamic_o_offset.has_value() << ':';
   append_layout_key(layout_key, shape);
@@ -419,7 +475,8 @@ bool dispatch_dynamic_general_copy(
       i_strides,
       o_strides,
       dynamic_i_offset.has_value(),
-      dynamic_o_offset.has_value());
+      dynamic_o_offset.has_value(),
+      use_u32_indices);
 
   std::vector<vulkan::DynamicArrayRef> arrays;
   arrays.push_back({&in, 0});
@@ -431,36 +488,56 @@ bool dispatch_dynamic_general_copy(
     arrays.push_back({&*dynamic_o_offset, 3});
   }
 
-  struct PushConstants {
+  struct PushConstants32 {
+    uint32_t total_elements;
+    uint32_t input_base;
+    uint32_t output_base;
+  };
+  struct PushConstants64 {
     uint32_t total_elements;
     int64_t input_base;
     int64_t output_base;
     int64_t dynamic_i_base;
     int64_t dynamic_o_base;
   };
-  constexpr uint32_t kPushConstantSize = sizeof(PushConstants);
+  const uint32_t push_constant_size = use_u32_indices
+      ? static_cast<uint32_t>(sizeof(PushConstants32))
+      : static_cast<uint32_t>(sizeof(PushConstants64));
   auto dispatch = vulkan::dispatch_dynamic_compute_begin(
       shader_name,
       glsl_source,
       static_cast<uint32_t>(arrays.size()),
       arrays.data(),
-      kPushConstantSize,
+      push_constant_size,
       s);
 
-  PushConstants pc{};
-  pc.total_elements = static_cast<uint32_t>(total_elements);
-  pc.input_base = in_base_offset + i_offset;
-  pc.output_base = out_base_offset + o_offset;
-  pc.dynamic_i_base = dynamic_i_base_offset;
-  pc.dynamic_o_base = dynamic_o_base_offset;
-
-  vkCmdPushConstants(
-      dispatch.command_buffer,
-      dispatch.pipeline->layout,
-      VK_SHADER_STAGE_COMPUTE_BIT,
-      0,
-      kPushConstantSize,
-      &pc);
+  if (use_u32_indices) {
+    PushConstants32 pc{};
+    pc.total_elements = static_cast<uint32_t>(total_elements);
+    pc.input_base = static_cast<uint32_t>(input_base);
+    pc.output_base = static_cast<uint32_t>(output_base);
+    vkCmdPushConstants(
+        dispatch.command_buffer,
+        dispatch.pipeline->layout,
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        push_constant_size,
+        &pc);
+  } else {
+    PushConstants64 pc{};
+    pc.total_elements = static_cast<uint32_t>(total_elements);
+    pc.input_base = input_base;
+    pc.output_base = output_base;
+    pc.dynamic_i_base = dynamic_i_base_offset;
+    pc.dynamic_o_base = dynamic_o_base_offset;
+    vkCmdPushConstants(
+        dispatch.command_buffer,
+        dispatch.pipeline->layout,
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        push_constant_size,
+        &pc);
+  }
 
   const uint32_t workgroups = std::max<uint32_t>(
       (static_cast<uint32_t>(total_elements) + 255u) / 256u, 1u);
@@ -492,21 +569,23 @@ bool dispatch_dynamic_scalar_fill(
 
   std::ostringstream os;
   os << emit_dynamic_shader_preamble(in.dtype(), out.dtype(), false);
-  if (needs_bf16_helpers(in.dtype(), out.dtype())) {
+  if (needs_bf16_conversion_helpers(in.dtype(), out.dtype())) {
     os << emit_bf16_conversion_helpers();
   }
   os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
+  os << storage_buffer_layout_for_dtype(in.dtype(), 0)
+     << " readonly buffer InputBuffer {"
      << dtype_to_glsl_storage_type(in.dtype()) << " data[];} input_buf;\n";
-  os << "layout(set = 0, binding = 1) buffer OutputBuffer {"
+  os << storage_buffer_layout_for_dtype(out.dtype(), 1)
+     << " buffer OutputBuffer {"
      << dtype_to_glsl_storage_type(out.dtype()) << " data[];} output_buf;\n\n";
   os << "void main() {\n";
   os << "  uint idx = gl_GlobalInvocationID.x;\n";
   os << "  if (idx >= pc.total_elements) return;\n";
   std::string cast_expr;
-  if (needs_bf16_helpers(in.dtype(), out.dtype())) {
-    cast_expr =
-        bf16_cast_expr("input_buf.data[pc.in_offset]", in.dtype(), out.dtype());
+  if (needs_bf16_conversion_helpers(in.dtype(), out.dtype())) {
+    cast_expr = cast_expr_for_dtype(
+        "input_buf.data[pc.in_offset]", in.dtype(), out.dtype());
   } else if (
       in.dtype() == mlx::core::complex64 && out.dtype() == mlx::core::float32) {
     cast_expr = "input_buf.data[pc.in_offset].x";
@@ -558,65 +637,20 @@ bool dispatch_dynamic_scalar_fill(
   return true;
 }
 
-bool needs_bf16_helpers(Dtype in_dtype, Dtype out_dtype) {
-  return in_dtype == mlx::core::bfloat16 || out_dtype == mlx::core::bfloat16;
-}
-
-std::string emit_bf16_conversion_helpers() {
-  std::ostringstream os;
-  os << "uint fp32_to_bf16(float f) {\n";
-  os << "  uint u = floatBitsToUint(f);\n";
-  os << "  u = (u + (0x7fffu + ((u >> 16) & 1u))) >> 16;\n";
-  os << "  return u;\n";
-  os << "}\n\n";
-  os << "float bf16_to_fp32(uint u) {\n";
-  os << "  return uintBitsToFloat(u << 16);\n";
-  os << "}\n\n";
-  return os.str();
-}
-
-std::string
-bf16_cast_expr(const std::string& expr, Dtype in_dtype, Dtype out_dtype) {
-  const bool in_is_bf16 = in_dtype == mlx::core::bfloat16;
-  const bool out_is_bf16 = out_dtype == mlx::core::bfloat16;
-
-  if (in_is_bf16 && out_is_bf16) {
-    return expr;
-  }
-
-  if (in_is_bf16 && !out_is_bf16) {
-    std::string as_float = "bf16_to_fp32(uint(" + expr + "))";
-    if (out_dtype == mlx::core::bool_) {
-      return "(" + as_float + " != 0.0 ? uint8_t(1) : uint8_t(0))";
-    }
-    return dtype_to_glsl_storage_type(out_dtype) + "(" + as_float + ")";
-  }
-
-  if (!in_is_bf16 && out_is_bf16) {
-    std::string intermediate;
-    if (in_dtype == mlx::core::bool_) {
-      intermediate = "float(" + expr + ")";
-    } else {
-      intermediate = "float(" + expr + ")";
-    }
-    return "uint16_t(fp32_to_bf16(" + intermediate + "))";
-  }
-
-  return {};
-}
-
 std::string build_dynamic_vector_cast_shader(Dtype in_dtype, Dtype out_dtype) {
   std::ostringstream os;
   os << emit_dynamic_shader_preamble(in_dtype, out_dtype, false);
 
-  if (needs_bf16_helpers(in_dtype, out_dtype)) {
+  if (needs_bf16_conversion_helpers(in_dtype, out_dtype)) {
     os << emit_bf16_conversion_helpers();
   }
 
   os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer InputBuffer {"
+  os << storage_buffer_layout_for_dtype(in_dtype, 0)
+     << " readonly buffer InputBuffer {"
      << dtype_to_glsl_storage_type(in_dtype) << " data[];} input_buf;\n";
-  os << "layout(set = 0, binding = 1) buffer OutputBuffer {"
+  os << storage_buffer_layout_for_dtype(out_dtype, 1)
+     << " buffer OutputBuffer {"
      << dtype_to_glsl_storage_type(out_dtype) << " data[];} output_buf;\n\n";
   os << "void main() {\n";
   os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
@@ -626,14 +660,8 @@ std::string build_dynamic_vector_cast_shader(Dtype in_dtype, Dtype out_dtype) {
   os << "  uint input_index = linear_idx + pc.in_offset;\n";
   os << "  uint output_index = linear_idx + pc.out_offset;\n";
 
-  std::string cast_expr;
-  if (needs_bf16_helpers(in_dtype, out_dtype)) {
-    cast_expr =
-        bf16_cast_expr("input_buf.data[input_index]", in_dtype, out_dtype);
-  } else {
-    cast_expr =
-        cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype);
-  }
+  std::string cast_expr =
+      cast_expr_for_dtype("input_buf.data[input_index]", in_dtype, out_dtype);
 
   os << "  output_buf.data[output_index] = " << cast_expr << ";\n";
   os << "}\n";

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -98,7 +98,10 @@ std::string build_to_fp8_f32_shader() {
   os << R"(
 layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;
 layout(set = 0, binding = 0) readonly buffer Input { float data[]; } in_buf;
-layout(set = 0, binding = 1) buffer Output { uint8_t data[]; } out_buf;
+)";
+  os << vulkan::storage_buffer_layout_for_dtype(uint8, 1)
+     << " buffer Output { uint8_t data[]; } out_buf;\n";
+  os << R"(
 
 uint8_t to_fp8_e4m3(float x) {
   uint f_bits = floatBitsToUint(x);
@@ -144,8 +147,9 @@ std::string build_from_fp8_shader(Dtype out_dtype) {
                                               : "float";
   os << R"(
 layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;
-layout(set = 0, binding = 0) readonly buffer Input { uint8_t data[]; } in_buf;
 )";
+  os << vulkan::storage_buffer_layout_for_dtype(uint8, 0)
+     << " readonly buffer Input { uint8_t data[]; } in_buf;\n";
   os << "layout(set = 0, binding = 1) buffer Output { " << out_type
      << " data[]; } out_buf;\n";
   os << R"(

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -1164,6 +1164,76 @@ void KernelManager::register_shader(
   shader->module = VK_NULL_HANDLE;
 }
 
+ShaderModule* KernelManager::get_dynamic_shader(const std::string& name) {
+  std::lock_guard<std::mutex> lock(shader_cache_mutex_);
+  auto it = dynamic_shaders_.find(name);
+  if (it == dynamic_shaders_.end()) {
+    return nullptr;
+  }
+  return it->second.get();
+}
+
+ShaderModule* KernelManager::get_or_register_dynamic_shader(
+    const std::string& name,
+    const std::function<std::vector<uint32_t>()>& compile_spirv) {
+  if (auto* shader = get_dynamic_shader(name)) {
+    return shader;
+  }
+
+  std::shared_ptr<DynamicShaderRegistration> registration;
+  while (true) {
+    {
+      std::unique_lock<std::mutex> lock(dynamic_shader_registration_mutex_);
+      auto it = dynamic_shader_registrations_.find(name);
+      if (it == dynamic_shader_registrations_.end()) {
+        registration = std::make_shared<DynamicShaderRegistration>();
+        dynamic_shader_registrations_.emplace(name, registration);
+        break;
+      }
+      registration = it->second;
+      registration->cv.wait(lock, [&registration]() {
+        return !registration->compiling;
+      });
+    }
+    if (auto* shader = get_dynamic_shader(name)) {
+      return shader;
+    }
+  }
+
+  auto finish_registration = [&]() {
+    {
+      std::lock_guard<std::mutex> lock(dynamic_shader_registration_mutex_);
+      registration->compiling = false;
+      auto it = dynamic_shader_registrations_.find(name);
+      if (it != dynamic_shader_registrations_.end() &&
+          it->second == registration) {
+        dynamic_shader_registrations_.erase(it);
+      }
+    }
+    registration->cv.notify_all();
+  };
+
+  try {
+    if (auto* shader = get_dynamic_shader(name)) {
+      finish_registration();
+      return shader;
+    }
+
+    auto spirv = compile_spirv();
+    register_shader(name, spirv.data(), spirv.size() * sizeof(uint32_t));
+  } catch (...) {
+    finish_registration();
+    throw;
+  }
+
+  finish_registration();
+  auto* shader = get_dynamic_shader(name);
+  if (shader == nullptr) {
+    throw std::runtime_error("Failed to register dynamic shader: " + name);
+  }
+  return shader;
+}
+
 void KernelManager::ensure_static_registry_initialized() {
   if (static_registry_initialized_) {
     return;
@@ -2098,6 +2168,20 @@ void KernelManager::purge_descriptor_sets_for_layouts(
 
 void KernelManager::cleanup() {
   reclaim_all_descriptor_sets();
+  std::vector<std::shared_ptr<DynamicShaderRegistration>> registrations;
+  {
+    std::lock_guard<std::mutex> lock(dynamic_shader_registration_mutex_);
+    registrations.reserve(dynamic_shader_registrations_.size());
+    for (auto& entry : dynamic_shader_registrations_) {
+      auto& registration = entry.second;
+      registration->compiling = false;
+      registrations.push_back(registration);
+    }
+    dynamic_shader_registrations_.clear();
+  }
+  for (auto& registration : registrations) {
+    registration->cv.notify_all();
+  }
   {
     std::lock_guard<std::mutex> pipeline_lock(pipeline_cache_mutex_);
     pipelines_.clear();
@@ -4113,13 +4197,9 @@ void ensure_dynamic_shader_registered(
     const std::string& shader_name,
     const std::string& glsl_source) {
   auto& manager = KernelManager::get();
-  if (manager.get_shader(shader_name) != nullptr) {
-    return;
-  }
-
-  auto spirv = compile_glsl_to_spirv(glsl_source, shader_name);
-  manager.register_shader(
-      shader_name, spirv.data(), spirv.size() * sizeof(uint32_t));
+  manager.get_or_register_dynamic_shader(shader_name, [&]() {
+    return compile_glsl_to_spirv(glsl_source, shader_name);
+  });
 }
 
 bool is_vulkan_storage_array(const array& arr) {

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -3,7 +3,9 @@
 #pragma once
 
 #include <vulkan/vulkan.hpp>
+#include <condition_variable>
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -107,6 +109,11 @@ class KernelManager {
   ShaderModule* get_shader(StaticShaderId id);
   ShaderModule* get_shader(const std::string& name);
 
+  // Get an existing dynamic shader or serialize first-time registration.
+  ShaderModule* get_or_register_dynamic_shader(
+      const std::string& name,
+      const std::function<std::vector<uint32_t>()>& compile_spirv);
+
   // Register a dynamic shader from SPIR-V data.
   void
   register_shader(const std::string& name, const void* data, size_t size_bytes);
@@ -173,6 +180,7 @@ class KernelManager {
       const void* data,
       size_t size_bytes);
   vk::ShaderModule compile_shader(const std::vector<uint32_t>& spirv);
+  ShaderModule* get_dynamic_shader(const std::string& name);
   static DescriptorBindingKey make_descriptor_binding_key(
       const vk::DescriptorSetLayoutBinding& binding);
   void purge_descriptor_sets_for_layouts(
@@ -191,6 +199,17 @@ class KernelManager {
   std::mutex static_registry_mutex_;
   std::mutex shader_cache_mutex_;
   std::mutex pipeline_cache_mutex_;
+
+  struct DynamicShaderRegistration {
+    bool compiling{true};
+    std::condition_variable cv;
+  };
+
+  std::mutex dynamic_shader_registration_mutex_;
+  std::unordered_map<
+      std::string,
+      std::shared_ptr<DynamicShaderRegistration>>
+      dynamic_shader_registrations_;
 
   struct DescriptorSetRecord {
     vk::DescriptorSet set;

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -572,9 +572,12 @@ std::string build_equal_shader(
     std::ostringstream os;
     os << vulkan::emit_dynamic_shader_preamble(bool_, bool_, false);
     os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
-    os << "layout(set = 0, binding = 0) readonly buffer InputA {uint8_t data[];} a_buf;\n";
-    os << "layout(set = 0, binding = 1) readonly buffer InputB {uint8_t data[];} b_buf;\n";
-    os << "layout(set = 0, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+    os << vulkan::storage_buffer_layout_for_dtype(bool_, 0)
+       << " readonly buffer InputA {uint8_t data[];} a_buf;\n";
+    os << vulkan::storage_buffer_layout_for_dtype(bool_, 1)
+       << " readonly buffer InputB {uint8_t data[];} b_buf;\n";
+    os << vulkan::storage_buffer_layout_for_dtype(bool_, 2)
+       << " buffer Output {uint8_t data[];} out_buf;\n\n";
     os << "void main() {\n";
     os << "  uint idx = gl_GlobalInvocationID.x;\n";
     os << "  if (idx >= pc.total_elements) return;\n";
@@ -615,11 +618,14 @@ std::string build_equal_shader(
   }
 
   os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(scalar, binding = 0) readonly buffer InputA {"
+  os << vulkan::storage_buffer_layout_for_dtype(a_dtype, 0)
+     << " readonly buffer InputA {"
      << vulkan::dtype_to_glsl_storage_type(a_dtype) << " data[];} a_buf;\n";
-  os << "layout(scalar, binding = 1) readonly buffer InputB {"
+  os << vulkan::storage_buffer_layout_for_dtype(b_dtype, 1)
+     << " readonly buffer InputB {"
      << vulkan::dtype_to_glsl_storage_type(b_dtype) << " data[];} b_buf;\n";
-  os << "layout(scalar, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 2)
+     << " buffer Output {uint8_t data[];} out_buf;\n\n";
   os << "void main() {\n";
   os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
   os << "  if (linear_idx >= pc.total_elements) return;\n";
@@ -705,11 +711,14 @@ std::string build_compare_shader(
   }
 
   os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(scalar, binding = 0) readonly buffer InputA {"
+  os << vulkan::storage_buffer_layout_for_dtype(a_dtype, 0)
+     << " readonly buffer InputA {"
      << vulkan::dtype_to_glsl_storage_type(a_dtype) << " data[];} a_buf;\n";
-  os << "layout(scalar, binding = 1) readonly buffer InputB {"
+  os << vulkan::storage_buffer_layout_for_dtype(b_dtype, 1)
+     << " readonly buffer InputB {"
      << vulkan::dtype_to_glsl_storage_type(b_dtype) << " data[];} b_buf;\n";
-  os << "layout(scalar, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 2)
+     << " buffer Output {uint8_t data[];} out_buf;\n\n";
   os << "void main() {\n";
   os << "  uint idx = gl_GlobalInvocationID.x;\n";
   os << "  if (idx >= pc.total_elements) return;\n";
@@ -1275,8 +1284,10 @@ std::string build_logical_not_shader() {
   std::ostringstream os;
   os << vulkan::emit_dynamic_shader_preamble(bool_, bool_, false);
   os << "layout(push_constant) uniform PushConstants { uint in_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer Input {uint8_t data[];} in_buf;\n";
-  os << "layout(set = 0, binding = 1) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 0)
+     << " readonly buffer Input {uint8_t data[];} in_buf;\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 1)
+     << " buffer Output {uint8_t data[];} out_buf;\n\n";
   os << "void main() {\n";
   os << "  uint idx = gl_GlobalInvocationID.x;\n";
   os << "  if (idx >= pc.total_elements) return;\n";
@@ -1289,9 +1300,12 @@ std::string build_logical_binary_shader(const char* expr) {
   std::ostringstream os;
   os << vulkan::emit_dynamic_shader_preamble(bool_, bool_, false);
   os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint out_offset; uint total_elements; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer InputA {uint8_t data[];} a_buf;\n";
-  os << "layout(set = 0, binding = 1) readonly buffer InputB {uint8_t data[];} b_buf;\n";
-  os << "layout(set = 0, binding = 2) buffer Output {uint8_t data[];} out_buf;\n\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 0)
+     << " readonly buffer InputA {uint8_t data[];} a_buf;\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 1)
+     << " readonly buffer InputB {uint8_t data[];} b_buf;\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 2)
+     << " buffer Output {uint8_t data[];} out_buf;\n\n";
   os << "void main() {\n";
   os << "  uint idx = gl_GlobalInvocationID.x;\n";
   os << "  if (idx >= pc.total_elements) return;\n";
@@ -1787,7 +1801,8 @@ std::string build_select_dynamic_shader(Dtype dtype) {
   os << vulkan::emit_dynamic_shader_preamble(
       bool_, dtype, dtype == int64 || dtype == uint64);
   os << "layout(push_constant) uniform PushConstants { uint cond_offset; uint x_offset; uint y_offset; uint out_offset; uint total_elements; uint out_ne0; uint out_ne1; uint out_ne2; uint out_ne3; uint cond_s0; uint cond_s1; uint cond_s2; uint cond_s3; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer Condition {uint8_t data[];} cond_buf;\n";
+  os << vulkan::storage_buffer_layout_for_dtype(bool_, 0)
+     << " readonly buffer Condition {uint8_t data[];} cond_buf;\n";
   os << "layout(set = 0, binding = 1) readonly buffer InputX {"
      << vulkan::dtype_to_glsl_storage_type(dtype) << " data[];} x_buf;\n";
   os << "layout(set = 0, binding = 2) readonly buffer InputY {"

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -298,7 +298,10 @@ bool fp_dequantize_to_float32_fallback(
   os << R"(
 layout(push_constant) uniform PushConstants { uint total_elements; } pc;
 layout(set = 0, binding = 0) readonly buffer Packed { uint data[]; } packed_buf;
-layout(set = 0, binding = 1) readonly buffer Scales { uint8_t data[]; } scale_buf;
+)";
+  os << vulkan::storage_buffer_layout_for_dtype(uint8, 1)
+     << " readonly buffer Scales { uint8_t data[]; } scale_buf;\n";
+  os << R"(
 layout(set = 0, binding = 2) buffer Output { float data[]; } out_buf;
 
 float fp8_e4m3_to_fp32(uint8_t x) {
@@ -449,17 +452,9 @@ bool fp_gather_qmm_fused(
   pc.bits = static_cast<uint32_t>(bits);
 
   std::ostringstream os;
-  os << "#version 450\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
-  os << "#extension GL_EXT_shader_8bit_storage : require\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
-  os << "#extension GL_EXT_shader_16bit_storage : require\n";
-  if (vulkan::uses_float16_extension(x.dtype()) ||
-      vulkan::uses_float16_extension(out.dtype())) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
-  }
-  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  vulkan::DynamicShaderPreambleOptions preamble_options;
+  preamble_options.dtypes = {uint8, x.dtype(), out.dtype()};
+  os << vulkan::emit_dynamic_shader_preamble(preamble_options);
   os << "#define X_TYPE " << vulkan::dtype_to_glsl_storage_type(x.dtype())
      << "\n";
   os << "#define OUT_TYPE " << vulkan::dtype_to_glsl_storage_type(out.dtype())
@@ -492,7 +487,10 @@ layout(push_constant) uniform PushConstants {
   uint bits;
 } p;
 layout(set = 0, binding = 0) readonly buffer W { uint data[]; } w;
-layout(set = 0, binding = 1) readonly buffer Scales { uint8_t data[]; } scales;
+)";
+  os << vulkan::storage_buffer_layout_for_dtype(uint8, 1)
+     << " readonly buffer Scales { uint8_t data[]; } scales;\n";
+  os << R"(
 layout(set = 0, binding = 2) readonly buffer X { X_TYPE data[]; } x;
 layout(set = 0, binding = 3) readonly buffer LhsIndices { uint data[]; } lhs;
 layout(set = 0, binding = 4) readonly buffer RhsIndices { uint data[]; } rhs;
@@ -636,9 +634,13 @@ void main() {
       {&rhs_indices, 4},
       {&out, 5},
   };
+  const std::string shader_name =
+      std::string(bits == 4 ? "dynamic_gather_mxfp4_qmm"
+                            : "dynamic_gather_mxfp8_qmm") +
+      "_x" + std::to_string(static_cast<int>(x.dtype().val())) + "_o" +
+      std::to_string(static_cast<int>(out.dtype().val()));
   auto dispatch = vulkan::dispatch_dynamic_compute_begin(
-      bits == 4 ? "dynamic_gather_mxfp4_qmm_f32"
-                : "dynamic_gather_mxfp8_qmm_f32",
+      shader_name,
       os.str(),
       6,
       arrays,

--- a/mlx/backend/vulkan/shader_compiler.cpp
+++ b/mlx/backend/vulkan/shader_compiler.cpp
@@ -1,25 +1,169 @@
 // Copyright © 2024 Apple Inc.
 
-#include "mlx/backend/vulkan/shader_compiler.h"
-
-#include <fmt/format.h>
-#include <shaderc/shaderc.hpp>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <optional>
 #include <sstream>
 #include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include <fmt/format.h>
+#include <shaderc/shaderc.hpp>
+
+#include "mlx/backend/vulkan/shader_compiler.h"
 
 namespace mlx::core::vulkan {
 
 namespace {
 
+bool env_flag_enabled(const char* name) {
+  const char* env = std::getenv(name);
+  return env != nullptr && std::string(env) != "0";
+}
+
 bool trace_shader_compile_enabled() {
   static const bool enabled = []() {
-    const char* env = std::getenv("MLX_VULKAN_TRACE_SHADER_COMPILE");
-    return env != nullptr && std::string(env) != "0";
+    return env_flag_enabled("MLX_VULKAN_TRACE_SHADER_COMPILE");
   }();
   return enabled;
+}
+
+bool dump_failed_shader_source_enabled() {
+  static const bool enabled = []() {
+    return env_flag_enabled("MLX_VULKAN_DUMP_FAILED_SHADER");
+  }();
+  return enabled;
+}
+
+shaderc_optimization_level shaderc_optimization_level_for(
+    DynamicShaderOptimization optimization) {
+  switch (optimization) {
+    case DynamicShaderOptimization::Zero:
+      return shaderc_optimization_level_zero;
+    case DynamicShaderOptimization::Size:
+      return shaderc_optimization_level_size;
+    case DynamicShaderOptimization::Performance:
+      return shaderc_optimization_level_performance;
+  }
+  return shaderc_optimization_level_performance;
+}
+
+shaderc::CompileOptions make_compile_options(
+    DynamicShaderOptimization optimization) {
+  shaderc::CompileOptions options;
+  options.SetTargetEnvironment(
+      shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_2);
+  options.SetSourceLanguage(shaderc_source_language_glsl);
+  options.SetForcedVersionProfile(450, shaderc_profile_core);
+  options.SetOptimizationLevel(shaderc_optimization_level_for(optimization));
+  return options;
+}
+
+shaderc::Compiler& shaderc_compiler() {
+  thread_local shaderc::Compiler compiler;
+  return compiler;
+}
+
+const shaderc::CompileOptions& compile_options_for(
+    DynamicShaderOptimization optimization) {
+  thread_local const shaderc::CompileOptions zero_options =
+      make_compile_options(DynamicShaderOptimization::Zero);
+  thread_local const shaderc::CompileOptions size_options =
+      make_compile_options(DynamicShaderOptimization::Size);
+  thread_local const shaderc::CompileOptions performance_options =
+      make_compile_options(DynamicShaderOptimization::Performance);
+  switch (optimization) {
+    case DynamicShaderOptimization::Zero:
+      return zero_options;
+    case DynamicShaderOptimization::Size:
+      return size_options;
+    case DynamicShaderOptimization::Performance:
+      return performance_options;
+  }
+  return performance_options;
+}
+
+std::mutex& spirv_cache_mutex() {
+  static auto* mutex = new std::mutex();
+  return *mutex;
+}
+
+std::unordered_map<std::string, std::vector<uint32_t>>& spirv_cache() {
+  static auto* cache =
+      new std::unordered_map<std::string, std::vector<uint32_t>>();
+  return *cache;
+}
+
+std::optional<std::vector<uint32_t>> get_cached_spirv(
+    const std::string& cache_key) {
+  std::lock_guard<std::mutex> lock(spirv_cache_mutex());
+  auto it = spirv_cache().find(cache_key);
+  if (it == spirv_cache().end()) {
+    return std::nullopt;
+  }
+  return it->second;
+}
+
+void cache_spirv(
+    const std::string& cache_key,
+    const std::vector<uint32_t>& spirv) {
+  std::lock_guard<std::mutex> lock(spirv_cache_mutex());
+  spirv_cache().try_emplace(cache_key, spirv);
+}
+
+std::string make_spirv_cache_key(
+    const std::string& glsl_source,
+    const DynamicShaderCompileOptions& options) {
+  return fmt::format(
+      "optimization:{}\n{}",
+      static_cast<int>(options.optimization),
+      glsl_source);
+}
+
+std::string source_excerpt(const std::string& glsl_source) {
+  constexpr size_t kMaxLines = 120;
+  std::istringstream input(glsl_source);
+  std::ostringstream excerpt;
+  std::string line;
+  size_t line_number = 1;
+  while (line_number <= kMaxLines && std::getline(input, line)) {
+    excerpt << line_number++ << ": " << line << '\n';
+  }
+  if (std::getline(input, line)) {
+    excerpt << "... truncated after " << kMaxLines << " lines ...\n";
+  }
+  return excerpt.str();
+}
+
+struct DynamicShaderFeatures {
+  bool needs_int64{false};
+  bool uses_float16{false};
+  bool uses_16bit_storage{false};
+  bool uses_8bit_storage{false};
+  bool uses_scalar_block_layout{false};
+};
+
+DynamicShaderFeatures collect_dynamic_shader_features(
+    const DynamicShaderPreambleOptions& options) {
+  DynamicShaderFeatures features;
+  features.needs_int64 = options.needs_int64;
+  for (Dtype dtype : options.dtypes) {
+    features.needs_int64 = features.needs_int64 || dtype == mlx::core::int64 ||
+        dtype == mlx::core::uint64;
+    features.uses_float16 =
+        features.uses_float16 || uses_float16_extension(dtype);
+    features.uses_16bit_storage =
+        features.uses_16bit_storage || uses_16bit_storage(dtype);
+    features.uses_8bit_storage =
+        features.uses_8bit_storage || uses_8bit_storage(dtype);
+  }
+  features.uses_scalar_block_layout =
+      options.needs_scalar_block_layout || features.uses_8bit_storage;
+  return features;
 }
 
 } // namespace
@@ -27,7 +171,23 @@ bool trace_shader_compile_enabled() {
 std::vector<uint32_t> compile_glsl_to_spirv(
     const std::string& glsl_source,
     const std::string& shader_name) {
+  return compile_glsl_to_spirv(glsl_source, shader_name, {});
+}
+
+std::vector<uint32_t> compile_glsl_to_spirv(
+    const std::string& glsl_source,
+    const std::string& shader_name,
+    const DynamicShaderCompileOptions& options) {
   const bool trace = trace_shader_compile_enabled();
+  const std::string cache_key = make_spirv_cache_key(glsl_source, options);
+
+  if (auto cached = get_cached_spirv(cache_key)) {
+    if (trace) {
+      std::cerr << "[vulkan-shader-compile] cache_hit: " << shader_name
+                << " spirv_words=" << cached->size() << "\n";
+    }
+    return *cached;
+  }
 
   if (trace) {
     std::cerr << "[vulkan-shader-compile] start: " << shader_name
@@ -36,21 +196,12 @@ std::vector<uint32_t> compile_glsl_to_spirv(
   const auto t0 = trace ? std::chrono::steady_clock::now()
                         : std::chrono::steady_clock::time_point{};
 
-  shaderc::Compiler compiler;
-  shaderc::CompileOptions options;
-
-  options.SetTargetEnvironment(
-      shaderc_target_env_vulkan, shaderc_env_version_vulkan_1_2);
-  options.SetSourceLanguage(shaderc_source_language_glsl);
-  options.SetForcedVersionProfile(450, shaderc_profile_core);
-  options.SetOptimizationLevel(shaderc_optimization_level_performance);
-
-  auto result = compiler.CompileGlslToSpv(
+  auto result = shaderc_compiler().CompileGlslToSpv(
       glsl_source.c_str(),
       glsl_source.size(),
       shaderc_compute_shader,
       shader_name.c_str(),
-      options);
+      compile_options_for(options.optimization));
 
   if (trace) {
     const auto t1 = std::chrono::steady_clock::now();
@@ -66,14 +217,19 @@ std::vector<uint32_t> compile_glsl_to_spirv(
   }
 
   if (result.GetCompilationStatus() != shaderc_compilation_status_success) {
-    throw std::runtime_error(
-        fmt::format(
-            "Failed to compile Vulkan kernel '{}': {}",
-            shader_name,
-            result.GetErrorMessage()));
+    std::string message = fmt::format(
+        "Failed to compile Vulkan kernel '{}': {}",
+        shader_name,
+        result.GetErrorMessage());
+    if (dump_failed_shader_source_enabled()) {
+      message += "\nGenerated GLSL excerpt:\n" + source_excerpt(glsl_source);
+    }
+    throw std::runtime_error(message);
   }
 
-  return std::vector<uint32_t>(result.cbegin(), result.cend());
+  std::vector<uint32_t> spirv(result.cbegin(), result.cend());
+  cache_spirv(cache_key, spirv);
+  return spirv;
 }
 
 std::string dtype_to_glsl_storage_type(Dtype dtype) {
@@ -110,6 +266,19 @@ std::string dtype_to_glsl_storage_type(Dtype dtype) {
   }
 }
 
+std::string dtype_to_glsl_compute_type(Dtype dtype) {
+  switch (dtype) {
+    case mlx::core::bfloat16:
+      return "float";
+    case mlx::core::complex64:
+      return "vec2";
+    case mlx::core::bool_:
+      return "bool";
+    default:
+      return dtype_to_glsl_storage_type(dtype);
+  }
+}
+
 bool uses_float16_extension(Dtype dtype) {
   return dtype == mlx::core::float16;
 }
@@ -124,54 +293,82 @@ bool uses_8bit_storage(Dtype dtype) {
       dtype == mlx::core::uint8;
 }
 
-std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output) {
+bool needs_bf16_conversion_helpers(Dtype in_dtype, Dtype out_dtype) {
+  return in_dtype == mlx::core::bfloat16 || out_dtype == mlx::core::bfloat16;
+}
+
+std::string emit_bf16_conversion_helpers() {
+  std::ostringstream os;
+  os << "uint fp32_to_bf16(float f) {\n";
+  os << "  uint u = floatBitsToUint(f);\n";
+  os << "  u = (u + (0x7fffu + ((u >> 16) & 1u))) >> 16;\n";
+  os << "  return u;\n";
+  os << "}\n\n";
+  os << "float bf16_to_fp32(uint u) {\n";
+  os << "  return uintBitsToFloat(u << 16);\n";
+  os << "}\n\n";
+  return os.str();
+}
+
+std::string storage_buffer_layout_for_dtype(Dtype dtype, uint32_t binding) {
+  return fmt::format(
+      "layout({}set = 0, binding = {})",
+      uses_8bit_storage(dtype) ? "scalar, " : "",
+      binding);
+}
+
+std::string emit_dynamic_shader_preamble(
+    const DynamicShaderPreambleOptions& options) {
+  if (!options.use_local_size_x_id && options.local_size_x == 0) {
+    throw std::runtime_error("Dynamic Vulkan shader local_size_x must be > 0.");
+  }
+
+  const auto features = collect_dynamic_shader_features(options);
   std::ostringstream os;
   os << "#version 450\n";
   os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
-  if (needs_int64_output || dtype == mlx::core::int64 ||
-      dtype == mlx::core::uint64) {
+  if (features.needs_int64) {
     os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
   }
-  if (uses_float16_extension(dtype)) {
+  if (features.uses_float16) {
     os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
   }
-  if (uses_16bit_storage(dtype)) {
+  if (features.uses_16bit_storage) {
     os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
     os << "#extension GL_EXT_shader_16bit_storage : require\n";
   }
-  if (uses_8bit_storage(dtype)) {
+  if (features.uses_8bit_storage) {
     os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
     os << "#extension GL_EXT_shader_8bit_storage : require\n";
   }
-  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  if (features.uses_scalar_block_layout) {
+    os << "#extension GL_EXT_scalar_block_layout : require\n";
+  }
+  if (options.use_local_size_x_id) {
+    os << "\nlayout(local_size_x_id = " << options.local_size_x_id
+       << ", local_size_y = 1, local_size_z = 1) in;\n\n";
+  } else {
+    os << "\nlayout(local_size_x = " << options.local_size_x
+       << ", local_size_y = 1, local_size_z = 1) in;\n\n";
+  }
   return os.str();
+}
+
+std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64) {
+  DynamicShaderPreambleOptions options;
+  options.dtypes = {dtype};
+  options.needs_int64 = needs_int64;
+  return emit_dynamic_shader_preamble(options);
 }
 
 std::string emit_dynamic_shader_preamble(
     Dtype in_dtype,
     Dtype out_dtype,
-    bool needs_int64_output) {
-  std::ostringstream os;
-  os << "#version 450\n";
-  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
-  if (needs_int64_output || in_dtype == mlx::core::int64 ||
-      in_dtype == mlx::core::uint64 || out_dtype == mlx::core::int64 ||
-      out_dtype == mlx::core::uint64) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int64 : require\n";
-  }
-  if (uses_float16_extension(in_dtype) || uses_float16_extension(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
-  }
-  if (uses_16bit_storage(in_dtype) || uses_16bit_storage(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
-    os << "#extension GL_EXT_shader_16bit_storage : require\n";
-  }
-  if (uses_8bit_storage(in_dtype) || uses_8bit_storage(out_dtype)) {
-    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require\n";
-    os << "#extension GL_EXT_shader_8bit_storage : require\n";
-  }
-  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
-  return os.str();
+    bool needs_int64) {
+  DynamicShaderPreambleOptions options;
+  options.dtypes = {in_dtype, out_dtype};
+  options.needs_int64 = needs_int64;
+  return emit_dynamic_shader_preamble(options);
 }
 
 std::string zero_literal_for_dtype(Dtype dtype) {
@@ -207,7 +404,36 @@ std::string zero_literal_for_dtype(Dtype dtype) {
 }
 
 std::string cast_expr_for_dtype(const std::string& expr, Dtype in, Dtype out) {
+  if (in == mlx::core::bfloat16 || out == mlx::core::bfloat16) {
+    if (in == mlx::core::bfloat16 && out == mlx::core::bfloat16) {
+      return expr;
+    }
+    auto expr_as_float = [&]() {
+      if (in == mlx::core::bfloat16) {
+        return "bf16_to_fp32(uint(" + expr + "))";
+      }
+      if (in == mlx::core::complex64) {
+        return expr + ".x";
+      }
+      return "float(" + expr + ")";
+    };
+    const std::string as_float = expr_as_float();
+    if (out == mlx::core::bfloat16) {
+      return "uint16_t(fp32_to_bf16(" + as_float + "))";
+    }
+    if (out == mlx::core::bool_) {
+      return "(" + as_float + " != 0.0 ? uint8_t(1) : uint8_t(0))";
+    }
+    if (out == mlx::core::complex64) {
+      return "vec2(" + as_float + ", 0.0)";
+    }
+    return dtype_to_glsl_storage_type(out) + "(" + as_float + ")";
+  }
   if (out == mlx::core::bool_) {
+    if (in == mlx::core::complex64) {
+      return "((" + expr + ".x != 0.0 || " + expr +
+          ".y != 0.0) ? uint8_t(1) : uint8_t(0))";
+    }
     return "((" + expr + ") != " + zero_literal_for_dtype(in) +
         " ? uint8_t(1) : uint8_t(0))";
   }

--- a/mlx/backend/vulkan/shader_compiler.h
+++ b/mlx/backend/vulkan/shader_compiler.h
@@ -3,7 +3,6 @@
 #pragma once
 
 #include <cstdint>
-#include <sstream>
 #include <string>
 #include <vector>
 
@@ -11,14 +10,40 @@
 
 namespace mlx::core::vulkan {
 
+enum class DynamicShaderOptimization {
+  Zero,
+  Size,
+  Performance,
+};
+
+struct DynamicShaderCompileOptions {
+  DynamicShaderOptimization optimization{DynamicShaderOptimization::Performance};
+};
+
 // Compile GLSL compute shader source to SPIR-V.
 // Throws std::runtime_error on compilation failure.
 std::vector<uint32_t> compile_glsl_to_spirv(
     const std::string& glsl_source,
     const std::string& shader_name);
+std::vector<uint32_t> compile_glsl_to_spirv(
+    const std::string& glsl_source,
+    const std::string& shader_name,
+    const DynamicShaderCompileOptions& options);
+
+struct DynamicShaderPreambleOptions {
+  std::vector<Dtype> dtypes;
+  bool needs_int64{false};
+  bool needs_scalar_block_layout{false};
+  bool use_local_size_x_id{false};
+  uint32_t local_size_x{256};
+  uint32_t local_size_x_id{0};
+};
 
 // Returns the GLSL storage type string for a dtype (e.g. "float", "uint16_t").
 std::string dtype_to_glsl_storage_type(Dtype dtype);
+
+// Returns the GLSL compute type string for a dtype (e.g. "bool" for bool_).
+std::string dtype_to_glsl_compute_type(Dtype dtype);
 
 // Returns true if the dtype requires the float16 GLSL extension.
 bool uses_float16_extension(Dtype dtype);
@@ -29,14 +54,27 @@ bool uses_16bit_storage(Dtype dtype);
 // Returns true if the dtype requires 8-bit storage extensions.
 bool uses_8bit_storage(Dtype dtype);
 
+// Returns true if a dtype pair needs bf16 conversion helper functions.
+bool needs_bf16_conversion_helpers(Dtype in_dtype, Dtype out_dtype);
+
+// Emits GLSL helpers for converting bf16 storage bits to and from fp32.
+std::string emit_bf16_conversion_helpers();
+
+// Emits a storage buffer layout prefix, adding scalar layout for 8-bit types.
+std::string storage_buffer_layout_for_dtype(Dtype dtype, uint32_t binding);
+
+// Emits a GLSL #version + extension preamble from explicit options.
+std::string emit_dynamic_shader_preamble(
+    const DynamicShaderPreambleOptions& options);
+
 // Emits a GLSL #version + extension preamble for a single-dtype shader.
-std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64_output);
+std::string emit_dynamic_shader_preamble(Dtype dtype, bool needs_int64);
 
 // Emits a GLSL #version + extension preamble for a cast shader (two dtypes).
 std::string emit_dynamic_shader_preamble(
     Dtype in_dtype,
     Dtype out_dtype,
-    bool needs_int64_output);
+    bool needs_int64);
 
 // Returns a GLSL zero literal for the given dtype.
 std::string zero_literal_for_dtype(Dtype dtype);


### PR DESCRIPTION
## Summary
- Serialize first-use dynamic shader registration per shader name.
- Reuse shaderc compiler/options and cache generated SPIR-V by GLSL source and compile options.
- Consolidate dynamic shader preamble/type helpers, add scalar 8-bit layouts, and make bf16 casts bit-correct.
- Avoid dynamic shader name collisions for mxfp gather QMM and use 32-bit copy indexing when safe.

Closes goniz/mlx-vulkan#46

## Verification
- `./dev.sh build`
- `./dev.sh test-cpp`: 249 test cases / 3314 assertions passed
- `./dev.sh test-py`: 699 passed / 13 skipped
- `./dev.sh model-report --max-tokens 32`: all default models generated coherent output

## Benchmarks

### `./dev.sh benchmark bf16`
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=2295.946, generation_tps=28.708, peak_memory=2.602, total_time=6.363
Trial 2:  prompt_tps=2284.733, generation_tps=28.632, peak_memory=2.603, total_time=6.390
Trial 3:  prompt_tps=2294.895, generation_tps=28.676, peak_memory=2.603, total_time=6.362
Trial 4:  prompt_tps=2288.677, generation_tps=28.620, peak_memory=2.603, total_time=6.384
Trial 5:  prompt_tps=2300.905, generation_tps=28.587, peak_memory=2.603, total_time=6.377
Averages: prompt_tps=2293.031, generation_tps=28.645, peak_memory=2.603
```

### `./dev.sh benchmark 8bit`
```text
Running benchmark for model: mlx-community/Qwen3-0.6B-8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1330.315, generation_tps=19.092, peak_memory=1.900, total_time=9.900
Trial 2:  prompt_tps=1328.005, generation_tps=18.795, peak_memory=1.900, total_time=10.015
Trial 3:  prompt_tps=1328.725, generation_tps=18.835, peak_memory=1.900, total_time=9.997
Trial 4:  prompt_tps=1330.893, generation_tps=18.577, peak_memory=1.901, total_time=10.085
Trial 5:  prompt_tps=1331.816, generation_tps=18.921, peak_memory=1.901, total_time=9.960
Averages: prompt_tps=1329.951, generation_tps=18.844, peak_memory=1.901
```