### PR TITLE
[Vulkan] Expose subgroup_size in device_info()

### DIFF
--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -131,7 +131,10 @@ device_info(int device_index) {
         {"max_compute_work_group_size_y", static_cast<size_t>(limits.maxComputeWorkGroupSize[1])},
         {"max_compute_work_group_size_z", static_cast<size_t>(limits.maxComputeWorkGroupSize[2])},
         {"max_memory_allocation_count", static_cast<size_t>(limits.maxMemoryAllocationCount)},
-        {"resource_limit", static_cast<size_t>(limits.maxMemoryAllocationCount)}};
+        {"resource_limit", static_cast<size_t>(limits.maxMemoryAllocationCount)},
+        {"subgroup_size", static_cast<size_t>(ctx.subgroup_size())},
+        {"subgroup_min_size", static_cast<size_t>(ctx.subgroup_min_size())},
+        {"subgroup_max_size", static_cast<size_t>(ctx.subgroup_max_size())}};
   };
 
   static auto device_info_ = init_device_info();


### PR DESCRIPTION
## Summary

Surface the Vulkan subgroup size collected by `VulkanContext` through the public `mx.device_info()` payload so downstream code (e.g. `mlx-lm` custom Vulkan kernels) can gate subgroup-based reductions on whether the hardware subgroup is wide enough to cover the workgroup.

Adds three keys to `mx.device_info(mx.gpu)` on the Vulkan backend:

- `subgroup_size`     — current/default subgroup size
- `subgroup_min_size` — minimum subgroup size (with `VK_EXT_subgroup_size_control`)
- `subgroup_max_size` — maximum subgroup size (with `VK_EXT_subgroup_size_control`)

## Why

Several `mx.fast.vulkan_kernel`-based primitives reduce a 32-lane workgroup using a single `subgroupAdd`. On hardware whose subgroup size is `< 32` (Mali, some Intel configs), a single `subgroupAdd` only reduces within each hardware subgroup, so when only the leader lane writes the output the contributions from the other subgroup(s) are silently dropped.

The concrete trigger is the `mlx-lm` gated-delta Vulkan kernel (goniz/mlx-lm#1), which produces incorrect outputs for `Dk = 128` on small-subgroup devices. With this change the kernel can do:

```python
info = mx.device_info(mx.Device(mx.gpu, 0))
if int(info.get("subgroup_size", 0)) < 32:
    return None  # fall back to gated_delta_ops
```

…keeping the hot path barrier-free on full-subgroup hardware while remaining correct on every supported device.

## Verification

```text
$ ./dev.sh run python -c "
import mlx.core as mx
info = mx.device_info(mx.gpu)
print('subgroup_size:', info.get('subgroup_size'))
print('subgroup_min_size:', info.get('subgroup_min_size'))
print('subgroup_max_size:', info.get('subgroup_max_size'))
"
subgroup_size: 64
subgroup_min_size: 32
subgroup_max_size: 64
```

## Benchmarks — Qwen3-0.6B

Run on this branch; both prompt and decode TPS are unchanged from baseline, as expected for a device-info-only change.

### bf16

```text
$ ./dev.sh benchmark bf16
Running benchmark for model: mlx-community/Qwen3-0.6B-bf16
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=2421.562, generation_tps=65.772, peak_memory=2.614, total_time=3.749
Trial 2:  prompt_tps=2427.961, generation_tps=65.823, peak_memory=2.614, total_time=3.745
Trial 3:  prompt_tps=2371.206, generation_tps=65.716, peak_memory=2.614, total_time=3.788
Trial 4:  prompt_tps=2421.927, generation_tps=65.793, peak_memory=2.615, total_time=3.748
Trial 5:  prompt_tps=2410.370, generation_tps=65.800, peak_memory=2.615, total_time=3.758
Averages: prompt_tps=2410.605, generation_tps=65.781, peak_memory=2.614
```

### 8bit

```text
$ ./dev.sh benchmark 8bit
Running benchmark for model: mlx-community/Qwen3-0.6B-8bit
Running warmup..
Timing with prompt_tokens=4096, generation_tokens=128, batch_size=1.
Trial 1:  prompt_tps=1369.056, generation_tps=88.693, peak_memory=2.055, total_time=4.544
Trial 2:  prompt_tps=1354.516, generation_tps=88.762, peak_memory=2.055, total_time=4.585
Trial 3:  prompt_tps=1371.884, generation_tps=88.554, peak_memory=2.056, total_time=4.547
Trial 4:  prompt_tps=1366.554, generation_tps=88.855, peak_memory=2.056, total_time=4.553
Trial 5:  prompt_tps=1364.765, generation_tps=88.833, peak_memory=2.056, total_time=4.554
Averages: prompt_tps=1365.355, generation_tps=88.739, peak_memory=2.056
```

Closes goniz/mlx-vulkan#53
