### PR TITLE
make DiffusionGemma work on vulkan

### DIFF
--- a/mlx/backend/vulkan/kernels/mul_mm_affine_bf16_tiled.comp
+++ b/mlx/backend/vulkan/kernels/mul_mm_affine_bf16_tiled.comp
@@ -38,11 +38,27 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-const uint BM = 32u;
-const uint BN = 16u;
-const uint BK = 32u;
-const uint TM = 4u;
-const uint TN = 2u;
+#ifndef MLX_BM
+#define MLX_BM 32
+#endif
+#ifndef MLX_BN
+#define MLX_BN 16
+#endif
+#ifndef MLX_BK
+#define MLX_BK 32
+#endif
+#ifndef MLX_TM
+#define MLX_TM 4
+#endif
+#ifndef MLX_TN
+#define MLX_TN 2
+#endif
+
+const uint BM = MLX_BM;
+const uint BN = MLX_BN;
+const uint BK = MLX_BK;
+const uint TM = MLX_TM;
+const uint TN = MLX_TN;
 
 shared float xs[BM][BK];
 shared float ws[BN][BK];
@@ -101,6 +117,7 @@ void main() {
         barrier();
 
         for (uint kk = 0u; kk < BK; ++kk) {
+#if MLX_TN == 2
             const float w0 = ws[lx * TN + 0u][kk];
             const float w1 = ws[lx * TN + 1u][kk];
             for (uint mr = 0u; mr < TM; ++mr) {
@@ -108,17 +125,61 @@ void main() {
                 acc[mr][0] = fma(x, w0, acc[mr][0]);
                 acc[mr][1] = fma(x, w1, acc[mr][1]);
             }
+#elif MLX_TN == 4
+            const float w0 = ws[lx * TN + 0u][kk];
+            const float w1 = ws[lx * TN + 1u][kk];
+            const float w2 = ws[lx * TN + 2u][kk];
+            const float w3 = ws[lx * TN + 3u][kk];
+            for (uint mr = 0u; mr < TM; ++mr) {
+                const float x = xs[ly * TM + mr][kk];
+                acc[mr][0] = fma(x, w0, acc[mr][0]);
+                acc[mr][1] = fma(x, w1, acc[mr][1]);
+                acc[mr][2] = fma(x, w2, acc[mr][2]);
+                acc[mr][3] = fma(x, w3, acc[mr][3]);
+            }
+#else
+            for (uint mr = 0u; mr < TM; ++mr) {
+                const float x = xs[ly * TM + mr][kk];
+                for (uint nc = 0u; nc < TN; ++nc) {
+                    acc[mr][nc] = fma(x, ws[lx * TN + nc][kk], acc[mr][nc]);
+                }
+            }
+#endif
         }
         barrier();
     }
 
     for (uint mr = 0u; mr < TM; ++mr) {
         const uint row = row0 + mr;
+#if MLX_TN == 2
         if (row < p.rows && col0 < p.cols) {
             data_out[row * p.out_row_stride + col0] = uint16_t(fp32_to_bf16(acc[mr][0]));
         }
         if (row < p.rows && col0 + 1u < p.cols) {
             data_out[row * p.out_row_stride + col0 + 1u] = uint16_t(fp32_to_bf16(acc[mr][1]));
         }
+#elif MLX_TN == 4
+        if (row < p.rows && col0 < p.cols) {
+            data_out[row * p.out_row_stride + col0] = uint16_t(fp32_to_bf16(acc[mr][0]));
+        }
+        if (row < p.rows && col0 + 1u < p.cols) {
+            data_out[row * p.out_row_stride + col0 + 1u] = uint16_t(fp32_to_bf16(acc[mr][1]));
+        }
+        if (row < p.rows && col0 + 2u < p.cols) {
+            data_out[row * p.out_row_stride + col0 + 2u] = uint16_t(fp32_to_bf16(acc[mr][2]));
+        }
+        if (row < p.rows && col0 + 3u < p.cols) {
+            data_out[row * p.out_row_stride + col0 + 3u] = uint16_t(fp32_to_bf16(acc[mr][3]));
+        }
+#else
+        if (row < p.rows) {
+            for (uint nc = 0u; nc < TN; ++nc) {
+                if (col0 + nc < p.cols) {
+                    data_out[row * p.out_row_stride + col0 + nc] =
+                        uint16_t(fp32_to_bf16(acc[mr][nc]));
+                }
+            }
+        }
+#endif
     }
 }

--- a/mlx/backend/vulkan/kernels/scatter_axis.comp
+++ b/mlx/backend/vulkan/kernels/scatter_axis.comp
@@ -1,5 +1,7 @@
 #version 450
 
+#include "types.glsl"
+
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_scalar_block_layout : require
 

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -1570,6 +1570,20 @@ void process_shaders() {
   indexing_shaders("scatter_pair", "scatter_pair.comp");
   indexing_shaders("scatter_axis", "scatter_axis.comp");
 
+  auto scatter_axis_bool_shaders =
+      [&](const std::string& index_tag,
+          const std::map<std::string, std::string>& extra_index_defines) {
+        auto defines =
+            merge_maps({{"VALUE_TYPE", "uint8_t"}}, extra_index_defines);
+        string_to_spv(
+            "scatter_axis_bool_" + index_tag, "scatter_axis.comp", defines);
+      };
+  scatter_axis_bool_shaders("i32", {});
+  scatter_axis_bool_shaders("i64", {{"INDEX_IS_I64", "1"}});
+  scatter_axis_bool_shaders("u32", {{"INDEX_IS_UNSIGNED", "1"}});
+  scatter_axis_bool_shaders(
+      "u64", {{"INDEX_IS_I64", "1"}, {"INDEX_IS_UNSIGNED", "1"}});
+
   auto scatter_sum_axis_shaders =
       [&](const std::string& value_tag,
           const std::string& value_type,
@@ -2207,6 +2221,10 @@ void process_shaders() {
       "fused_affine_qmm_bf16_bf16", "mul_mm_affine_bf16_acc.comp", {});
   string_to_spv(
       "fused_affine_qmm_bf16_bf16_tiled", "mul_mm_affine_bf16_tiled.comp", {});
+  string_to_spv(
+      "fused_affine_qmm_bf16_bf16_tiled_n32",
+      "mul_mm_affine_bf16_tiled.comp",
+      {{"MLX_BN", "32"}, {"MLX_TN", "4"}});
 
   string_to_spv(
       "fused_affine_matvec8_f32_f32",

--- a/mlx/backend/vulkan/primitives_utils.cpp
+++ b/mlx/backend/vulkan/primitives_utils.cpp
@@ -510,21 +510,25 @@ std::optional<vulkan::StaticShaderId> scatter_axis_shader_id(
   MLX_VK_GATHER_CASE(bfloat16, int32, scatter_axis_bf16_i32);
   MLX_VK_GATHER_CASE(int32, int32, scatter_axis_i32_i32);
   MLX_VK_GATHER_CASE(uint32, int32, scatter_axis_u32_i32);
+  MLX_VK_GATHER_CASE(bool_, int32, scatter_axis_bool_i32);
   MLX_VK_GATHER_CASE(float32, int64, scatter_axis_f32_i64);
   MLX_VK_GATHER_CASE(float16, int64, scatter_axis_f16_i64);
   MLX_VK_GATHER_CASE(bfloat16, int64, scatter_axis_bf16_i64);
   MLX_VK_GATHER_CASE(int32, int64, scatter_axis_i32_i64);
   MLX_VK_GATHER_CASE(uint32, int64, scatter_axis_u32_i64);
+  MLX_VK_GATHER_CASE(bool_, int64, scatter_axis_bool_i64);
   MLX_VK_GATHER_CASE(float32, uint32, scatter_axis_f32_u32);
   MLX_VK_GATHER_CASE(float16, uint32, scatter_axis_f16_u32);
   MLX_VK_GATHER_CASE(bfloat16, uint32, scatter_axis_bf16_u32);
   MLX_VK_GATHER_CASE(int32, uint32, scatter_axis_i32_u32);
   MLX_VK_GATHER_CASE(uint32, uint32, scatter_axis_u32_u32);
+  MLX_VK_GATHER_CASE(bool_, uint32, scatter_axis_bool_u32);
   MLX_VK_GATHER_CASE(float32, uint64, scatter_axis_f32_u64);
   MLX_VK_GATHER_CASE(float16, uint64, scatter_axis_f16_u64);
   MLX_VK_GATHER_CASE(bfloat16, uint64, scatter_axis_bf16_u64);
   MLX_VK_GATHER_CASE(int32, uint64, scatter_axis_i32_u64);
   MLX_VK_GATHER_CASE(uint32, uint64, scatter_axis_u32_u64);
+  MLX_VK_GATHER_CASE(bool_, uint64, scatter_axis_bool_u64);
   return std::nullopt;
 }
 

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1412,13 +1412,22 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           const bool use_tiled_prefill = rows > 1 && group_size_ >= 32 &&
               (group_size_ % 32) == 0 &&
               fused_affine_bf16_tiled_prefill_enabled();
+          const bool use_large_n_tile = use_tiled_prefill && cols >= 65536;
           const auto shader_id = use_decode_matvec
               ? vulkan::StaticShaderId::fused_affine_matvec8_bf16_bf16
+              : use_large_n_tile
+              ? vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled_n32
               : use_tiled_prefill
               ? vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               : vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16;
           const std::array<uint32_t, 3> grid = use_decode_matvec
               ? std::array<uint32_t, 3>{cols, rows, 1u}
+              : shader_id ==
+                      vulkan::StaticShaderId::
+                          fused_affine_qmm_bf16_bf16_tiled_n32
+              ? std::array<
+                    uint32_t,
+                    3>{(cols + 31u) / 32u, (rows + 31u) / 32u, 1u}
               : shader_id ==
                       vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               ? std::array<

--- a/mlx/backend/vulkan/scan.cpp
+++ b/mlx/backend/vulkan/scan.cpp
@@ -240,7 +240,13 @@ std::string build_complex_sum_scan_shader(bool reverse, bool inclusive) {
   return os.str();
 }
 
-std::string build_prod_scan_shader(bool reverse, bool inclusive) {
+std::string build_float_scan_shader(
+    Scan::ReduceType reduce_type,
+    bool reverse,
+    bool inclusive) {
+  const bool prod = reduce_type == Scan::Prod;
+  const bool min = reduce_type == Scan::Min;
+  const bool max = reduce_type == Scan::Max;
   std::ostringstream os;
   os << "#version 450\n\n";
   os << "layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;\n\n";
@@ -254,19 +260,45 @@ std::string build_prod_scan_shader(bool reverse, bool inclusive) {
   os << "    uint row = gl_GlobalInvocationID.x;\n";
   os << "    if (row >= p.row_count) return;\n";
   os << "    uint base = row * p.n_cols;\n";
-  os << "    float acc = 1.0;\n";
+  os << "    float acc = ";
+  if (prod) {
+    os << "1.0;\n";
+  } else if (min) {
+    os << "1.0 / 0.0;\n";
+  } else if (max) {
+    os << "-1.0 / 0.0;\n";
+  } else {
+    os << "0.0;\n";
+  }
   os << "    for (uint logical_col = 0; logical_col < p.n_cols; ++logical_col) {\n";
   if (reverse) {
     os << "        uint col = p.n_cols - 1 - logical_col;\n";
   } else {
     os << "        uint col = logical_col;\n";
   }
+  os << "        float value = data_a[base + col];\n";
   if (inclusive) {
-    os << "        acc *= data_a[base + col];\n";
+    if (prod) {
+      os << "        acc *= value;\n";
+    } else if (min) {
+      os << "        acc = min(acc, value);\n";
+    } else if (max) {
+      os << "        acc = max(acc, value);\n";
+    } else {
+      os << "        acc += value;\n";
+    }
     os << "        data_d[base + col] = acc;\n";
   } else {
     os << "        data_d[base + col] = acc;\n";
-    os << "        acc *= data_a[base + col];\n";
+    if (prod) {
+      os << "        acc *= value;\n";
+    } else if (min) {
+      os << "        acc = min(acc, value);\n";
+    } else if (max) {
+      os << "        acc = max(acc, value);\n";
+    } else {
+      os << "        acc += value;\n";
+    }
   }
   os << "    }\n";
   os << "}\n";
@@ -376,20 +408,23 @@ bool try_dispatch_complex_sum_scan(
   return true;
 }
 
-bool try_dispatch_prod_scan(
+bool try_dispatch_float_scan(
     const array& in,
     array& out,
     Stream s,
+    Scan::ReduceType reduce_type,
     bool reverse,
     bool inclusive) {
   if (in.dtype() != float32 || out.dtype() != float32 || in.ndim() == 0 ||
-      in.shape(in.ndim() - 1) == 0 || in.size() != out.size()) {
+      in.shape(in.ndim() - 1) == 0 || in.size() != out.size() ||
+      (reduce_type != Scan::Prod && reduce_type != Scan::Min &&
+       reduce_type != Scan::Max)) {
     return false;
   }
 
   const uint32_t n_cols =
-      checked_u32_size(in.shape(in.ndim() - 1), "prod_scan n_cols");
-  const uint32_t total = checked_u32_size(out.size(), "prod_scan size");
+      checked_u32_size(in.shape(in.ndim() - 1), "float_scan n_cols");
+  const uint32_t total = checked_u32_size(out.size(), "float_scan size");
   if (total % n_cols != 0) {
     return false;
   }
@@ -398,9 +433,13 @@ bool try_dispatch_prod_scan(
     return true;
   }
 
-  const std::string shader_name = std::string("dynamic_cumprod_f32_") +
+  const std::string shader_name = std::string("dynamic_") +
+      (reduce_type == Scan::Prod  ? "cumprod_f32_"
+           : reduce_type == Scan::Min ? "cummin_f32_"
+                                      : "cummax_f32_") +
       (reverse ? "rev_" : "fwd_") + (inclusive ? "inc" : "exc");
-  const std::string glsl = build_prod_scan_shader(reverse, inclusive);
+  const std::string glsl =
+      build_float_scan_shader(reduce_type, reverse, inclusive);
   const std::array<uint32_t, 2> pc = {n_cols, row_count};
   const std::array<vulkan::DynamicArrayRef, 2> refs = {{{&in, 0}, {&out, 1}}};
 
@@ -666,8 +705,8 @@ bool try_eval_scan_vulkan(
 
   if (((reduce_type == Scan::Prod && !cumprod_c64 && !scan_f32 &&
         !cumprod_i32 && !integral_i64) ||
-       (reduce_type == Scan::Min && !int_minmax_i32) ||
-       (reduce_type == Scan::Max && !int_minmax_i32) ||
+       (reduce_type == Scan::Min && !int_minmax_i32 && !scan_f32) ||
+       (reduce_type == Scan::Max && !int_minmax_i32 && !scan_f32) ||
        reduce_type == Scan::LogAddExp) &&
       scan_input.shape(scan_input.ndim() - 1) > 128) {
     return false;
@@ -760,8 +799,13 @@ bool try_eval_scan_vulkan(
           command_buffer = vulkan::begin_command_recording(s.index);
         } else if (scan_f32 && scan_input.shape(scan_input.ndim() - 1) > 128) {
           vulkan::end_command_recording(s.index);
-          if (!try_dispatch_prod_scan(
-                  scan_input, inclusive_out, s, reverse, inclusive)) {
+          if (!try_dispatch_float_scan(
+                  scan_input,
+                  inclusive_out,
+                  s,
+                  reduce_type,
+                  reverse,
+                  inclusive)) {
             return false;
           }
           command_buffer = vulkan::begin_command_recording(s.index);
@@ -785,6 +829,18 @@ bool try_eval_scan_vulkan(
             return false;
           }
           command_buffer = vulkan::begin_command_recording(s.index);
+        } else if (scan_f32 && scan_input.shape(scan_input.ndim() - 1) > 128) {
+          vulkan::end_command_recording(s.index);
+          if (!try_dispatch_float_scan(
+                  scan_input,
+                  inclusive_out,
+                  s,
+                  reduce_type,
+                  reverse,
+                  inclusive)) {
+            return false;
+          }
+          command_buffer = vulkan::begin_command_recording(s.index);
         } else {
           vulkan::dispatch_scan_op(
               scan_input,
@@ -801,6 +857,18 @@ bool try_eval_scan_vulkan(
           vulkan::end_command_recording(s.index);
           if (!try_dispatch_integral_scan(
                   scan_input, inclusive_out, s, reduce_type, reverse, inclusive)) {
+            return false;
+          }
+          command_buffer = vulkan::begin_command_recording(s.index);
+        } else if (scan_f32 && scan_input.shape(scan_input.ndim() - 1) > 128) {
+          vulkan::end_command_recording(s.index);
+          if (!try_dispatch_float_scan(
+                  scan_input,
+                  inclusive_out,
+                  s,
+                  reduce_type,
+                  reverse,
+                  inclusive)) {
             return false;
           }
           command_buffer = vulkan::begin_command_recording(s.index);


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Vulkan backend, focusing on enhanced flexibility for matrix multiplication tiling, expanded support for scan operations, and enabling boolean scatter operations. The most important changes are summarized below:

**Matrix Multiplication Tiling Improvements**
* Made tiling parameters (`BM`, `BN`, `BK`, `TM`, `TN`) in `mul_mm_affine_bf16_tiled.comp` configurable via preprocessor defines, allowing for easier experimentation and tuning of tile sizes.
* Added support for a new "large N tile" variant (`fused_affine_qmm_bf16_bf16_tiled_n32`) with `MLX_BN=32` and `MLX_TN=4`, and updated the kernel logic to handle different `TN` values efficiently. [[1]](diffhunk://#diff-8bb4beedde90f66f1f57772b3b360eb44e71baca4b2cad0dac4ba82410871367R120-R183) [[2]](diffhunk://#diff-f70b331e6a1cc0a7faa5a85448d1f2949bc5cbdbb1338a356f131c471e9675baR2224-R2227) [[3]](diffhunk://#diff-fcb180352b343716f188dcd388e23d594f0d6923332c94a8196643cfb82874abR1415-R1430)

**Scan Operation Enhancements**
* Generalized the product scan shader to support cumulative min and max operations for float32, and updated the dispatch logic to use the appropriate shader for each reduce type. [[1]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L243-R249) [[2]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L257-R301) [[3]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L379-R427) [[4]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L401-R442) [[5]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L669-R709) [[6]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046L763-R808) [[7]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046R832-R843) [[8]](diffhunk://#diff-8a9b4ee4be7bd5a926a6a53027777a461ba0dc341b072dc05c15a7c4fadd5046R863-R874)

**Scatter Operation Extensions**
* Added support for boolean value types in `scatter_axis` shaders and registered the new shaders for all relevant index types, enabling scatter operations with boolean data. [[1]](diffhunk://#diff-89c52ba0e56e10f2b1578399038a6f8f0e3e3cc556445818539f1cc44bcf3bdcR3-R4) [[2]](diffhunk://#diff-f70b331e6a1cc0a7faa5a85448d1f2949bc5cbdbb1338a356f131c471e9675baR1573-R1586) [[3]](diffhunk://#diff-5f0c98ca6215a7afb2cab68733e51c431d6d9b11ccc681b40300dc89085717ddR513-R531)

These changes collectively improve the flexibility, performance, and feature coverage of the Vulkan backend, especially for large matrix multiplications, advanced scan operations, and boolean scatter support.

closes goniz/mlx-vulkan#55