### PR TITLE
Add Vulkan Python availability module

### DIFF
--- a/mlx/backend/vulkan/device_info.h
+++ b/mlx/backend/vulkan/device_info.h
@@ -6,9 +6,11 @@
 #include <unordered_map>
 #include <variant>
 
+#include "mlx/api.h"
+
 namespace mlx::core::vulkan {
 
-const std::unordered_map<std::string, std::variant<std::string, size_t>>&
+MLX_API const std::unordered_map<std::string, std::variant<std::string, size_t>>&
 device_info(int device_index);
 
 } // namespace mlx::core::vulkan

--- a/mlx/backend/vulkan/no_vulkan.cpp
+++ b/mlx/backend/vulkan/no_vulkan.cpp
@@ -1,6 +1,7 @@
 // Copyright © 2023-2024 Apple Inc.
 
 #include "mlx/primitives.h"
+#include "mlx/backend/vulkan/vulkan_api.h"
 #include "mlx/distributed/primitives.h"
 #include "mlx/fast.h"
 #include "mlx/fast_primitives.h"
@@ -23,6 +24,25 @@
   }
 
 namespace mlx::core {
+
+namespace vulkan {
+
+bool is_available() {
+  return false;
+}
+
+int device_count() {
+  return 0;
+}
+
+const std::unordered_map<std::string, std::variant<std::string, size_t>>&
+device_info(int) {
+  static std::unordered_map<std::string, std::variant<std::string, size_t>>
+      empty;
+  return empty;
+}
+
+} // namespace vulkan
 
 namespace fast {
 

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -10,13 +10,11 @@
 // Use C++ Vulkan API instead of C API
 #include <vulkan/vulkan.hpp>
 
-#include "mlx/api.h"
+#include "mlx/backend/vulkan/vulkan_api.h"
 
 namespace mlx::core::vulkan {
 
-MLX_API bool is_available();
 MLX_API bool is_unified_memory();
-MLX_API int device_count();
 
 enum class GpuArchitecture : uint8_t {
   Unknown,

--- a/mlx/backend/vulkan/vulkan_api.h
+++ b/mlx/backend/vulkan/vulkan_api.h
@@ -1,0 +1,24 @@
+// Copyright © 2024 Apple Inc.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+#include "mlx/api.h"
+
+namespace mlx::core::vulkan {
+
+/* Check if the Vulkan backend is available. */
+MLX_API bool is_available();
+
+/* Get the number of available Vulkan devices. */
+MLX_API int device_count();
+
+/* Get information about a Vulkan device. */
+MLX_API const
+    std::unordered_map<std::string, std::variant<std::string, size_t>>&
+    device_info(int device_index = 0);
+
+} // namespace mlx::core::vulkan

--- a/python/src/CMakeLists.txt
+++ b/python/src/CMakeLists.txt
@@ -18,6 +18,7 @@ nanobind_add_module(
   ${CMAKE_CURRENT_SOURCE_DIR}/load.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/metal.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/cuda.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/vulkan.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/memory.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/mlx_func.cpp
   ${CMAKE_CURRENT_SOURCE_DIR}/ops.cpp
@@ -54,6 +55,7 @@ if(MLX_BUILD_PYTHON_STUBS)
     "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/core/fft.pyi"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/core/linalg.pyi"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/core/metal.pyi"
+    "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/core/vulkan.pyi"
     "${CMAKE_CURRENT_SOURCE_DIR}/../mlx/core/random.pyi"
     # Make this an optional installable component.
     EXCLUDE_FROM_ALL

--- a/python/src/mlx.cpp
+++ b/python/src/mlx.cpp
@@ -13,6 +13,7 @@ void init_device(nb::module_&);
 void init_stream(nb::module_&);
 void init_metal(nb::module_&);
 void init_cuda(nb::module_&);
+void init_vulkan(nb::module_&);
 void init_memory(nb::module_&);
 void init_ops(nb::module_&);
 void init_transforms(nb::module_&);
@@ -37,6 +38,7 @@ NB_MODULE(core, m) {
   init_array(m);
   init_metal(m);
   init_cuda(m);
+  init_vulkan(m);
   init_memory(m);
   init_ops(m);
   init_transforms(m);

--- a/python/src/vulkan.cpp
+++ b/python/src/vulkan.cpp
@@ -1,0 +1,19 @@
+// Copyright © 2024 Apple Inc.
+
+#include <nanobind/nanobind.h>
+
+#include "mlx/backend/vulkan/vulkan_api.h"
+
+namespace mx = mlx::core;
+namespace nb = nanobind;
+
+void init_vulkan(nb::module_& m) {
+  nb::module_ vulkan = m.def_submodule("vulkan", "mlx.vulkan");
+
+  vulkan.def(
+      "is_available",
+      &mx::vulkan::is_available,
+      R"pbdoc(
+      Check if the Vulkan back-end is available.
+      )pbdoc");
+}


### PR DESCRIPTION
Adds an mx.vulkan Python submodule mirroring mx.metal/mx.cuda availability checks, exposing mx.vulkan.is_available() through the existing Vulkan backend availability primitive.\n\nValidation:\n- ./dev.sh build\n- ./dev.sh run python - <<'PY' ... verified hasattr(mx, 'vulkan') and mx.vulkan.is_available() both True\n- PYTHONPATH=/home/goniz/Work/mlx/mlx-vulkan/mlx-lm ./dev.sh run pytest mlx-lm/tests/test_models.py -k gated_delta: 3 passed\n\nQwen3 benchmark results:\n- ./dev.sh benchmark bf16: avg prompt_tps=2415.674, generation_tps=65.818, peak_memory=2.614 GB\n- ./dev.sh benchmark 8bit: avg prompt_tps=1348.622, generation_tps=88.485, peak_memory=2.055 GB