### PR TITLE
vulkan: native f16/bf16 argmax/argmin, optimize subtract scalar broad…

### DIFF
--- a/mlx/backend/vulkan/binary.cpp
+++ b/mlx/backend/vulkan/binary.cpp
@@ -1101,9 +1101,17 @@ bool try_eval_binary_op_vulkan(
 
   bool a_materialized = false;
   bool b_materialized = false;
-  auto materialize_broadcast_input = [&](array& in, bool& was_materialized) {
+  auto materialize_broadcast_input =
+      [&](array& in, bool& was_materialized, bool allow_scalar_view) {
     if (in.shape() == out.shape()) {
       if (in.data_size() == 1 && in.size() != 1) {
+        if (allow_scalar_view) {
+          array view(out.shape(), in.dtype(), nullptr, {});
+          broadcast(in, view);
+          in = view;
+          was_materialized = true;
+          return true;
+        }
         if (in.has_primitive()) {
           ensure_materialized_scalar_input(in);
         }
@@ -1118,6 +1126,13 @@ bool try_eval_binary_op_vulkan(
       return false;
     }
     if (in.data_size() == 1) {
+      if (allow_scalar_view) {
+        array view(out.shape(), in.dtype(), nullptr, {});
+        broadcast(in, view);
+        in = view;
+        was_materialized = true;
+        return true;
+      }
       array broadcast_arr(
           out.shape(),
           in.dtype(),
@@ -1140,8 +1155,13 @@ bool try_eval_binary_op_vulkan(
     return true;
   };
 
-  if ((!use_scalar_vector_fast_path && !materialize_broadcast_input(a, a_materialized)) ||
-      (!use_scalar_vector_fast_path && !materialize_broadcast_input(b, b_materialized))) {
+  const bool allow_subtract_scalar_rhs_view =
+      std::is_same_v<Primitive, Subtract> && b.data_size() == 1;
+  if ((!use_scalar_vector_fast_path &&
+       !materialize_broadcast_input(a, a_materialized, false)) ||
+      (!use_scalar_vector_fast_path &&
+       !materialize_broadcast_input(
+           b, b_materialized, allow_subtract_scalar_rhs_view))) {
     trace_binary_unsupported("broadcast_materialization_failed", a, b);
     return false;
   }

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2584,6 +2584,7 @@ void dispatch_sum_rows_op(
   const auto row_count = checked_u32(out.size(), "sum_rows output rows");
   const uint32_t block_size = push_constants.n_cols <= 32u ? 32u
       : push_constants.n_cols <= 64u                       ? 64u
+      : push_constants.n_cols >= 4096u                     ? 1024u
                                                            : 128u;
 
   const std::array<BoundArray, 2> bound_arrays = {{
@@ -2650,6 +2651,8 @@ void dispatch_argmax_op(
   const uint32_t row_width =
       checked_u32(in.shape(in.ndim() - 1), "argmax reduction width");
   const uint32_t row_count = checked_u32(out.size(), "argmax row count");
+  const uint32_t block_size =
+      row_width >= 4096u ? 1024u : (row_width <= 32u ? 32u : 128u);
   auto push_constants =
       make_generic_push_constants(row_width, 0.0f, 0.0f, 0.0f, 0.0f);
   push_constants.KY = row_count;
@@ -2667,7 +2670,7 @@ void dispatch_argmax_op(
       cmd_buffer,
       s,
       std::nullopt,
-      {32u});
+      {block_size});
 }
 
 void dispatch_argsort_op(
@@ -3484,6 +3487,7 @@ void dispatch_mul_mat_vec_op(
       VulkanContext::get().architecture() == GpuArchitecture::AmdRdna;
   const uint32_t col_chunk =
       force_single_column_dispatch ? 1u : kMaxMulMatVecCols;
+  const uint32_t block_size = nrows >= 65536u ? 128u : 32u;
 
   for (uint32_t base_work_group_y = 0; base_work_group_y < batch_rows;
        base_work_group_y += col_chunk) {
@@ -3492,7 +3496,7 @@ void dispatch_mul_mat_vec_op(
         std::min(col_chunk, batch_rows - base_work_group_y);
     const std::array<uint32_t, 3> grid = {groups_x, 1u, groups_z};
     const std::vector<uint32_t> specialization_constants = {
-        32u,
+        block_size,
         rows_per_workgroup,
         num_cols,
     };

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -33,6 +33,21 @@ uint32_t matvec_rows_per_workgroup() {
   return value;
 }
 
+uint32_t max_compute_work_group_invocations() {
+  static const uint32_t value = []() {
+    if (const char* env = std::getenv("MLX_VULKAN_MAX_WG_INVOCATIONS");
+        env != nullptr) {
+      return static_cast<uint32_t>(std::strtoul(env, nullptr, 10));
+    }
+    return VulkanContext::get()
+        .physical_device()
+        .getProperties()
+        .limits
+        .maxComputeWorkGroupInvocations;
+  }();
+  return value;
+}
+
 namespace {
 
 constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
@@ -2582,10 +2597,13 @@ void dispatch_sum_rows_op(
 
   const auto push_constants = make_sum_rows_push_constants(in, out, weight);
   const auto row_count = checked_u32(out.size(), "sum_rows output rows");
-  const uint32_t block_size = push_constants.n_cols <= 32u ? 32u
-      : push_constants.n_cols <= 64u                       ? 64u
-      : push_constants.n_cols >= 4096u                     ? 1024u
-                                                           : 128u;
+  const uint32_t max_invocations = max_compute_work_group_invocations();
+  const uint32_t block_size = std::min(
+      push_constants.n_cols <= 32u ? 32u
+          : push_constants.n_cols <= 64u                       ? 64u
+          : push_constants.n_cols >= 4096u                     ? 1024u
+                                                               : 128u,
+      max_invocations);
 
   const std::array<BoundArray, 2> bound_arrays = {{
       {&in, "src0"},
@@ -2651,8 +2669,10 @@ void dispatch_argmax_op(
   const uint32_t row_width =
       checked_u32(in.shape(in.ndim() - 1), "argmax reduction width");
   const uint32_t row_count = checked_u32(out.size(), "argmax row count");
-  const uint32_t block_size =
-      row_width >= 4096u ? 1024u : (row_width <= 32u ? 32u : 128u);
+  const uint32_t max_invocations = max_compute_work_group_invocations();
+  const uint32_t block_size = std::min(
+      row_width >= 4096u ? 1024u : (row_width <= 32u ? 32u : 128u),
+      max_invocations);
   auto push_constants =
       make_generic_push_constants(row_width, 0.0f, 0.0f, 0.0f, 0.0f);
   push_constants.KY = row_count;

--- a/mlx/backend/vulkan/kernels/argmax.comp
+++ b/mlx/backend/vulkan/kernels/argmax.comp
@@ -18,8 +18,16 @@ layout (binding = 1) writeonly buffer D {D_TYPE data_d[];};
 
 layout (constant_id = 0) const uint BLOCK_SIZE = 32;
 
-shared FLOAT_TYPE tmpmax[BLOCK_SIZE];
+shared float tmpmax[BLOCK_SIZE];
 shared uint tmp[BLOCK_SIZE];
+
+float load_value(uint idx) {
+#if defined(DATA_A_BF16)
+    return bf16_to_fp32(uint(data_a[idx]));
+#else
+    return float(data_a[idx]);
+#endif
+}
 
 void main() {
     const uint row = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
@@ -29,15 +37,15 @@ void main() {
         return;
     }
 
-    A_TYPE amax = ARGMIN != 0 ? A_TYPE(FLT_MAX) : A_TYPE(-FLT_MAX);
+    float amax = ARGMIN != 0 ? FLT_MAX : -FLT_MAX;
     uint acol = col;
 
     if (col < p.KX) {
-        amax = data_a[row*p.KX + col];
+        amax = load_value(row*p.KX + col);
     }
 
     for (uint i = col + BLOCK_SIZE; i < p.KX; i += BLOCK_SIZE) {
-        A_TYPE val = data_a[row*p.KX + i];
+        float val = load_value(row*p.KX + i);
         if ((ARGMIN != 0 && val < amax) || (ARGMIN == 0 && val > amax)) {
             amax = val;
             acol = i;

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2998,11 +2998,36 @@ void process_shaders() {
       "argmax.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "int"}}));
   string_to_spv(
+      "argmax_f16",
+      "argmax.comp",
+      merge_maps(base_dict, {{"A_TYPE", "float16_t"}, {"D_TYPE", "int"}}));
+  string_to_spv(
+      "argmax_bf16",
+      "argmax.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"}, {"D_TYPE", "int"}, {"DATA_A_BF16", "1"}}));
+  string_to_spv(
       "argmin_f32",
       "argmax.comp",
       merge_maps(
           base_dict,
           {{"A_TYPE", "float"}, {"D_TYPE", "int"}, {"ARGMIN", "1"}}));
+  string_to_spv(
+      "argmin_f16",
+      "argmax.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "float16_t"}, {"D_TYPE", "int"}, {"ARGMIN", "1"}}));
+  string_to_spv(
+      "argmin_bf16",
+      "argmax.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"D_TYPE", "int"},
+           {"ARGMIN", "1"},
+           {"DATA_A_BF16", "1"}}));
   string_to_spv(
       "sum_rows_f32",
       "sum_rows.comp",

--- a/mlx/backend/vulkan/reduce.cpp
+++ b/mlx/backend/vulkan/reduce.cpp
@@ -795,12 +795,13 @@ bool try_eval_arg_reduce_vulkan(
   }
 
   array in = inputs[0];
-  const bool f32_input = in.dtype() == float32;
+  const bool supported_input =
+      in.dtype() == float32 || in.dtype() == float16 || in.dtype() == bfloat16;
   if (in.ndim() == 0 || in.dtype() == float64 || out.dtype() != uint32) {
     return false;
   }
 
-  if (!f32_input) {
+  if (!supported_input) {
     array in_f32(in.shape(), float32, nullptr, {});
     copy_gpu(in, in_f32, CopyType::General, s);
     in = in_f32;
@@ -859,9 +860,17 @@ bool try_eval_arg_reduce_vulkan(
 
   try {
     auto command_buffer = vulkan::begin_command_recording(s.index);
-    const auto shader_id = reduce_type == ArgReduce::ArgMin
-        ? vulkan::StaticShaderId::argmin_f32
-        : vulkan::StaticShaderId::argmax_f32;
+    const auto shader_id = [&]() {
+      if (reduce_type == ArgReduce::ArgMin) {
+        return in_kernel.dtype() == bfloat16
+            ? vulkan::StaticShaderId::argmin_bf16
+            : in_kernel.dtype() == float16 ? vulkan::StaticShaderId::argmin_f16
+                                           : vulkan::StaticShaderId::argmin_f32;
+      }
+      return in_kernel.dtype() == bfloat16 ? vulkan::StaticShaderId::argmax_bf16
+          : in_kernel.dtype() == float16   ? vulkan::StaticShaderId::argmax_f16
+                                           : vulkan::StaticShaderId::argmax_f32;
+    }();
     vulkan::dispatch_argmax_op(
         in_kernel, out_work, shader_id, command_buffer, s);
     vulkan::end_command_recording(s.index);


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Vulkan backend, mainly focusing on enhanced support for different floating point types (including `float16` and `bfloat16`) in argmax/argmin operations, more flexible broadcasting for binary operations, and improved kernel dispatch efficiency. Below are the most important changes:

### Enhanced Data Type Support for Argmax/Argmin

* Added support for `float16` and `bfloat16` data types in argmax and argmin Vulkan shaders, including proper type handling and kernel dispatch logic in both the shader code and C++ backend (`argmax.comp`, `vulkan-shaders-gen.cpp`, `reduce.cpp`). [[1]](diffhunk://#diff-2c4e2b779d23918d42f55d7050b91d1b7cbd7dc42d598b004aab53490288be43L21-R31) [[2]](diffhunk://#diff-2c4e2b779d23918d42f55d7050b91d1b7cbd7dc42d598b004aab53490288be43L32-R48) [[3]](diffhunk://#diff-f70b331e6a1cc0a7faa5a85448d1f2949bc5cbdbb1338a356f131c471e9675baR3000-R3030) [[4]](diffhunk://#diff-b8f6ccb6a864b7f3f70e5047b503295679dac825edcf0904b273bca58efba36aL798-R804) [[5]](diffhunk://#diff-b8f6ccb6a864b7f3f70e5047b503295679dac825edcf0904b273bca58efba36aL862-R873)

### Improved Broadcasting Logic

* Updated the broadcasting logic in `try_eval_binary_op_vulkan` to allow scalar views for specific cases (e.g., when subtracting a scalar from a tensor), reducing unnecessary materialization and improving performance. [[1]](diffhunk://#diff-bac0a5028c1d16c2ee3791f0ec8de33d08174eaf746562c1ea0442c430cdaed6L1104-R1114) [[2]](diffhunk://#diff-bac0a5028c1d16c2ee3791f0ec8de33d08174eaf746562c1ea0442c430cdaed6R1129-R1135) [[3]](diffhunk://#diff-bac0a5028c1d16c2ee3791f0ec8de33d08174eaf746562c1ea0442c430cdaed6L1143-R1164)

### Kernel Dispatch Optimization

* Dynamically determined block sizes for `sum_rows`, `argmax`, and `mul_mat_vec` kernels based on input size, enabling better performance on large workloads. [[1]](diffhunk://#diff-d37f6fea69fd920b7408b2116ec194114fa509f3f98e5e74de8ac0703c62c34eR2587) [[2]](diffhunk://#diff-d37f6fea69fd920b7408b2116ec194114fa509f3f98e5e74de8ac0703c62c34eR2654-R2655) [[3]](diffhunk://#diff-d37f6fea69fd920b7408b2116ec194114fa509f3f98e5e74de8ac0703c62c34eL2670-R2673) [[4]](diffhunk://#diff-d37f6fea69fd920b7408b2116ec194114fa509f3f98e5e74de8ac0703c62c34eR3490) [[5]](diffhunk://#diff-d37f6fea69fd920b7408b2116ec194114fa509f3f98e5e74de8ac0703c62c34eL3495-R3499)

### Shader Code Improvements

* Refactored the argmax shader to use explicit float operations and added a helper function for correct `bfloat16` to `float32` conversion, ensuring numerical correctness across data types. [[1]](diffhunk://#diff-2c4e2b779d23918d42f55d7050b91d1b7cbd7dc42d598b004aab53490288be43L21-R31) [[2]](diffhunk://#diff-2c4e2b779d23918d42f55d7050b91d1b7cbd7dc42d598b004aab53490288be43L32-R48)

These changes collectively make the Vulkan backend more robust, efficient, and compatible with a wider range of tensor data types.