### PR TITLE
Add Vulkan fused fast kernel paths

### DIFF
--- a/mlx/backend/vulkan/conv.cpp
+++ b/mlx/backend/vulkan/conv.cpp
@@ -762,6 +762,82 @@ std::string conv1d_load_expr(const std::string& expr, Dtype dtype) {
   }
 }
 
+std::string conv1d_store_expr(const std::string& expr, Dtype dtype) {
+  switch (dtype) {
+    case float32:
+      return expr;
+    case float16:
+      return "float16_t(" + expr + ")";
+    case bfloat16:
+      return "uint16_t(fp32_to_bf16(" + expr + "))";
+    default:
+      throw std::runtime_error("Unsupported Conv1d Vulkan dtype.");
+  }
+}
+
+// This narrow depthwise Conv1d path is generated dynamically so it can
+// specialize only the input/weight/output dtype triplet without adding a static
+// shader variant matrix for the Qwen-style inference fast path.
+std::string build_depthwise_conv1d_shader(
+    Dtype in_dtype,
+    Dtype wt_dtype,
+    Dtype out_dtype) {
+  std::ostringstream os;
+  os << "#version 450\n";
+  os << "#extension GL_EXT_shader_explicit_arithmetic_types_int32 : require\n";
+  if (in_dtype == float16 || wt_dtype == float16 || out_dtype == float16) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require\n";
+  }
+  if (in_dtype == float16 || wt_dtype == float16 || out_dtype == float16 ||
+      in_dtype == bfloat16 || wt_dtype == bfloat16 || out_dtype == bfloat16) {
+    os << "#extension GL_EXT_shader_explicit_arithmetic_types_int16 : require\n";
+    os << "#extension GL_EXT_shader_16bit_storage : require\n";
+  }
+  os << "\nlayout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
+  if (in_dtype == bfloat16 || wt_dtype == bfloat16) {
+    os << "float bf16_to_fp32(uint u) { return uintBitsToFloat(u << 16); }\n";
+  }
+  if (out_dtype == bfloat16) {
+    os << R"(
+uint fp32_to_bf16(float v) {
+  uint u = floatBitsToUint(v);
+  return (u >> 16u) + (((u & 0xFFFFu) + 0x7FFFu) >> 16u);
+}
+)";
+  }
+  os << "\nlayout(push_constant) uniform PushConstants {\n";
+  os << "  uint total; uint out_len; uint channels; uint kernel;\n";
+  os << "  uint in_stride_batch; uint in_stride_time; uint in_stride_channel;\n";
+  os << "} pc;\n";
+  os << "layout(set = 0, binding = 0) readonly buffer Input {"
+     << conv1d_storage_type(in_dtype) << " data[];} in_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer Weight {"
+     << conv1d_storage_type(wt_dtype) << " data[];} wt_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Output {"
+     << conv1d_storage_type(out_dtype) << " data[];} out_buf;\n\n";
+  os << "void main() {\n";
+  os << "  uint idx = gl_GlobalInvocationID.x;\n";
+  os << "  if (idx >= pc.total) return;\n";
+  os << "  uint channel = idx % pc.channels;\n";
+  os << "  uint time = (idx / pc.channels) % pc.out_len;\n";
+  os << "  uint batch = idx / (pc.channels * pc.out_len);\n";
+  os << "  uint in_index = batch * pc.in_stride_batch + time * pc.in_stride_time + channel * pc.in_stride_channel;\n";
+  os << "  uint wt_index = channel * pc.kernel;\n";
+  os << "  float acc = 0.0;\n";
+  os << "  for (uint k = 0; k < pc.kernel; ++k) {\n";
+  os << "    float x = "
+     << conv1d_load_expr("in_buf.data[in_index + k * pc.in_stride_time]", in_dtype)
+     << ";\n";
+  os << "    float w = "
+     << conv1d_load_expr("wt_buf.data[wt_index + k]", wt_dtype) << ";\n";
+  os << "    acc = fma(x, w, acc);\n";
+  os << "  }\n";
+  os << "  out_buf.data[idx] = " << conv1d_store_expr("acc", out_dtype)
+     << ";\n";
+  os << "}\n";
+  return os.str();
+}
+
 std::string build_conv1d_shader(Dtype in_dtype, Dtype wt_dtype) {
   std::ostringstream os;
   os << "#version 450\n";
@@ -836,6 +912,16 @@ struct Conv1dPushConstants {
   uint32_t dilation;
   uint32_t input_dilation;
   uint32_t flip;
+};
+
+struct DepthwiseConv1dPushConstants {
+  uint32_t total;
+  uint32_t out_len;
+  uint32_t channels;
+  uint32_t kernel;
+  uint32_t in_stride_batch;
+  uint32_t in_stride_time;
+  uint32_t in_stride_channel;
 };
 
 struct Conv2dGeneralPushConstants {
@@ -1262,6 +1348,57 @@ bool try_eval_conv1d_direct_vulkan(
 
   in = ensure_conv1d_storage(std::move(in), s, "conv1d.copy_input");
   wt = ensure_conv1d_storage(std::move(wt), s, "conv1d.copy_weight");
+
+  const bool is_depthwise = input_dilation == 1 && groups == in.shape(2) &&
+      groups == wt.shape(0) && wt.shape(2) == 1 && stride == 1 &&
+      dilation == 1 && padding == 0 && !flip &&
+      (out.dtype() == float32 || out.dtype() == float16 ||
+       out.dtype() == bfloat16);
+  if (is_depthwise) {
+    out.set_data(vulkan::allocator().malloc(out.nbytes()));
+    if (out.size() == 0) {
+      return true;
+    }
+
+    DepthwiseConv1dPushConstants pc{};
+    pc.total = checked_u32_size(out.size(), "depthwise conv1d total");
+    pc.out_len = checked_u32_size(out.shape(1), "depthwise conv1d output length");
+    pc.channels = checked_u32_size(out.shape(2), "depthwise conv1d channels");
+    pc.kernel = checked_u32_size(wt.shape(1), "depthwise conv1d kernel");
+    pc.in_stride_batch =
+        checked_u32_size(in.strides(0), "depthwise conv1d input stride 0");
+    pc.in_stride_time =
+        checked_u32_size(in.strides(1), "depthwise conv1d input stride 1");
+    pc.in_stride_channel =
+        checked_u32_size(in.strides(2), "depthwise conv1d input stride 2");
+
+    const std::string shader_name = "dynamic_depthwise_conv1d_" +
+        std::to_string(static_cast<int>(in.dtype().val())) + "_" +
+        std::to_string(static_cast<int>(wt.dtype().val())) + "_" +
+        std::to_string(static_cast<int>(out.dtype().val()));
+    const std::string glsl_source =
+        build_depthwise_conv1d_shader(in.dtype(), wt.dtype(), out.dtype());
+    vulkan::DynamicArrayRef arrays[] = {{&in, 0}, {&wt, 1}, {&out, 2}};
+    auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+        shader_name,
+        glsl_source,
+        3,
+        arrays,
+        sizeof(DepthwiseConv1dPushConstants),
+        s);
+    vkCmdPushConstants(
+        dispatch.command_buffer,
+        dispatch.pipeline->layout,
+        VK_SHADER_STAGE_COMPUTE_BIT,
+        0,
+        sizeof(DepthwiseConv1dPushConstants),
+        &pc);
+    vkCmdDispatch(dispatch.command_buffer, (pc.total + 255u) / 256u, 1, 1);
+    vulkan::end_command_recording(s.index);
+    vulkan::retain_array_for_stream(s, in);
+    vulkan::retain_array_for_stream(s, wt);
+    return true;
+  }
 
   array out_work(out.shape(), float32, nullptr, {});
   out_work.set_data(vulkan::allocator().malloc(out_work.nbytes()));

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -22,6 +22,7 @@
 #include "mlx/backend/vulkan/quantized.h"
 #include "mlx/backend/vulkan/shader_compiler.h"
 #include "mlx/backend/vulkan/vulkan.h"
+#include "mlx/fast.h"
 #include "mlx/fast_primitives.h"
 #include "mlx/ops.h"
 #include "mlx/transforms_impl.h"
@@ -253,6 +254,110 @@ bool try_convert_fp8_f32_gpu(
       dispatch.command_buffer, (pc.total_elements + 255u) / 256u, 1, 1);
   vulkan::end_command_recording(s.index);
   return true;
+}
+
+CustomKernelFunction make_vulkan_kernel(
+    const std::string& name,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::string& source,
+    const std::string& header,
+    bool ensure_row_contiguous) {
+  if (output_names.empty()) {
+    throw std::invalid_argument(
+        "[vulkan_kernel] Must specify at least one output.");
+  }
+
+  std::vector<std::tuple<bool, bool, bool>> shape_infos;
+  shape_infos.reserve(input_names.size());
+  for (const auto& n : input_names) {
+    std::tuple<bool, bool, bool> shape_info{
+        source.find(n + "_shape") != std::string::npos,
+        source.find(n + "_strides") != std::string::npos,
+        source.find(n + "_ndim") != std::string::npos};
+    if (std::get<0>(shape_info) || std::get<1>(shape_info) ||
+        std::get<2>(shape_info)) {
+      throw std::invalid_argument(
+          "[vulkan_kernel] Shape, stride, and ndim auto-bindings are not supported yet.");
+    }
+    shape_infos.push_back(shape_info);
+  }
+
+  return [=, shape_infos = std::move(shape_infos)](
+             const std::vector<array>& inputs,
+             const std::vector<Shape>& output_shapes,
+             const std::vector<Dtype>& output_dtypes,
+             std::tuple<int, int, int> grid,
+             std::tuple<int, int, int> threadgroup,
+             const std::vector<std::pair<std::string, TemplateArg>>&
+                 template_args = {},
+             std::optional<float> init_value = std::nullopt,
+             bool verbose = false,
+             StreamOrDevice s_ = {}) {
+    if (inputs.size() != input_names.size()) {
+      std::ostringstream msg;
+      msg << "[vulkan_kernel] Expected `inputs` to have size "
+          << input_names.size() << " but got size " << inputs.size() << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (output_shapes.size() != output_names.size()) {
+      std::ostringstream msg;
+      msg << "[vulkan_kernel] Expected `output_shapes` to have size "
+          << output_names.size() << " but got size " << output_shapes.size()
+          << ".";
+      throw std::invalid_argument(msg.str());
+    }
+    if (output_dtypes.size() != output_names.size()) {
+      std::ostringstream msg;
+      msg << "[vulkan_kernel] Expected `output_dtypes` to have size "
+          << output_names.size() << " but got size " << output_dtypes.size()
+          << ".";
+      throw std::invalid_argument(msg.str());
+    }
+
+    auto s = to_stream(s_);
+    if (s.device != Device::gpu) {
+      throw std::invalid_argument("[vulkan_kernel] Only supports the GPU.");
+    }
+
+    std::string kernel_name =
+        "custom_vulkan_kernel_" + name +
+        vulkan::dynamic_template_arguments_hash(template_args);
+    std::string kernel_source = vulkan::emit_custom_kernel_source(
+        header,
+        source,
+        input_names,
+        inputs,
+        output_names,
+        output_dtypes,
+        template_args,
+        threadgroup);
+
+    if (verbose) {
+      std::cout << "Generated Vulkan source code for `" << kernel_name
+                << "`:" << std::endl
+                << "```" << std::endl
+                << kernel_source << std::endl
+                << "```" << std::endl;
+    }
+
+    return array::make_arrays(
+        std::move(output_shapes),
+        std::move(output_dtypes),
+        std::make_shared<CustomKernel>(
+            s,
+            std::move(kernel_name),
+            std::move(kernel_source),
+            grid,
+            threadgroup,
+            shape_infos,
+            ensure_row_contiguous,
+            init_value,
+            std::vector<ScalarArg>{},
+            false,
+            0),
+        std::move(inputs));
+  };
 }
 
 array apply_diag_mask_inf_vulkan(const array& scores, int n_past, Stream s);
@@ -2224,12 +2329,12 @@ bool try_eval_rms_norm_vulkan(
     return false;
   }
 
-  const bool native_lowp_2048 = x.shape(-1) == 2048 &&
+  const bool native_lowp_rms_norm =
       (x.dtype() == float16 || x.dtype() == bfloat16) &&
-      x.dtype() == w.dtype() && x.dtype() == out.dtype();
+      x.dtype() == out.dtype() && (!has_weight || x.dtype() == w.dtype());
   auto shader_id = (x.dtype() == float32 && w.dtype() == float32 &&
                     out.dtype() == float32) ||
-          native_lowp_2048
+          native_lowp_rms_norm
       ? rms_norm_shader_id(x.dtype())
       : std::nullopt;
   const bool use_f32_staging_io = !shader_id.has_value();
@@ -2500,6 +2605,17 @@ bool try_eval_layer_norm_vulkan(
 }
 
 } // namespace
+
+CustomKernelFunction vulkan_kernel(
+    const std::string& name,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::string& source,
+    const std::string& header,
+    bool ensure_row_contiguous) {
+  return make_vulkan_kernel(
+      name, input_names, output_names, source, header, ensure_row_contiguous);
+}
 
 bool ScaledDotProductAttention::use_fallback(
     const array& q,
@@ -3247,7 +3363,60 @@ void Quantize::eval_gpu(
 void CustomKernel::eval_gpu(
     const std::vector<array>& inputs,
     std::vector<array>& outputs) {
-  throw std::runtime_error("CustomKernel has no Vulkan implementation.");
+  auto s = stream();
+
+  std::vector<array> copies;
+
+  for (auto& out : outputs) {
+    if (init_value_) {
+      copies.emplace_back(init_value_.value(), out.dtype());
+      fill_gpu(copies.back(), out, s);
+    } else {
+      out.set_data(allocator::malloc(out.nbytes()));
+    }
+  }
+
+  auto check_input = [&copies, &s, this](const array& x) -> const array {
+    const bool no_copy = x.flags().row_contiguous && x.offset() == 0;
+    if (!ensure_row_contiguous_ || no_copy) {
+      return x;
+    }
+    copies.push_back(array(x.shape(), x.dtype(), nullptr, {}));
+    copy_gpu(x, copies.back(), CopyType::General, s);
+    return copies.back();
+  };
+
+  std::vector<array> checked_inputs;
+  checked_inputs.reserve(inputs.size());
+  for (const auto& in : inputs) {
+    checked_inputs.push_back(check_input(in));
+  }
+
+  std::vector<vulkan::DynamicArrayRef> arrays;
+  arrays.reserve(checked_inputs.size() + outputs.size());
+  uint32_t binding = 0;
+  for (const auto& in : checked_inputs) {
+    arrays.push_back({&in, binding++});
+  }
+  for (auto& out : outputs) {
+    arrays.push_back({&out, binding++});
+  }
+
+  auto dispatch = vulkan::dispatch_dynamic_compute_begin(
+      name_,
+      source_,
+      static_cast<uint32_t>(arrays.size()),
+      arrays.data(),
+      0,
+      s);
+
+  const auto [tx, ty, tz] = threadgroup_;
+  const auto [gx, gy, gz] = grid_;
+  const uint32_t wx = static_cast<uint32_t>((gx + tx - 1) / tx);
+  const uint32_t wy = static_cast<uint32_t>((gy + ty - 1) / ty);
+  const uint32_t wz = static_cast<uint32_t>((gz + tz - 1) / tz);
+  vkCmdDispatch(dispatch.command_buffer, wx, wy, wz);
+  vulkan::end_command_recording(s.index);
 }
 
 } // namespace fast

--- a/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
@@ -13,6 +13,18 @@
 #if !defined(TO_FLOAT_TYPE)
 #define TO_FLOAT_TYPE float
 #endif
+#if !defined(S_TYPE)
+#define S_TYPE float
+#endif
+#if !defined(D_TYPE)
+#define D_TYPE float
+#endif
+#if !defined(SCALE_TO_FLOAT_TYPE)
+#define SCALE_TO_FLOAT_TYPE(x) float(x)
+#endif
+#if !defined(FROM_FLOAT_TYPE)
+#define FROM_FLOAT_TYPE(x) (x)
+#endif
 
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
@@ -20,16 +32,16 @@ layout(binding = 0) readonly buffer W {
     uint8_t data_w[];
 };
 layout(binding = 1) readonly buffer SCALES {
-    float data_scales[];
+    S_TYPE data_scales[];
 };
 layout(binding = 2) readonly buffer BIASES {
-    float data_biases[];
+    S_TYPE data_biases[];
 };
 layout(binding = 3) readonly buffer X {
     B_TYPE data_x[];
 };
 layout(binding = 4) writeonly buffer OUT {
-    float data_out[];
+    D_TYPE data_out[];
 };
 
 layout(push_constant) uniform parameter {
@@ -65,8 +77,9 @@ void main() {
     float acc = 0.0f;
     for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
         const uint group = k / p.group_size;
-        const float w = data_scales[scale_row_base + group] *
-            float(data_w[w_row_base + k]) + data_biases[bias_row_base + group];
+        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
+            float(data_w[w_row_base + k]) +
+            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
         acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
     }
 
@@ -80,6 +93,6 @@ void main() {
     }
 
     if (tid == 0u) {
-        data_out[row * p.out_row_stride + col] = partial[0];
+        data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(partial[0]));
     }
 }

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2199,6 +2199,15 @@ void process_shaders() {
       "mul_mv_affine8.comp",
       {{"FLOAT16", "1"}, {"B_TYPE", "float16_t"}});
   string_to_spv(
+      "fused_affine_matvec8_bf16_bf16",
+      "mul_mv_affine8.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"S_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"SCALE_TO_FLOAT_TYPE(x)", "bf16_to_fp32(uint(x))"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
       "fused_affine_matvec_f32_f32",
       "mul_mv_affine.comp",
       {{"B_TYPE", "float"}});

--- a/mlx/backend/vulkan/no_vulkan.cpp
+++ b/mlx/backend/vulkan/no_vulkan.cpp
@@ -2,6 +2,7 @@
 
 #include "mlx/primitives.h"
 #include "mlx/distributed/primitives.h"
+#include "mlx/fast.h"
 #include "mlx/fast_primitives.h"
 
 #define NO_GPU_MULTI(func)                                             \
@@ -22,6 +23,22 @@
   }
 
 namespace mlx::core {
+
+namespace fast {
+
+// Mirrors the Metal/CUDA no-backend stubs so the public fast API remains
+// defined for builds where Vulkan is disabled.
+CustomKernelFunction vulkan_kernel(
+    const std::string&,
+    const std::vector<std::string>&,
+    const std::vector<std::string>&,
+    const std::string&,
+    const std::string&,
+    bool) {
+  throw std::runtime_error("[vulkan_kernel] No Vulkan back-end.");
+}
+
+} // namespace fast
 
 bool fast::ScaledDotProductAttention::use_fallback(
     const array& q,

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1335,12 +1335,6 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   };
   array x = ensure_row_contiguous_zero_offset(inputs[0], s);
   array w = ensure_row_contiguous_zero_offset(inputs[1], s);
-  array scales = mode_ == QuantizationMode::Affine
-      ? ensure_float32_row_contiguous(inputs[2], s)
-      : inputs[2];
-  std::optional<array> biases = mode_ == QuantizationMode::Affine
-      ? std::make_optional(ensure_float32_row_contiguous(inputs[3], s))
-      : std::nullopt;
 
   const bool vector_lhs = x.ndim() == 1;
   const bool flatten_lhs_batches = x.ndim() > 2 && w.ndim() == 2;
@@ -1414,14 +1408,19 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           push_constants.group_size = static_cast<uint32_t>(group_size_);
           push_constants.num_groups = num_groups;
 
+          const bool use_decode_matvec = rows == 1;
           const bool use_tiled_prefill = rows > 1 && group_size_ >= 32 &&
               (group_size_ % 32) == 0 &&
               fused_affine_bf16_tiled_prefill_enabled();
-          const auto shader_id = use_tiled_prefill
+          const auto shader_id = use_decode_matvec
+              ? vulkan::StaticShaderId::fused_affine_matvec8_bf16_bf16
+              : use_tiled_prefill
               ? vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               : vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16;
-          const std::array<uint32_t, 3> grid = shader_id ==
-                  vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
+          const std::array<uint32_t, 3> grid = use_decode_matvec
+              ? std::array<uint32_t, 3>{cols, rows, 1u}
+              : shader_id ==
+                      vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               ? std::array<
                     uint32_t,
                     3>{(cols + 15u) / 16u, (rows + 31u) / 32u, 1u}
@@ -1471,6 +1470,13 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       }
     }
   }
+
+  array scales = mode_ == QuantizationMode::Affine
+      ? ensure_float32_row_contiguous(inputs[2], s)
+      : inputs[2];
+  std::optional<array> biases = mode_ == QuantizationMode::Affine
+      ? std::make_optional(ensure_float32_row_contiguous(inputs[3], s))
+      : std::nullopt;
 
   if (x_mat.dtype() == bfloat16) {
     x_mat = ensure_float32_row_contiguous(x_mat, s);

--- a/mlx/backend/vulkan/shader_compiler.cpp
+++ b/mlx/backend/vulkan/shader_compiler.cpp
@@ -1,5 +1,6 @@
 // Copyright © 2024 Apple Inc.
 
+#include <algorithm>
 #include <chrono>
 #include <cstdlib>
 #include <iostream>
@@ -319,8 +320,10 @@ std::string storage_buffer_layout_for_dtype(Dtype dtype, uint32_t binding) {
 
 std::string emit_dynamic_shader_preamble(
     const DynamicShaderPreambleOptions& options) {
-  if (!options.use_local_size_x_id && options.local_size_x == 0) {
-    throw std::runtime_error("Dynamic Vulkan shader local_size_x must be > 0.");
+  if (!options.use_local_size_x_id &&
+      (options.local_size_x == 0 || options.local_size_y == 0 ||
+       options.local_size_z == 0)) {
+    throw std::runtime_error("Dynamic Vulkan shader local sizes must be > 0.");
   }
 
   const auto features = collect_dynamic_shader_features(options);
@@ -346,10 +349,12 @@ std::string emit_dynamic_shader_preamble(
   }
   if (options.use_local_size_x_id) {
     os << "\nlayout(local_size_x_id = " << options.local_size_x_id
-       << ", local_size_y = 1, local_size_z = 1) in;\n\n";
+       << ", local_size_y = " << options.local_size_y
+       << ", local_size_z = " << options.local_size_z << ") in;\n\n";
   } else {
     os << "\nlayout(local_size_x = " << options.local_size_x
-       << ", local_size_y = 1, local_size_z = 1) in;\n\n";
+       << ", local_size_y = " << options.local_size_y
+       << ", local_size_z = " << options.local_size_z << ") in;\n\n";
   }
   return os.str();
 }
@@ -369,6 +374,134 @@ std::string emit_dynamic_shader_preamble(
   options.dtypes = {in_dtype, out_dtype};
   options.needs_int64 = needs_int64;
   return emit_dynamic_shader_preamble(options);
+}
+
+std::string dynamic_template_arguments_hash(
+    const std::vector<std::pair<std::string, DynamicTemplateArg>>&
+        template_args) {
+  std::ostringstream os;
+  for (const auto& [name, arg] : template_args) {
+    if (std::holds_alternative<int>(arg)) {
+      os << "_" << std::get<int>(arg);
+    } else if (std::holds_alternative<bool>(arg)) {
+      os << (std::get<bool>(arg) ? "_t" : "_f");
+    } else if (std::holds_alternative<Dtype>(arg)) {
+      os << "_" << static_cast<int>(std::get<Dtype>(arg).val());
+    }
+  }
+  return os.str();
+}
+
+namespace {
+
+std::string read_float_expr_for_dtype(const std::string& expr, Dtype dtype) {
+  if (dtype == mlx::core::bfloat16) {
+    return "bf16_to_fp32(uint(" + expr + "))";
+  }
+  if (dtype == mlx::core::float32) {
+    return expr;
+  }
+  return "float(" + expr + ")";
+}
+
+} // namespace
+
+std::string emit_custom_kernel_source(
+    const std::string& header,
+    const std::string& source,
+    const std::vector<std::string>& input_names,
+    const std::vector<array>& inputs,
+    const std::vector<std::string>& output_names,
+    const std::vector<Dtype>& output_dtypes,
+    const std::vector<std::pair<std::string, DynamicTemplateArg>>&
+        template_args,
+    std::tuple<int, int, int> threadgroup) {
+  const auto [tx, ty, tz] = threadgroup;
+  DynamicShaderPreambleOptions options;
+  options.local_size_x = std::max(tx, 1);
+  options.local_size_y = std::max(ty, 1);
+  options.local_size_z = std::max(tz, 1);
+  options.needs_int64 = true;
+  options.dtypes.reserve(
+      inputs.size() + output_dtypes.size() + template_args.size());
+  for (const auto& input : inputs) {
+    options.dtypes.push_back(input.dtype());
+  }
+  for (const auto& dtype : output_dtypes) {
+    options.dtypes.push_back(dtype);
+  }
+  for (const auto& [_, arg] : template_args) {
+    if (std::holds_alternative<Dtype>(arg)) {
+      options.dtypes.push_back(std::get<Dtype>(arg));
+    }
+  }
+
+  std::ostringstream os;
+  os << emit_dynamic_shader_preamble(options);
+  os << header;
+  os << "\n";
+  for (const auto& dtype : options.dtypes) {
+    if (dtype == mlx::core::bfloat16) {
+      os << emit_bf16_conversion_helpers();
+      break;
+    }
+  }
+
+  for (const auto& [name, arg] : template_args) {
+    if (std::holds_alternative<int>(arg)) {
+      os << "const int " << name << " = " << std::get<int>(arg) << ";\n";
+    } else if (std::holds_alternative<bool>(arg)) {
+      os << "const bool " << name << " = "
+         << (std::get<bool>(arg) ? "true" : "false") << ";\n";
+    } else if (std::holds_alternative<Dtype>(arg)) {
+      Dtype dtype = std::get<Dtype>(arg);
+      os << "#define " << name << " " << dtype_to_glsl_storage_type(dtype)
+         << "\n";
+      os << "float read_" << name << "(" << dtype_to_glsl_storage_type(dtype)
+         << " x) { return " << read_float_expr_for_dtype("x", dtype)
+         << "; }\n";
+      os << dtype_to_glsl_storage_type(dtype) << " write_" << name
+         << "(float x) { return " << cast_expr_for_dtype("x", float32, dtype)
+         << "; }\n";
+    }
+  }
+  if (!template_args.empty()) {
+    os << "\n";
+  }
+
+  uint32_t binding = 0;
+  std::vector<std::pair<std::string, std::string>> name_aliases;
+  for (size_t i = 0; i < inputs.size(); ++i, ++binding) {
+    const auto& name = input_names[i];
+    const auto safe_name = name == "out" ? name + "_buf" : name;
+    if (safe_name != name) {
+      name_aliases.push_back({name, safe_name});
+    }
+    const auto dtype = inputs[i].dtype();
+    os << storage_buffer_layout_for_dtype(dtype, binding)
+       << " readonly buffer " << name << "Buffer { "
+       << dtype_to_glsl_storage_type(dtype) << " data[]; } " << safe_name
+       << ";\n";
+  }
+  for (size_t i = 0; i < output_names.size(); ++i, ++binding) {
+    const auto& name = output_names[i];
+    const auto safe_name = name == "out" ? name + "_buf" : name;
+    if (safe_name != name) {
+      name_aliases.push_back({name, safe_name});
+    }
+    const auto dtype = output_dtypes[i];
+    os << storage_buffer_layout_for_dtype(dtype, binding) << " buffer " << name
+       << "Buffer { " << dtype_to_glsl_storage_type(dtype) << " data[]; } "
+       << safe_name << ";\n";
+  }
+  for (const auto& [name, safe_name] : name_aliases) {
+    os << "#define " << name << " " << safe_name << "\n";
+  }
+
+  os << "\nvoid main() {\n";
+  os << source;
+  os << "\n}\n";
+  return os.str();
 }
 
 std::string zero_literal_for_dtype(Dtype dtype) {

--- a/mlx/backend/vulkan/shader_compiler.h
+++ b/mlx/backend/vulkan/shader_compiler.h
@@ -4,8 +4,12 @@
 
 #include <cstdint>
 #include <string>
+#include <tuple>
+#include <utility>
+#include <variant>
 #include <vector>
 
+#include "mlx/array.h"
 #include "mlx/dtype.h"
 
 namespace mlx::core::vulkan {
@@ -36,6 +40,8 @@ struct DynamicShaderPreambleOptions {
   bool needs_scalar_block_layout{false};
   bool use_local_size_x_id{false};
   uint32_t local_size_x{256};
+  uint32_t local_size_y{1};
+  uint32_t local_size_z{1};
   uint32_t local_size_x_id{0};
 };
 
@@ -75,6 +81,27 @@ std::string emit_dynamic_shader_preamble(
     Dtype in_dtype,
     Dtype out_dtype,
     bool needs_int64);
+
+using DynamicTemplateArg = std::variant<int, bool, Dtype>;
+
+// Returns a deterministic suffix for dynamic shader template arguments.
+std::string dynamic_template_arguments_hash(
+    const std::vector<std::pair<std::string, DynamicTemplateArg>>&
+        template_args);
+
+// Emits a full GLSL compute shader for mx.fast.vulkan_kernel-style kernels.
+// The caller provides the body of main(); this helper supplies the dynamic
+// preamble, template constants/helpers, and input/output storage buffers.
+std::string emit_custom_kernel_source(
+    const std::string& header,
+    const std::string& source,
+    const std::vector<std::string>& input_names,
+    const std::vector<array>& inputs,
+    const std::vector<std::string>& output_names,
+    const std::vector<Dtype>& output_dtypes,
+    const std::vector<std::pair<std::string, DynamicTemplateArg>>&
+        template_args,
+    std::tuple<int, int, int> threadgroup);
 
 // Returns a GLSL zero literal for the given dtype.
 std::string zero_literal_for_dtype(Dtype dtype);

--- a/mlx/fast.h
+++ b/mlx/fast.h
@@ -86,6 +86,15 @@ MLX_API CustomKernelFunction cuda_kernel(
     bool ensure_row_contiguous = true,
     int shared_memory = 0);
 
+// Vulkan counterpart of metal_kernel/cuda_kernel.
+MLX_API CustomKernelFunction vulkan_kernel(
+    const std::string& name,
+    const std::vector<std::string>& input_names,
+    const std::vector<std::string>& output_names,
+    const std::string& source,
+    const std::string& header = "",
+    bool ensure_row_contiguous = true);
+
 MLX_API std::vector<array> precompiled_cuda_kernel(
     const std::string& name,
     const std::string& compiled_source,

--- a/python/src/fast.cpp
+++ b/python/src/fast.cpp
@@ -624,4 +624,62 @@ void init_fast(nb::module_& parent_module) {
            before the kernel runs. Default: ``False``.
         stream (mx.stream, optional): Stream to run the kernel on. Default: ``None``.
       )pbdoc");
+
+  // Mirrors the Metal/CUDA custom-kernel binding shape: the factory returns a
+  // callable that accepts inputs, output metadata, launch geometry, and template
+  // arguments.
+  m.def(
+      "vulkan_kernel",
+      [](const std::string& name,
+         const std::vector<std::string>& input_names,
+         const std::vector<std::string>& output_names,
+         const std::string& source,
+         const std::string& header,
+         bool ensure_row_contiguous) {
+        auto kernel = mx::fast::vulkan_kernel(
+            name,
+            input_names,
+            output_names,
+            source,
+            header,
+            ensure_row_contiguous);
+        return nb::cpp_function(
+            PyCustomKernelFunction(std::move(kernel), "[vulkan_kernel]"),
+            nb::kw_only(),
+            "inputs"_a,
+            "output_shapes"_a,
+            "output_dtypes"_a,
+            "grid"_a,
+            "threadgroup"_a,
+            "template"_a = nb::none(),
+            "init_value"_a = nb::none(),
+            "verbose"_a = false,
+            "stream"_a = nb::none(),
+            nb::sig(
+                "def __call__(self, *, inputs: List[Union[scalar, array]], output_shapes: List[Sequence[int]], output_dtypes: List[Dtype], grid: tuple[int, int, int], threadgroup: tuple[int, int, int], template: Optional[List[Tuple[str, Union[bool, int, Dtype]]]] = None, init_value: Optional[float] = None, verbose: bool = false, stream: Union[None, Stream, Device] = None)"));
+      },
+      "name"_a,
+      "input_names"_a,
+      "output_names"_a,
+      "source"_a,
+      "header"_a = "",
+      "ensure_row_contiguous"_a = true,
+      R"pbdoc(
+      A JIT-compiled custom Vulkan compute shader defined from a source string.
+
+      The source is the body of ``main()``. Inputs and outputs are exposed as
+      storage buffers named after ``input_names`` and ``output_names`` with a
+      ``.data`` member. Template dtype arguments additionally define
+      ``read_<Name>(value)`` and ``write_<Name>(float_value)`` helpers.
+
+      Args:
+        name (str): Kernel name used for compilation and diagnostics.
+        input_names (list(str)): Names for the input buffers.
+        output_names (list(str)): Names for the output buffers.
+        source (str): GLSL source for the body of ``main()``.
+        header (str, optional): GLSL source emitted before buffers and
+            ``main()``. Default: ``""``.
+        ensure_row_contiguous (bool): Whether to ensure inputs are row
+            contiguous before the kernel runs. Default: ``True``.
+      )pbdoc");
 }


### PR DESCRIPTION
## Summary

Closes goniz/mlx-vulkan#51.

This PR adds Vulkan fast-path support needed by the mlx-lm Vulkan work:

- Adds `mx.fast.vulkan_kernel` plumbing for Vulkan custom fused kernels.
- Implements Vulkan-side custom kernel dispatch support.
- Adds Vulkan depthwise Conv1d fast path coverage used by Qwen3.6 gated-delta blocks.
- Adds BF16 8-bit affine matvec support for decode-shaped quantized matmul.
- Broadens native low-precision Vulkan RMSNorm so Qwen3.6 gated-delta `q/k` RMSNorm avoids unnecessary FP32 staging for small head dimensions.
- Avoids eager FP32 affine scale/bias staging before the BF16 fused QMM path.

## Validation

- `./dev.sh test-cpp`
  - 249 test cases passed
  - 3314 assertions passed
- `./dev.sh test-py`
  - 699 passed
  - 13 skipped
- `./dev.sh generate`
  - coherent output
- `./dev.sh generate --model mlx-community/Qwen3.6-35B-A3B-8bit`
  - coherent output
- `./dev.sh run python scripts/model_generation_report.py --json-output /tmp/model_generation_report.json`
  - all 10 model entries generated coherent output

## Benchmarks

### `./dev.sh benchmark bf16`

```text
Running benchmark for model: mlx-community/Qwen3-0.6B-bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=2433.556, generation_tps=65.807, peak_memory=2.614, total_time=3.732
Trial 2:  prompt_tps=2419.242, generation_tps=65.866, peak_memory=2.614, total_time=3.746
Trial 3:  prompt_tps=2432.330, generation_tps=65.850, peak_memory=2.614, total_time=3.735
Trial 4:  prompt_tps=2425.489, generation_tps=65.864, peak_memory=2.615, total_time=3.740
Trial 5:  prompt_tps=2386.391, generation_tps=65.856, peak_memory=2.615, total_time=3.768
Averages: prompt_tps=2419.402, generation_tps=65.849, peak_memory=2.614
```

### `./dev.sh benchmark 8bit`

```text
Running benchmark for model: mlx-community/Qwen3-0.6B-8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1349.699, generation_tps=88.834, peak_memory=2.055, total_time=4.586
Trial 2:  prompt_tps=1349.641, generation_tps=88.652, peak_memory=2.055, total_time=4.585
Trial 3:  prompt_tps=1345.601, generation_tps=88.767, peak_memory=2.056, total_time=4.589
Trial 4:  prompt_tps=1353.543, generation_tps=88.747, peak_memory=2.056, total_time=4.573
Trial 5:  prompt_tps=1343.560, generation_tps=88.527, peak_memory=2.056, total_time=4.600
Averages: prompt_tps=1348.409, generation_tps=88.705, peak_memory=2.056
```

Additional Qwen3.6 35B prefill check on the final tree:

```text
MLX_MPI_LIBNAME=/dev/null OMPI_MCA_accelerator=^rocm ./dev.sh run mlx_lm.benchmark --model mlx-community/Qwen3.6-35B-A3B-8bit -p 4096 -g 1 -n 3
Averages: prompt_tps=119.139, generation_tps=24232.064, peak_memory=40.349
```