### PR TITLE
[Vulkan] Fix sum_rows block size for n_cols < 32

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -2599,7 +2599,8 @@ void dispatch_sum_rows_op(
   const auto row_count = checked_u32(out.size(), "sum_rows output rows");
   const uint32_t max_invocations = max_compute_work_group_invocations();
   const uint32_t block_size = std::min(
-      push_constants.n_cols <= 32u ? 32u
+      push_constants.n_cols < 32u ? 1u
+          : push_constants.n_cols <= 32u                    ? 32u
           : push_constants.n_cols <= 64u                       ? 64u
           : push_constants.n_cols >= 4096u                     ? 1024u
                                                                : 128u,


### PR DESCRIPTION
This pull request makes a small adjustment to the logic for determining the `block_size` in the `dispatch_sum_rows_op` function. The change ensures that when the number of columns is less than 32, the block size is set to 1 instead of 32, which can improve efficiency for small row sizes.

- Updated `block_size` calculation in `dispatch_sum_rows_op` to use a block size of 1 when `push_constants.n_cols` is less than 32 (`mlx/backend/vulkan/kernels.cpp`).

fixes goniz/mlx-vulkan#54