### PR TITLE
Vulkan: address fable review perf and async pipeline issues

### DIFF
--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -65,6 +65,8 @@ void* Buffer::raw_ptr() {
   }
   if (auto* host_buf =
           static_cast<vulkan::VulkanBuffer*>(buf->host_readback.ptr())) {
+    std::lock_guard<std::mutex> lock(buf->queue_affinity_mutex);
+    buf->host_readback_dirty = true;
     return host_buf->mapped_ptr;
   }
   return nullptr;
@@ -85,6 +87,7 @@ void reset_buffer_sync_state(VulkanBuffer* buf) {
   buf->last_semaphore = vk::Semaphore();
   buf->last_timeline_value = 0;
   buf->queue_affinity = VulkanBuffer::QueueAffinity::None;
+  buf->host_readback_dirty = false;
 }
 
 constexpr size_t min_cache_pool_size = 4096 * 4;
@@ -547,13 +550,15 @@ Buffer VulkanAllocator::malloc_impl(size_t size, bool require_host_visible) {
     mapped_ptr = vk_device.mapMemory(vk_memory, 0, VK_WHOLE_SIZE);
   }
 
-  auto* buf = new VulkanBuffer{mapped_ptr,
-                               Buffer{nullptr},
-                               vk_buffer,
-                               vk_memory,
-                               size,
-                               allocation_size,
-                               memory_flags};
+  auto* buf = new VulkanBuffer{
+      mapped_ptr,
+      Buffer{nullptr},
+      false,
+      vk_buffer,
+      vk_memory,
+      size,
+      allocation_size,
+      memory_flags};
 
   {
     std::unique_lock lk(mutex_);

--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -55,7 +55,14 @@ void* Buffer::raw_ptr() {
 
   vulkan::synchronize_buffer_for_host_access(buf);
 
-  return buf->mapped_ptr;
+  if (buf->mapped_ptr != nullptr) {
+    return buf->mapped_ptr;
+  }
+  if (auto* host_buf =
+          static_cast<vulkan::VulkanBuffer*>(buf->host_readback.ptr())) {
+    return host_buf->mapped_ptr;
+  }
+  return nullptr;
 }
 
 } // namespace allocator
@@ -535,8 +542,13 @@ Buffer VulkanAllocator::malloc_impl(size_t size, bool require_host_visible) {
     mapped_ptr = vk_device.mapMemory(vk_memory, 0, VK_WHOLE_SIZE);
   }
 
-  auto* buf = new VulkanBuffer{
-      mapped_ptr, vk_buffer, vk_memory, size, allocation_size, memory_flags};
+  auto* buf = new VulkanBuffer{mapped_ptr,
+                               Buffer{nullptr},
+                               vk_buffer,
+                               vk_memory,
+                               size,
+                               allocation_size,
+                               memory_flags};
 
   {
     std::unique_lock lk(mutex_);
@@ -593,6 +605,11 @@ void VulkanAllocator::free(Buffer buffer) {
 }
 
 void VulkanAllocator::free_vulkan_buffer(VulkanBuffer* buf) {
+  if (buf->host_readback.ptr() != nullptr) {
+    free(buf->host_readback);
+    buf->host_readback = Buffer{nullptr};
+  }
+
   auto vk_device = VulkanContext::get().device();
   if (buf->mapped_ptr != nullptr) {
     vk_device.unmapMemory(buf->memory);

--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -579,6 +579,7 @@ void VulkanAllocator::free(Buffer buffer) {
     return;
   }
 
+  Buffer host_readback{nullptr};
   {
     std::unique_lock lk(mutex_);
     if (live_buffers_.find(buf) == live_buffers_.end()) {
@@ -586,7 +587,16 @@ void VulkanAllocator::free(Buffer buffer) {
     }
     live_buffers_.erase(buf);
     active_memory_ -= std::min(active_memory_, buf->size);
+    host_readback = buf->host_readback;
+    buf->host_readback = Buffer{nullptr};
+  }
 
+  if (host_readback.ptr() != nullptr) {
+    free(host_readback);
+  }
+
+  {
+    std::unique_lock lk(mutex_);
     const auto cacheable_limit =
         cacheable_size_limit(active_memory_, max_cacheable_size_);
     const auto pool_limit = cache_pool_limit(active_memory_, max_pool_size_);
@@ -610,9 +620,10 @@ void VulkanAllocator::free(Buffer buffer) {
 }
 
 void VulkanAllocator::free_vulkan_buffer(VulkanBuffer* buf) {
-  if (buf->host_readback.ptr() != nullptr) {
-    free(buf->host_readback);
+  if (auto* host_readback =
+          static_cast<VulkanBuffer*>(buf->host_readback.ptr())) {
     buf->host_readback = Buffer{nullptr};
+    free_vulkan_buffer(host_readback);
   }
 
   auto vk_device = VulkanContext::get().device();

--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -19,6 +19,11 @@
 
 namespace mlx::core {
 
+namespace vulkan {
+void clear_dequantized_weight_cache();
+void clear_mul_mm_transpose_cache();
+} // namespace vulkan
+
 namespace allocator {
 
 namespace {
@@ -678,6 +683,9 @@ size_t get_cache_memory() {
 }
 
 void clear_cache() {
+  vulkan::synchronize_all();
+  vulkan::clear_dequantized_weight_cache();
+  vulkan::clear_mul_mm_transpose_cache();
   vulkan::allocator().clear_cache();
 }
 

--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -220,18 +220,26 @@ size_t cache_pool_limit(size_t active_memory, size_t max_pool_size) {
   return max_pool_size;
 }
 
+struct PreferredMemoryType {
+  vk::MemoryPropertyFlags required;
+  vk::MemoryPropertyFlags forbidden;
+};
+
 uint32_t find_memory_type_index(
     const VulkanContext& ctx,
     uint32_t type_filter,
-    const std::vector<vk::MemoryPropertyFlags>& preferred_flags) {
-  for (auto flags : preferred_flags) {
-    try {
-      // Convert vk::MemoryPropertyFlags to VkMemoryPropertyFlags
-      // This is safe since they're the same underlying type
-      VkMemoryPropertyFlags vk_flags =
-          static_cast<VkMemoryPropertyFlags>(flags);
-      return ctx.find_memory_type(type_filter, vk_flags);
-    } catch (const std::runtime_error&) {
+    const std::vector<PreferredMemoryType>& preferred_types) {
+  const auto mem_props = ctx.memory_properties();
+  for (const auto& preference : preferred_types) {
+    for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
+      if ((type_filter & (1u << i)) == 0) {
+        continue;
+      }
+      const auto flags = mem_props.memoryTypes[i].propertyFlags;
+      if ((flags & preference.required) == preference.required &&
+          (flags & preference.forbidden) == vk::MemoryPropertyFlags{}) {
+        return i;
+      }
     }
   }
   throw std::runtime_error("[vulkan::malloc] No suitable memory type found.");
@@ -248,7 +256,11 @@ void clear_alloc_trace_primitive() {
 }
 
 VulkanAllocator::VulkanAllocator()
-    : buffer_cache_(
+    : device_buffer_cache_(
+          query_page_size(),
+          [](VulkanBuffer* buf) { return buf->allocation_size; },
+          [this](VulkanBuffer* buf) { free_vulkan_buffer(buf); }),
+      host_visible_buffer_cache_(
           query_page_size(),
           [](VulkanBuffer* buf) { return buf->allocation_size; },
           [this](VulkanBuffer* buf) { free_vulkan_buffer(buf); }) {
@@ -286,8 +298,8 @@ size_t VulkanAllocator::set_cache_limit(size_t limit) {
   std::swap(limit, max_pool_size_);
   max_cacheable_size_ = default_max_cacheable_size(max_pool_size_);
   if (get_cache_memory() > max_pool_size_) {
-    num_resources_ -= buffer_cache_.release_cached_buffers(
-        get_cache_memory() - max_pool_size_);
+    num_resources_ -=
+        release_cached_buffers(get_cache_memory() - max_pool_size_);
   }
   return limit;
 }
@@ -314,7 +326,8 @@ size_t VulkanAllocator::set_wired_limit(size_t limit) {
 
 void VulkanAllocator::clear_cache() {
   std::unique_lock lk(mutex_);
-  num_resources_ -= buffer_cache_.clear();
+  num_resources_ -= device_buffer_cache_.clear();
+  num_resources_ -= host_visible_buffer_cache_.clear();
 }
 
 bool VulkanAllocator::owns(Buffer buffer) const {
@@ -327,18 +340,58 @@ bool VulkanAllocator::owns(Buffer buffer) const {
   return live_buffers_.contains(vk_buffer);
 }
 
+size_t VulkanAllocator::get_cache_memory() const {
+  return device_buffer_cache_.cache_size() +
+      host_visible_buffer_cache_.cache_size();
+}
+
+size_t VulkanAllocator::release_cached_buffers(size_t min_bytes_to_free) {
+  if (min_bytes_to_free == 0) {
+    return 0;
+  }
+  size_t released = 0;
+  const size_t device_cache_memory = device_buffer_cache_.cache_size();
+  if (device_cache_memory > 0) {
+    const size_t device_bytes_to_free =
+        std::min(min_bytes_to_free, device_cache_memory);
+    released +=
+        device_buffer_cache_.release_cached_buffers(device_bytes_to_free);
+  }
+  const size_t remaining = min_bytes_to_free > device_cache_memory
+      ? min_bytes_to_free - device_cache_memory
+      : 0;
+  if (remaining > 0 && host_visible_buffer_cache_.cache_size() > 0) {
+    released += host_visible_buffer_cache_.release_cached_buffers(remaining);
+  }
+  return released;
+}
+
 Buffer VulkanAllocator::malloc(size_t size) {
+  return malloc_impl(size, false);
+}
+
+Buffer VulkanAllocator::malloc_host_visible(size_t size) {
+  return malloc_impl(size, true);
+}
+
+Buffer VulkanAllocator::malloc_impl(size_t size, bool require_host_visible) {
   if (size == 0) {
     return Buffer{nullptr};
   }
 
+  auto& ctx = VulkanContext::get();
+  const bool use_device_local_cache =
+      !require_host_visible && !ctx.is_unified_memory();
+  auto& buffer_cache = use_device_local_cache ? device_buffer_cache_
+                                              : host_visible_buffer_cache_;
+
   // Try to reuse a buffer from the cache.
   {
     std::unique_lock lk(mutex_);
-    auto* cached = buffer_cache_.reuse_from_cache(size);
+    auto* cached = buffer_cache.reuse_from_cache(size);
     if (cached) {
-      if (cached->allocation_size > size + buffer_cache_.page_size()) {
-        buffer_cache_.recycle_to_cache(cached);
+      if (cached->allocation_size > size + buffer_cache.page_size()) {
+        buffer_cache.recycle_to_cache(cached);
       } else {
         cached->size = size;
         reset_buffer_sync_state(cached);
@@ -354,12 +407,11 @@ Buffer VulkanAllocator::malloc(size_t size) {
     int64_t mem_to_free =
         get_active_memory() + get_cache_memory() + size - gc_limit_;
     if (mem_to_free > 0) {
-      num_resources_ -= buffer_cache_.release_cached_buffers(mem_to_free);
+      num_resources_ -= release_cached_buffers(mem_to_free);
     }
 
     if (num_resources_ >= resource_limit_) {
-      num_resources_ -=
-          buffer_cache_.release_cached_buffers(get_cache_memory());
+      num_resources_ -= release_cached_buffers(get_cache_memory());
       if (num_resources_ >= resource_limit_) {
         std::ostringstream msg;
         msg << "[vulkan::malloc] Resource limit (" << resource_limit_
@@ -369,7 +421,6 @@ Buffer VulkanAllocator::malloc(size_t size) {
     }
   }
 
-  auto& ctx = VulkanContext::get();
   auto vk_device = ctx.device();
 
   // Use C++ Vulkan API for buffer creation
@@ -405,24 +456,53 @@ Buffer VulkanAllocator::malloc(size_t size) {
     }
   }
 
-  std::vector<vk::MemoryPropertyFlags> preferred_memory_types;
-  if (ctx.is_unified_memory()) {
+  std::vector<PreferredMemoryType> preferred_memory_types;
+  if (require_host_visible && ctx.is_unified_memory()) {
     preferred_memory_types = {
-        vk::MemoryPropertyFlagBits::eDeviceLocal |
-            vk::MemoryPropertyFlagBits::eHostVisible |
-            vk::MemoryPropertyFlagBits::eHostCoherent,
-        vk::MemoryPropertyFlagBits::eHostVisible |
-            vk::MemoryPropertyFlagBits::eHostCoherent};
+        {vk::MemoryPropertyFlagBits::eDeviceLocal |
+             vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}},
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}}};
+  } else if (require_host_visible) {
+    preferred_memory_types = {
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent |
+             vk::MemoryPropertyFlagBits::eHostCached,
+         {}},
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}},
+        {vk::MemoryPropertyFlagBits::eDeviceLocal |
+             vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}}};
+  } else if (ctx.is_unified_memory()) {
+    preferred_memory_types = {
+        {vk::MemoryPropertyFlagBits::eDeviceLocal |
+             vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}},
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}}};
   } else {
     preferred_memory_types = {
-        vk::MemoryPropertyFlagBits::eDeviceLocal |
-            vk::MemoryPropertyFlagBits::eHostVisible |
-            vk::MemoryPropertyFlagBits::eHostCoherent,
-        vk::MemoryPropertyFlagBits::eHostVisible |
-            vk::MemoryPropertyFlagBits::eHostCoherent,
-        vk::MemoryPropertyFlagBits::eHostVisible |
-            vk::MemoryPropertyFlagBits::eHostCoherent |
-            vk::MemoryPropertyFlagBits::eHostCached};
+        {vk::MemoryPropertyFlagBits::eDeviceLocal,
+         vk::MemoryPropertyFlagBits::eHostVisible},
+        {vk::MemoryPropertyFlagBits::eDeviceLocal |
+             vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}},
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent,
+         {}},
+        {vk::MemoryPropertyFlagBits::eHostVisible |
+             vk::MemoryPropertyFlagBits::eHostCoherent |
+             vk::MemoryPropertyFlagBits::eHostCached,
+         {}}};
   }
 
   uint32_t memory_type_index = 0;
@@ -469,8 +549,7 @@ Buffer VulkanAllocator::malloc(size_t size) {
     // Maintain the cache below the requested limit.
     const auto pool_limit = cache_pool_limit(active_memory_, max_pool_size_);
     if (get_cache_memory() > pool_limit) {
-      num_resources_ -= buffer_cache_.release_cached_buffers(
-          get_cache_memory() - pool_limit);
+      num_resources_ -= release_cached_buffers(get_cache_memory() - pool_limit);
     }
   }
 
@@ -497,7 +576,11 @@ void VulkanAllocator::free(Buffer buffer) {
     if (buf->allocation_size <= cacheable_limit &&
         get_cache_memory() + buf->allocation_size <= pool_limit) {
       reset_buffer_sync_state(buf);
-      buffer_cache_.recycle_to_cache(buf);
+      if (buf->memory_flags & vk::MemoryPropertyFlagBits::eHostVisible) {
+        host_visible_buffer_cache_.recycle_to_cache(buf);
+      } else {
+        device_buffer_cache_.recycle_to_cache(buf);
+      }
       trace_free(buf->size, true);
       return;
     }
@@ -511,6 +594,9 @@ void VulkanAllocator::free(Buffer buffer) {
 
 void VulkanAllocator::free_vulkan_buffer(VulkanBuffer* buf) {
   auto vk_device = VulkanContext::get().device();
+  if (buf->mapped_ptr != nullptr) {
+    vk_device.unmapMemory(buf->memory);
+  }
   vk_device.destroyBuffer(buf->buffer);
   vk_device.freeMemory(buf->memory);
   delete buf;

--- a/mlx/backend/vulkan/allocator.h
+++ b/mlx/backend/vulkan/allocator.h
@@ -25,6 +25,7 @@ struct VulkanBuffer {
 
   void* mapped_ptr{nullptr};
   Buffer host_readback{nullptr};
+  bool host_readback_dirty{false};
   // Use C++ Vulkan API types
   vk::Buffer buffer;
   vk::DeviceMemory memory;

--- a/mlx/backend/vulkan/allocator.h
+++ b/mlx/backend/vulkan/allocator.h
@@ -24,6 +24,7 @@ struct VulkanBuffer {
   };
 
   void* mapped_ptr{nullptr};
+  Buffer host_readback{nullptr};
   // Use C++ Vulkan API types
   vk::Buffer buffer;
   vk::DeviceMemory memory;

--- a/mlx/backend/vulkan/allocator.h
+++ b/mlx/backend/vulkan/allocator.h
@@ -47,6 +47,7 @@ struct VulkanBuffer {
 class VulkanAllocator : public allocator::Allocator {
  public:
   Buffer malloc(size_t size) override;
+  Buffer malloc_host_visible(size_t size);
   void free(Buffer buffer) override;
   size_t size(Buffer buffer) const override;
   Buffer make_buffer(void* ptr, size_t size) override;
@@ -62,9 +63,7 @@ class VulkanAllocator : public allocator::Allocator {
     std::unique_lock lk(mutex_);
     peak_memory_ = 0;
   }
-  size_t get_cache_memory() const {
-    return buffer_cache_.cache_size();
-  }
+  size_t get_cache_memory() const;
   size_t set_cache_limit(size_t limit);
   size_t set_memory_limit(size_t limit);
   size_t get_memory_limit() const;
@@ -77,6 +76,8 @@ class VulkanAllocator : public allocator::Allocator {
   ~VulkanAllocator() = default;
   friend VulkanAllocator& allocator();
 
+  Buffer malloc_impl(size_t size, bool require_host_visible);
+  size_t release_cached_buffers(size_t min_bytes_to_free);
   void free_vulkan_buffer(VulkanBuffer* buf);
 
   size_t block_limit_{0};
@@ -90,7 +91,8 @@ class VulkanAllocator : public allocator::Allocator {
   size_t max_cacheable_size_{0};
   std::unordered_set<VulkanBuffer*> live_buffers_;
 
-  BufferCache<VulkanBuffer> buffer_cache_;
+  BufferCache<VulkanBuffer> device_buffer_cache_;
+  BufferCache<VulkanBuffer> host_visible_buffer_cache_;
 
   mutable std::mutex mutex_;
 };

--- a/mlx/backend/vulkan/binary.cpp
+++ b/mlx/backend/vulkan/binary.cpp
@@ -1067,8 +1067,7 @@ bool try_eval_binary_op_vulkan(
   const bool use_f32_staging_io =
       (std::string_view(op_name) == "div" &&
        (a.dtype() == float16 || b.dtype() == float16 ||
-        out.dtype() == float16 || a.dtype() == bfloat16 ||
-        b.dtype() == bfloat16 || out.dtype() == bfloat16)) ||
+        out.dtype() == float16)) ||
       mixed_bf16_f16;
   if (use_f32_staging_io) {
     array a_f32(a.shape(), float32, nullptr, {});

--- a/mlx/backend/vulkan/binary.cpp
+++ b/mlx/backend/vulkan/binary.cpp
@@ -5,6 +5,7 @@
 #include "mlx/backend/vulkan/primitives_utils.h"
 #include "mlx/backend/vulkan/shader_compiler.h"
 #include "mlx/backend/vulkan/vulkan.h"
+#include "mlx/transforms.h"
 #include "mlx/utils.h"
 
 #include <algorithm>
@@ -18,7 +19,8 @@ const array* broadcast_scalar_source(const array& arr, const array& out) {
   if (!arr.has_primitive()) {
     return nullptr;
   }
-  if (typeid(arr.primitive()) != typeid(Broadcast) || arr.inputs().size() != 1) {
+  if (typeid(arr.primitive()) != typeid(Broadcast) ||
+      arr.inputs().size() != 1) {
     return nullptr;
   }
   const array& src = arr.inputs()[0];
@@ -107,7 +109,7 @@ bool is_supported_binary_input_layout(const array& arr, uint32_t max_offset) {
        offset_fits_binary_operand(arr, max_offset));
 }
 
-void ensure_materialized_scalar_input(array& arr) {
+void schedule_materialized_scalar_input(array& arr) {
   if (arr.data_size() != 1 || !arr.has_primitive()) {
     return;
   }
@@ -116,7 +118,7 @@ void ensure_materialized_scalar_input(array& arr) {
       (data == nullptr || data->buffer.ptr() == nullptr)) {
     arr.set_status(array::Status::unscheduled);
   }
-  arr.eval();
+  async_eval(arr);
 }
 
 bool ensure_vulkan_buffer(array& arr, Stream s) {
@@ -125,9 +127,21 @@ bool ensure_vulkan_buffer(array& arr, Stream s) {
   }
 
   if (arr.has_primitive()) {
-    if (auto& p = arr.primitive();
-        typeid(p) == typeid(Broadcast) || typeid(p) == typeid(BroadcastAxes)) {
-      arr.eval();
+    auto data = arr.data_shared_ptr();
+    if (arr.status() != array::Status::unscheduled &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      arr.set_status(array::Status::unscheduled);
+    }
+    async_eval(arr);
+    if (has_vulkan_buffer(arr)) {
+      return true;
+    }
+    if (!arr.has_primitive()) {
+      auto data = arr.data_shared_ptr();
+      if (data == nullptr || data->buffer.ptr() == nullptr) {
+        return false;
+      }
+      arr = contiguous_copy_gpu(arr, s);
       return has_vulkan_buffer(arr);
     }
     arr = contiguous_copy_gpu(arr, s);
@@ -665,14 +679,14 @@ std::string build_divmod_shader(Dtype dtype) {
   os << vulkan::emit_dynamic_shader_preamble(
       dtype, dtype, dtype == int64 || dtype == uint64);
   os << "layout(push_constant) uniform PushConstants { uint a_offset; uint b_offset; uint q_offset; uint r_offset; uint total_elements; } pc;\n";
-  os << "layout(set = 0, binding = 0) readonly buffer InputA {"
-     << type_name << " data[];} a_buf;\n";
-  os << "layout(set = 0, binding = 1) readonly buffer InputB {"
-     << type_name << " data[];} b_buf;\n";
-  os << "layout(set = 0, binding = 2) buffer Quotient {"
-     << type_name << " data[];} q_buf;\n";
-  os << "layout(set = 0, binding = 3) buffer Remainder {"
-     << type_name << " data[];} r_buf;\n\n";
+  os << "layout(set = 0, binding = 0) readonly buffer InputA {" << type_name
+     << " data[];} a_buf;\n";
+  os << "layout(set = 0, binding = 1) readonly buffer InputB {" << type_name
+     << " data[];} b_buf;\n";
+  os << "layout(set = 0, binding = 2) buffer Quotient {" << type_name
+     << " data[];} q_buf;\n";
+  os << "layout(set = 0, binding = 3) buffer Remainder {" << type_name
+     << " data[];} r_buf;\n\n";
   os << "void main() {\n";
   os << "  uint idx = gl_GlobalInvocationID.x;\n";
   os << "  if (idx >= pc.total_elements) return;\n";
@@ -709,21 +723,20 @@ bool try_eval_divmod_vulkan(
   array b = b_input;
   auto& quotient = outputs[0];
   auto& remainder = outputs[1];
-  const bool float_case =
-      (a.dtype() == float16 || a.dtype() == float32) && a.dtype() == b.dtype() &&
-      a.dtype() == quotient.dtype() && a.dtype() == remainder.dtype();
-  const bool int_case = a.dtype() == b.dtype() && a.dtype() == quotient.dtype() &&
-      a.dtype() == remainder.dtype() &&
+  const bool float_case = (a.dtype() == float16 || a.dtype() == float32) &&
+      a.dtype() == b.dtype() && a.dtype() == quotient.dtype() &&
+      a.dtype() == remainder.dtype();
+  const bool int_case = a.dtype() == b.dtype() &&
+      a.dtype() == quotient.dtype() && a.dtype() == remainder.dtype() &&
       (a.dtype() == int16 || a.dtype() == uint16 || a.dtype() == int32 ||
        a.dtype() == uint32 || a.dtype() == int64 || a.dtype() == uint64);
-  if ((!float_case && !int_case) ||
-      quotient.shape() != remainder.shape()) {
+  if ((!float_case && !int_case) || quotient.shape() != remainder.shape()) {
     return false;
   }
 
   auto ensure_binary_input = [&](array& in) {
     if (in.data_size() == 1 && in.has_primitive()) {
-      ensure_materialized_scalar_input(in);
+      schedule_materialized_scalar_input(in);
     }
     return ensure_vulkan_buffer(in, s);
   };
@@ -799,8 +812,8 @@ bool try_eval_divmod_vulkan(
   vulkan::DynamicArrayRef arrays[] = {
       {&a, 0}, {&b, 1}, {&quotient_work, 2}, {&remainder_work, 3}};
   constexpr uint32_t kPushConstantSize = sizeof(uint32_t) * 5;
-  const std::string shader_name = "dynamic_divmod_v2_" +
-      std::to_string(static_cast<int>(a.dtype().val()));
+  const std::string shader_name =
+      "dynamic_divmod_v2_" + std::to_string(static_cast<int>(a.dtype().val()));
   auto dispatch = vulkan::dispatch_dynamic_compute_begin(
       shader_name,
       build_divmod_shader(a.dtype()),
@@ -907,11 +920,11 @@ bool try_eval_binary_op_vulkan(
   const bool bool_add = std::is_same_v<Primitive, Add> &&
       a_input.dtype() == bool_ && b_input.dtype() == bool_ &&
       out.dtype() == bool_;
-  const bool small_signed_integer_case =
-      a_input.dtype() == b_input.dtype() && a_input.dtype() == out.dtype() &&
+  const bool small_signed_integer_case = a_input.dtype() == b_input.dtype() &&
+      a_input.dtype() == out.dtype() &&
       (a_input.dtype() == int8 || a_input.dtype() == int16);
-  const bool small_unsigned_integer_case =
-      a_input.dtype() == b_input.dtype() && a_input.dtype() == out.dtype() &&
+  const bool small_unsigned_integer_case = a_input.dtype() == b_input.dtype() &&
+      a_input.dtype() == out.dtype() &&
       (a_input.dtype() == uint8 || a_input.dtype() == uint16);
   const bool float_case = is_vulkan_float_dtype(a_input.dtype()) &&
       is_vulkan_float_dtype(b_input.dtype()) &&
@@ -919,29 +932,21 @@ bool try_eval_binary_op_vulkan(
   const bool integer_case = a_input.dtype() == b_input.dtype() &&
       a_input.dtype() == out.dtype() &&
       is_vulkan_integer_dtype(a_input.dtype());
-  const bool complex_add =
-      std::is_same_v<Primitive, Add> &&
+  const bool complex_add = std::is_same_v<Primitive, Add> &&
       is_same_complex_add(a_input, b_input, out);
-  const bool complex_sub =
-      std::is_same_v<Primitive, Subtract> &&
+  const bool complex_sub = std::is_same_v<Primitive, Subtract> &&
       is_same_complex_sub(a_input, b_input, out);
-  const bool complex_scalar_mul =
-      std::is_same_v<Primitive, Multiply> &&
+  const bool complex_scalar_mul = std::is_same_v<Primitive, Multiply> &&
       is_complex_scalar_mul(a_input, b_input, out);
-  const bool complex_float_mul =
-      std::is_same_v<Primitive, Multiply> &&
+  const bool complex_float_mul = std::is_same_v<Primitive, Multiply> &&
       is_complex_float_mul(a_input, b_input, out);
-  const bool complex_mul =
-      std::is_same_v<Primitive, Multiply> &&
+  const bool complex_mul = std::is_same_v<Primitive, Multiply> &&
       is_same_complex_mul(a_input, b_input, out);
-  const bool complex_div =
-      std::is_same_v<Primitive, Divide> &&
+  const bool complex_div = std::is_same_v<Primitive, Divide> &&
       is_same_complex_div(a_input, b_input, out);
-  const bool complex_max =
-      std::is_same_v<Primitive, Maximum> &&
+  const bool complex_max = std::is_same_v<Primitive, Maximum> &&
       is_same_complex_max(a_input, b_input, out);
-  const bool complex_min =
-      std::is_same_v<Primitive, Minimum> &&
+  const bool complex_min = std::is_same_v<Primitive, Minimum> &&
       is_same_complex_min(a_input, b_input, out);
   if (!float_case && !integer_case && !bool_add && !mixed_numeric_div &&
       !complex_add && !complex_sub && !complex_scalar_mul &&
@@ -960,14 +965,14 @@ bool try_eval_binary_op_vulkan(
       (input_broadcast_scalar_b != nullptr && a_input.size() > 1);
   const bool scalar_is_a = scalar_vector_case &&
       (a_input.data_size() == 1 || input_broadcast_scalar_a != nullptr);
-  const array* vector_input = scalar_vector_case
-      ? (scalar_is_a ? &b_input : &a_input)
-      : nullptr;
-  const bool can_donate_scalar_vector_input =
-      scalar_vector_case && std::is_same_v<Primitive, Multiply> &&
-      vector_input != nullptr && has_vulkan_buffer(*vector_input) &&
-      is_donatable(*vector_input, out) && vector_input->dtype() == out.dtype() &&
-      vector_input->shape() == out.shape() && vector_input->flags().row_contiguous &&
+  const array* vector_input =
+      scalar_vector_case ? (scalar_is_a ? &b_input : &a_input) : nullptr;
+  const bool can_donate_scalar_vector_input = scalar_vector_case &&
+      std::is_same_v<Primitive, Multiply> && vector_input != nullptr &&
+      has_vulkan_buffer(*vector_input) && is_donatable(*vector_input, out) &&
+      vector_input->dtype() == out.dtype() &&
+      vector_input->shape() == out.shape() &&
+      vector_input->flags().row_contiguous &&
       vector_input->flags().contiguous &&
       vector_input->size() == vector_input->data_size() &&
       vector_input->offset() == 0 && vector_input->ndim() == 1 &&
@@ -979,10 +984,10 @@ bool try_eval_binary_op_vulkan(
   if ((a.data_size() == 1 && a.has_primitive()) ||
       (b.data_size() == 1 && b.has_primitive())) {
     if (a.data_size() == 1 && a.has_primitive()) {
-      ensure_materialized_scalar_input(a);
+      schedule_materialized_scalar_input(a);
     }
     if (b.data_size() == 1 && b.has_primitive()) {
-      ensure_materialized_scalar_input(b);
+      schedule_materialized_scalar_input(b);
     }
   }
 
@@ -1089,8 +1094,7 @@ bool try_eval_binary_op_vulkan(
     array& scalar = scalar_is_a ? a : b;
     if (scalar.shape() != Shape{} && scalar.data_size() == 1) {
       array scalar_base(Shape{}, scalar.dtype(), nullptr, {});
-      scalar_base.copy_shared_buffer(
-          scalar, Strides{}, {true, true, true}, 1);
+      scalar_base.copy_shared_buffer(scalar, Strides{}, {true, true, true}, 1);
       scalar = scalar_base;
     }
   }
@@ -1103,57 +1107,57 @@ bool try_eval_binary_op_vulkan(
   bool b_materialized = false;
   auto materialize_broadcast_input =
       [&](array& in, bool& was_materialized, bool allow_scalar_view) {
-    if (in.shape() == out.shape()) {
-      if (in.data_size() == 1 && in.size() != 1) {
-        if (allow_scalar_view) {
-          array view(out.shape(), in.dtype(), nullptr, {});
-          broadcast(in, view);
-          in = view;
+        if (in.shape() == out.shape()) {
+          if (in.data_size() == 1 && in.size() != 1) {
+            if (allow_scalar_view) {
+              array view(out.shape(), in.dtype(), nullptr, {});
+              broadcast(in, view);
+              in = view;
+              was_materialized = true;
+              return true;
+            }
+            if (in.has_primitive()) {
+              schedule_materialized_scalar_input(in);
+            }
+            array materialized_arr(out.shape(), in.dtype(), nullptr, {});
+            copy_gpu(in, materialized_arr, CopyType::Scalar, s);
+            in = materialized_arr;
+            was_materialized = true;
+          }
+          return true;
+        }
+        if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
+          return false;
+        }
+        if (in.data_size() == 1) {
+          if (allow_scalar_view) {
+            array view(out.shape(), in.dtype(), nullptr, {});
+            broadcast(in, view);
+            in = view;
+            was_materialized = true;
+            return true;
+          }
+          array broadcast_arr(
+              out.shape(),
+              in.dtype(),
+              std::make_shared<Broadcast>(s, out.shape()),
+              {in});
+          schedule_materialized_scalar_input(broadcast_arr);
+          array materialized_arr(out.shape(), in.dtype(), nullptr, {});
+          copy_gpu(broadcast_arr, materialized_arr, CopyType::Scalar, s);
+          in = materialized_arr;
           was_materialized = true;
           return true;
         }
-        if (in.has_primitive()) {
-          ensure_materialized_scalar_input(in);
+        if (!ensure_vulkan_buffer(in, s)) {
+          return false;
         }
-        array materialized_arr(out.shape(), in.dtype(), nullptr, {});
-        copy_gpu(in, materialized_arr, CopyType::Scalar, s);
-        in = materialized_arr;
-        was_materialized = true;
-      }
-      return true;
-    }
-    if (broadcast_shapes(in.shape(), out.shape()) != out.shape()) {
-      return false;
-    }
-    if (in.data_size() == 1) {
-      if (allow_scalar_view) {
         array view(out.shape(), in.dtype(), nullptr, {});
         broadcast(in, view);
         in = view;
         was_materialized = true;
         return true;
-      }
-      array broadcast_arr(
-          out.shape(),
-          in.dtype(),
-          std::make_shared<Broadcast>(s, out.shape()),
-          {in});
-      ensure_materialized_scalar_input(broadcast_arr);
-      array materialized_arr(out.shape(), in.dtype(), nullptr, {});
-      copy_gpu(broadcast_arr, materialized_arr, CopyType::Scalar, s);
-      in = materialized_arr;
-      was_materialized = true;
-      return true;
-    }
-    if (!ensure_vulkan_buffer(in, s)) {
-      return false;
-    }
-    array view(out.shape(), in.dtype(), nullptr, {});
-    broadcast(in, view);
-    in = view;
-    was_materialized = true;
-    return true;
-  };
+      };
 
   const bool allow_subtract_scalar_rhs_view =
       std::is_same_v<Primitive, Subtract> && b.data_size() == 1;
@@ -1384,8 +1388,7 @@ VULKAN_BINARY_GPU(Multiply, "mul")
 
 void Remainder::eval_gpu(const std::vector<array>& inputs, array& out) {
   if (!try_eval_remainder_vulkan(inputs, out, stream())) {
-    throw std::runtime_error(
-        "Remainder has no Vulkan implementation.");
+    throw std::runtime_error("Remainder has no Vulkan implementation.");
   }
 }
 

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -1185,10 +1185,6 @@ void Compiled::eval_gpu(
   auto* pipeline =
       manager.get_pipeline(kernel_name, bindings, push_constant_size);
 
-  // Get command buffer
-  auto cmd_buffer = vulkan::begin_command_recording(s.index);
-  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
-
   const bool use_push_descriptor = pipeline->supports_push_descriptor;
 
   // Prepare descriptor writes
@@ -1304,9 +1300,20 @@ void Compiled::eval_gpu(
     }
   }
 
-  auto params_array =
-      array(params_data.data(), {static_cast<int>(params_data.size())}, uint32);
-  params_array.eval();
+  array params_array({static_cast<int>(params_data.size())}, uint32, nullptr, {});
+  params_array.set_data(allocator::malloc(params_array.nbytes()));
+  auto* params_buffer =
+      static_cast<vulkan::VulkanBuffer*>(params_array.buffer().ptr());
+  if (params_buffer == nullptr || !params_buffer->buffer) {
+    throw std::runtime_error("Missing Vulkan params buffer for compiled kernel");
+  }
+  vulkan::enqueue_owned_staging_upload(
+      s,
+      params_data.data(),
+      params_array.nbytes(),
+      params_buffer->buffer,
+      params_array.offset() * size_of(params_array.dtype()),
+      params_array.data_shared_ptr());
   add_buffer(params_array);
   vulkan::retain_array_for_stream(s, params_array);
   writes.push_back({});
@@ -1330,6 +1337,10 @@ void Compiled::eval_gpu(
       }
     }
   }
+
+  // Get command buffer after transfer uploads have been enqueued.
+  auto cmd_buffer = vulkan::begin_command_recording(s.index);
+  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
 
   auto update_descriptor_set_for_chunk = [&](uint64_t chunk_base_elements,
                                              uint64_t chunk_elements) {

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -1486,6 +1486,7 @@ void Compiled::eval_gpu(
           s.index, descriptor_epoch, descriptor_set);
     }
   }
+  vulkan::end_command_recording(s.index);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -1187,6 +1187,11 @@ void Compiled::eval_gpu(
 
   const bool use_push_descriptor = pipeline->supports_push_descriptor;
 
+  // Get command buffer before retaining descriptor buffers so temporary runtime
+  // params are kept alive by the submission that reads them.
+  auto cmd_buffer = vulkan::begin_command_recording(s.index);
+  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
+
   // Prepare descriptor writes
   std::vector<VkWriteDescriptorSet> writes;
   std::vector<VkDescriptorBufferInfo> buffer_infos;
@@ -1326,10 +1331,6 @@ void Compiled::eval_gpu(
       }
     }
   }
-
-  // Get command buffer
-  auto cmd_buffer = vulkan::begin_command_recording(s.index);
-  const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
 
   auto update_descriptor_set_for_chunk = [&](uint64_t chunk_base_elements,
                                              uint64_t chunk_elements) {

--- a/mlx/backend/vulkan/compiled.cpp
+++ b/mlx/backend/vulkan/compiled.cpp
@@ -1300,20 +1300,9 @@ void Compiled::eval_gpu(
     }
   }
 
-  array params_array({static_cast<int>(params_data.size())}, uint32, nullptr, {});
-  params_array.set_data(allocator::malloc(params_array.nbytes()));
-  auto* params_buffer =
-      static_cast<vulkan::VulkanBuffer*>(params_array.buffer().ptr());
-  if (params_buffer == nullptr || !params_buffer->buffer) {
-    throw std::runtime_error("Missing Vulkan params buffer for compiled kernel");
-  }
-  vulkan::enqueue_owned_staging_upload(
-      s,
-      params_data.data(),
-      params_array.nbytes(),
-      params_buffer->buffer,
-      params_array.offset() * size_of(params_array.dtype()),
-      params_array.data_shared_ptr());
+  auto params_array =
+      array(params_data.data(), {static_cast<int>(params_data.size())}, uint32);
+  params_array.eval();
   add_buffer(params_array);
   vulkan::retain_array_for_stream(s, params_array);
   writes.push_back({});
@@ -1338,7 +1327,7 @@ void Compiled::eval_gpu(
     }
   }
 
-  // Get command buffer after transfer uploads have been enqueued.
+  // Get command buffer
   auto cmd_buffer = vulkan::begin_command_recording(s.index);
   const uint64_t descriptor_epoch = vulkan::descriptor_epoch_for_stream(s);
 
@@ -1497,7 +1486,6 @@ void Compiled::eval_gpu(
           s.index, descriptor_epoch, descriptor_set);
     }
   }
-  vulkan::end_command_recording(s.index);
 }
 
 } // namespace mlx::core

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -280,6 +280,19 @@ std::string build_dynamic_general_copy_shader(
   if (use_u32_indices) {
     os << "  uint input_base;\n";
     os << "  uint output_base;\n";
+    os << "  uint rank;\n";
+    os << "  uint shape0;\n";
+    os << "  uint shape1;\n";
+    os << "  uint shape2;\n";
+    os << "  uint shape3;\n";
+    os << "  uint input_stride0;\n";
+    os << "  uint input_stride1;\n";
+    os << "  uint input_stride2;\n";
+    os << "  uint input_stride3;\n";
+    os << "  uint output_stride0;\n";
+    os << "  uint output_stride1;\n";
+    os << "  uint output_stride2;\n";
+    os << "  uint output_stride3;\n";
   } else {
     os << "  int64_t input_base;\n";
     os << "  int64_t output_base;\n";
@@ -299,6 +312,28 @@ std::string build_dynamic_general_copy_shader(
   if (has_dynamic_o_offset) {
     os << "layout(set = 0, binding = 3) readonly buffer DynamicOutputOffset {int64_t data[];} dynamic_o_offset_buf;\n";
   }
+  if (use_u32_indices) {
+    os << R"(
+uint shape_dim(uint dim) {
+  if (dim == 0u) return pc.shape0;
+  if (dim == 1u) return pc.shape1;
+  if (dim == 2u) return pc.shape2;
+  return pc.shape3;
+}
+uint input_stride_dim(uint dim) {
+  if (dim == 0u) return pc.input_stride0;
+  if (dim == 1u) return pc.input_stride1;
+  if (dim == 2u) return pc.input_stride2;
+  return pc.input_stride3;
+}
+uint output_stride_dim(uint dim) {
+  if (dim == 0u) return pc.output_stride0;
+  if (dim == 1u) return pc.output_stride1;
+  if (dim == 2u) return pc.output_stride2;
+  return pc.output_stride3;
+}
+)";
+  }
   os << "\nvoid main() {\n";
   os << "  uint linear_idx = gl_GlobalInvocationID.x;\n";
   os << "  if (linear_idx >= pc.total_elements) {\n";
@@ -314,24 +349,27 @@ std::string build_dynamic_general_copy_shader(
   if (has_dynamic_o_offset) {
     os << "  output_index += dynamic_o_offset_buf.data[uint(pc.dynamic_o_base)];\n";
   }
-  if (!shape.empty()) {
+  if (use_u32_indices) {
+    os << "  uint remaining = linear_idx;\n";
+    os << "  for (int dim = int(pc.rank) - 1; dim >= 0; --dim) {\n";
+    os << "    uint dim_u = uint(dim);\n";
+    os << "    uint extent = shape_dim(dim_u);\n";
+    os << "    uint coord = remaining % extent;\n";
+    os << "    remaining /= extent;\n";
+    os << "    input_index += coord * input_stride_dim(dim_u);\n";
+    os << "    output_index += coord * output_stride_dim(dim_u);\n";
+    os << "  }\n";
+  } else if (!shape.empty()) {
     os << "  uint remaining = linear_idx;\n";
     for (int dim = static_cast<int>(shape.size()) - 1; dim >= 0; --dim) {
       os << "  {\n";
       os << "    uint coord = remaining % " << static_cast<uint32_t>(shape[dim])
          << "u;\n";
       os << "    remaining /= " << static_cast<uint32_t>(shape[dim]) << "u;\n";
-      if (use_u32_indices) {
-        os << "    input_index += coord * "
-           << static_cast<uint32_t>(i_strides[dim]) << "u;\n";
-        os << "    output_index += coord * "
-           << static_cast<uint32_t>(o_strides[dim]) << "u;\n";
-      } else {
-        os << "    input_index += int64_t(coord) * "
-           << glsl_i64_literal(i_strides[dim]) << ";\n";
-        os << "    output_index += int64_t(coord) * "
-           << glsl_i64_literal(o_strides[dim]) << ";\n";
-      }
+      os << "    input_index += int64_t(coord) * "
+         << glsl_i64_literal(i_strides[dim]) << ";\n";
+      os << "    output_index += int64_t(coord) * "
+         << glsl_i64_literal(o_strides[dim]) << ";\n";
       os << "  }\n";
     }
   }
@@ -460,11 +498,15 @@ bool dispatch_dynamic_general_copy(
              << use_u32_indices << ':'
              << dynamic_i_offset.has_value() << ':'
              << dynamic_o_offset.has_value() << ':';
-  append_layout_key(layout_key, shape);
-  layout_key << ':';
-  append_layout_key(layout_key, i_strides);
-  layout_key << ':';
-  append_layout_key(layout_key, o_strides);
+  if (use_u32_indices) {
+    layout_key << "rank=" << shape.size();
+  } else {
+    append_layout_key(layout_key, shape);
+    layout_key << ':';
+    append_layout_key(layout_key, i_strides);
+    layout_key << ':';
+    append_layout_key(layout_key, o_strides);
+  }
 
   const std::string shader_name = "dynamic_general_copy_" +
       copy_dtype_suffix(in.dtype()) + "_" + copy_dtype_suffix(out.dtype()) +
@@ -494,6 +536,10 @@ bool dispatch_dynamic_general_copy(
     uint32_t total_elements;
     uint32_t input_base;
     uint32_t output_base;
+    uint32_t rank;
+    uint32_t shape[4];
+    uint32_t input_strides[4];
+    uint32_t output_strides[4];
   };
   struct PushConstants64 {
     uint32_t total_elements;
@@ -518,6 +564,12 @@ bool dispatch_dynamic_general_copy(
     pc.total_elements = static_cast<uint32_t>(total_elements);
     pc.input_base = static_cast<uint32_t>(input_base);
     pc.output_base = static_cast<uint32_t>(output_base);
+    pc.rank = static_cast<uint32_t>(shape.size());
+    for (size_t i = 0; i < shape.size(); ++i) {
+      pc.shape[i] = static_cast<uint32_t>(shape[i]);
+      pc.input_strides[i] = static_cast<uint32_t>(i_strides[i]);
+      pc.output_strides[i] = static_cast<uint32_t>(o_strides[i]);
+    }
     vkCmdPushConstants(
         dispatch.command_buffer,
         dispatch.pipeline->layout,

--- a/mlx/backend/vulkan/copy.cpp
+++ b/mlx/backend/vulkan/copy.cpp
@@ -10,6 +10,8 @@
 #include "mlx/backend/vulkan/vulkan.h"
 #include "mlx/primitives.h"
 #include "mlx/stream.h"
+#include "mlx/transforms.h"
+#include "mlx/transforms_impl.h"
 
 #include <algorithm>
 #include <cstring>
@@ -1412,8 +1414,17 @@ void copy_gpu_inplace(
   const array* source = &in;
   if (in.has_primitive()) {
     materialized_in.emplace(in);
-    if (materialized_in->status() == array::Status::unscheduled) {
-      materialized_in->eval();
+    if (detail::in_tracing() || detail::retain_graph()) {
+      if (materialized_in->status() == array::Status::unscheduled) {
+        materialized_in->eval();
+      }
+    } else {
+      auto data = materialized_in->data_shared_ptr();
+      if (materialized_in->status() != array::Status::unscheduled &&
+          (data == nullptr || data->buffer.ptr() == nullptr)) {
+        materialized_in->set_status(array::Status::unscheduled);
+      }
+      async_eval(*materialized_in);
     }
     source = &*materialized_in;
   } else {

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -417,7 +417,7 @@ void pop_sync_label() {
   }
 }
 
-void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
+void sync_copy_buffer(vk::Buffer src, vk::Buffer dst, size_t size) {
   if (size == 0 || !src || !dst) {
     return;
   }
@@ -425,9 +425,8 @@ void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
   auto& ctx = VulkanContext::get();
   auto device = ctx.device();
   const bool use_transfer = ctx.has_separate_transfer_queue();
-  const uint32_t queue_family = use_transfer
-      ? ctx.transfer_queue_family_index()
-      : ctx.compute_queue_family_index();
+  const uint32_t queue_family = use_transfer ? ctx.transfer_queue_family_index()
+                                             : ctx.compute_queue_family_index();
   const vk::Queue queue =
       use_transfer ? ctx.transfer_queue() : ctx.compute_queue();
 
@@ -439,8 +438,9 @@ void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
       pool, vk::CommandBufferLevel::ePrimary, 1);
   vk::CommandBuffer cmd = device.allocateCommandBuffers(alloc_info).front();
 
-  cmd.begin(vk::CommandBufferBeginInfo(
-      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+  cmd.begin(
+      vk::CommandBufferBeginInfo(
+          vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
   vk::BufferCopy copy_region(0, 0, size);
   cmd.copyBuffer(src, dst, copy_region);
   cmd.end();
@@ -455,6 +455,14 @@ void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
 
   device.destroyFence(fence);
   device.destroyCommandPool(pool);
+}
+
+void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
+  sync_copy_buffer(src, dst, size);
+}
+
+void sync_copy_buffer_to_device(vk::Buffer src, vk::Buffer dst, size_t size) {
+  sync_copy_buffer(src, dst, size);
 }
 
 void ensure_host_readback_mirror(VulkanBuffer* buffer) {
@@ -480,6 +488,8 @@ void ensure_host_readback_mirror(VulkanBuffer* buffer) {
   }
 
   sync_copy_buffer_to_host(buffer->buffer, host_buf->buffer, buffer->size);
+  std::lock_guard<std::mutex> lock(buffer->queue_affinity_mutex);
+  buffer->host_readback_dirty = false;
 }
 
 } // namespace
@@ -1427,6 +1437,7 @@ class VulkanDevice {
     // Release references held by already-completed submissions before backend
     // primitives decide whether input buffers are uniquely owned and donatable.
     retire_submissions(stream, false);
+    flush_host_readback_writes(inputs);
 
     if (!deferred_submission_enabled()) {
       return;
@@ -1790,6 +1801,40 @@ class VulkanDevice {
     }
 
     return ranges;
+  }
+
+  void flush_host_readback_writes(const std::vector<array>& arrays) {
+    for (const auto& arr : arrays) {
+      auto data = arr.data_shared_ptr();
+      auto* buffer = referenced_vulkan_buffer(data);
+      if (buffer == nullptr || !buffer->buffer ||
+          buffer->mapped_ptr != nullptr) {
+        continue;
+      }
+
+      bool dirty = false;
+      {
+        std::lock_guard<std::mutex> lock(buffer->queue_affinity_mutex);
+        dirty = buffer->host_readback_dirty;
+      }
+      if (!dirty) {
+        continue;
+      }
+
+      auto* host_buf = static_cast<VulkanBuffer*>(buffer->host_readback.ptr());
+      if (host_buf == nullptr || host_buf->mapped_ptr == nullptr ||
+          !host_buf->buffer) {
+        continue;
+      }
+
+      std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+      sync_copy_buffer_to_device(
+          host_buf->buffer, buffer->buffer, buffer->size);
+      {
+        std::lock_guard<std::mutex> lock(buffer->queue_affinity_mutex);
+        buffer->host_readback_dirty = false;
+      }
+    }
   }
 
   static std::vector<BufferAccessRange> make_potential_donation_writes(

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -532,7 +532,8 @@ constexpr size_t kStagingArenaAlignment = 256;
 constexpr size_t kDefaultStagingArenaBytes = 1 << 20;
 
 std::shared_ptr<array::Data> make_owned_staging_allocation(size_t size) {
-  auto data = std::make_shared<array::Data>(allocator::malloc(size));
+  auto data =
+      std::make_shared<array::Data>(allocator().malloc_host_visible(size));
   auto* buffer = static_cast<VulkanBuffer*>(data->buffer.ptr());
   if (buffer == nullptr || !buffer->buffer || buffer->mapped_ptr == nullptr) {
     throw std::runtime_error(

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -107,10 +107,10 @@ uint32_t max_adaptive_deferred_ops() {
         const int parsed = std::stoi(env);
         return parsed > 0 ? static_cast<uint32_t>(parsed) : 1u;
       } catch (...) {
-        return 128u;
+        return 32u;
       }
     }
-    return 128u;
+    return 32u;
   }();
   return value;
 }

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -417,6 +417,71 @@ void pop_sync_label() {
   }
 }
 
+void sync_copy_buffer_to_host(vk::Buffer src, vk::Buffer dst, size_t size) {
+  if (size == 0 || !src || !dst) {
+    return;
+  }
+
+  auto& ctx = VulkanContext::get();
+  auto device = ctx.device();
+  const bool use_transfer = ctx.has_separate_transfer_queue();
+  const uint32_t queue_family = use_transfer
+      ? ctx.transfer_queue_family_index()
+      : ctx.compute_queue_family_index();
+  const vk::Queue queue =
+      use_transfer ? ctx.transfer_queue() : ctx.compute_queue();
+
+  vk::CommandPoolCreateInfo pool_info(
+      vk::CommandPoolCreateFlagBits::eTransient, queue_family);
+  vk::CommandPool pool = device.createCommandPool(pool_info);
+
+  vk::CommandBufferAllocateInfo alloc_info(
+      pool, vk::CommandBufferLevel::ePrimary, 1);
+  vk::CommandBuffer cmd = device.allocateCommandBuffers(alloc_info).front();
+
+  cmd.begin(vk::CommandBufferBeginInfo(
+      vk::CommandBufferUsageFlagBits::eOneTimeSubmit));
+  vk::BufferCopy copy_region(0, 0, size);
+  cmd.copyBuffer(src, dst, copy_region);
+  cmd.end();
+
+  vk::Fence fence = device.createFence(vk::FenceCreateInfo{});
+  vk::SubmitInfo submit_info;
+  submit_info.setCommandBuffers(cmd);
+  queue.submit(submit_info, fence);
+  throw_if_vk_error(
+      static_cast<VkResult>(device.waitForFences(fence, VK_TRUE, UINT64_MAX)),
+      "[vulkan::raw_ptr] Failed waiting for host readback copy");
+
+  device.destroyFence(fence);
+  device.destroyCommandPool(pool);
+}
+
+void ensure_host_readback_mirror(VulkanBuffer* buffer) {
+  if (buffer == nullptr || buffer->mapped_ptr != nullptr || buffer->size == 0 ||
+      !buffer->buffer) {
+    return;
+  }
+
+  auto* host_buf = static_cast<VulkanBuffer*>(buffer->host_readback.ptr());
+  if (host_buf == nullptr ||
+      host_buf->allocation_size < buffer->allocation_size) {
+    if (buffer->host_readback.ptr() != nullptr) {
+      allocator().free(buffer->host_readback);
+    }
+    buffer->host_readback =
+        allocator().malloc_host_visible(buffer->allocation_size);
+    host_buf = static_cast<VulkanBuffer*>(buffer->host_readback.ptr());
+  }
+  if (host_buf == nullptr || host_buf->mapped_ptr == nullptr ||
+      !host_buf->buffer) {
+    throw std::runtime_error(
+        "[vulkan::raw_ptr] Failed to allocate host readback mirror.");
+  }
+
+  sync_copy_buffer_to_host(buffer->buffer, host_buf->buffer, buffer->size);
+}
+
 } // namespace
 
 // Stream data structure for Vulkan
@@ -934,6 +999,10 @@ class VulkanDevice {
     trace_sync(oss.str());
 
     if (!wait_semaphore || wait_timeline_value == 0) {
+      if (buffer->mapped_ptr == nullptr && buffer->size > 0) {
+        std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+        ensure_host_readback_mirror(buffer);
+      }
       return;
     }
 
@@ -956,6 +1025,11 @@ class VulkanDevice {
       buffer->last_semaphore = vk::Semaphore();
       buffer->last_timeline_value = 0;
       buffer->queue_affinity = VulkanBuffer::QueueAffinity::None;
+    }
+
+    if (buffer->mapped_ptr == nullptr) {
+      std::lock_guard<std::mutex> queue_lock(queue_mutex_);
+      ensure_host_readback_mirror(buffer);
     }
   }
 

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -849,6 +849,16 @@ class VulkanDevice {
       submit_commands(stream, "finalize");
     }
     retire_submissions(stream, false);
+    if (stream->in_flight_submissions.size() > max_inflight_submissions()) {
+      if (trace_sync_enabled()) {
+        std::ostringstream oss;
+        oss << "finalize(stream=" << s.index << ") action=drain-inflight"
+            << " inflight=" << stream->in_flight_submissions.size()
+            << " limit=" << max_inflight_submissions();
+        trace_sync(oss.str());
+      }
+      retire_submissions(stream, true);
+    }
     if (trace_sync_enabled()) {
       std::ostringstream oss;
       oss << "finalize(stream=" << s.index
@@ -2218,6 +2228,7 @@ class VulkanDevice {
       VkPhysicalDeviceProperties props{};
       vkGetPhysicalDeviceProperties(
           VulkanContext::get().physical_device(), &props);
+      auto recent_primitives = stream->recent_primitives;
 
       stream->recording = false;
       stream->recording_epoch = 0;
@@ -2267,13 +2278,13 @@ class VulkanDevice {
               << " submit_reason='" << submit_reason << "'"
               << " reset_pool=" << format_vk_result(reset_pool_result)
               << " device='" << props.deviceName << "'";
-      if (!stream->recent_primitives.empty()) {
+      if (!recent_primitives.empty()) {
         details << " recent_primitives='";
-        for (size_t i = 0; i < stream->recent_primitives.size(); ++i) {
+        for (size_t i = 0; i < recent_primitives.size(); ++i) {
           if (i > 0) {
             details << ",";
           }
-          details << stream->recent_primitives[i];
+          details << recent_primitives[i];
         }
         details << "'";
       }

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -1446,6 +1446,11 @@ bool is_supported_sdpa_rowwise_layout(const array& arr) {
       arr.strides().back() == 1;
 }
 
+bool is_supported_sdpa_matvec_layout(const array& arr) {
+  return arr.flags().row_contiguous && arr.offset() == 0 && arr.ndim() > 0 &&
+      arr.strides().back() == 1;
+}
+
 bool has_vulkan_buffer_fast(const array& arr) {
   auto data = arr.data_shared_ptr();
   return data != nullptr && data->buffer.ptr() != nullptr;
@@ -1943,14 +1948,10 @@ bool try_eval_sdpa_heads_vulkan(
       // q: scale + cast to f32
       array q_f32 =
           cast_to_f32_sdpa(multiply(array(scale, q_in.dtype()), q_in, s), s);
-      // K/V: cast original (bf16/f16) directly to f16 for NC matvec.
-      array k_f16(k_in.shape(), float16, nullptr, {});
-      copy_gpu(k_in, k_f16, CopyType::General, s);
-      k_f16.set_status(array::Status::evaluated);
-
-      array v_f16(v_in.shape(), float16, nullptr, {});
-      copy_gpu(v_in, v_f16, CopyType::General, s);
-      v_f16.set_status(array::Status::evaluated);
+      // K: reuse f16 KV cache buffers directly when possible. bf16 still needs
+      // one conversion pass because the NC matvec kernel consumes f16 matrices.
+      array k_f16 =
+          cast_flash_attention_kv_to_f16(k_in, kFlashAttnKCastScratchLane, s);
 
       // q in head layout, must be contiguous for matvec
       stage = "reshape_q_decode";
@@ -1959,9 +1960,9 @@ bool try_eval_sdpa_heads_vulkan(
       q_heads = ensure_sdpa_rowwise_layout(q_heads, s);
       q_heads.set_status(array::Status::evaluated);
 
-      // k is already in [batch, n_kv_heads, kv_len, q_dim] f16.
-      // Ensure k is row-contiguous so matvec strides are trivial.
-      if (!is_supported_sdpa_rowwise_layout(k_f16)) {
+      // k is already in [batch, n_kv_heads, kv_len, q_dim] f16. The NC matvec
+      // accepts explicit outer strides, so only require a dense inner row.
+      if (!is_supported_sdpa_matvec_layout(k_f16)) {
         k_f16 = contiguous_copy_gpu(k_f16, s);
       }
       k_f16.set_status(array::Status::evaluated);
@@ -2068,16 +2069,12 @@ bool try_eval_sdpa_heads_vulkan(
       // --- Scores×V matvec via NC dispatch (matrix = v_f16, vec = probs)
       // ------
       stage = "result_matmul_decode";
-      // Ensure v_f16 is contiguous before swapaxes
-      if (!is_supported_sdpa_rowwise_layout(v_f16)) {
-        v_f16 = contiguous_copy_gpu(v_f16, s);
-      }
-      v_f16.set_status(array::Status::evaluated);
-
-      array v_t = swapaxes_in_eval(v_f16, -1, -2);
-      if (!is_supported_sdpa_rowwise_layout(v_t)) {
-        v_t = contiguous_copy_gpu(v_t, s);
-      }
+      Shape v_t_shape = v_in.shape();
+      std::swap(v_t_shape[v_t_shape.size() - 2], v_t_shape.back());
+      array v_src = swap_sdpa_last_two_dims_view(v_in);
+      array v_t = vulkan::acquire_scratch_array(
+          s, kFlashAttnVCastScratchLane, v_t_shape, float16);
+      copy_gpu(v_src, v_t, CopyType::General, s);
       v_t.set_status(array::Status::evaluated);
 
       {

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -1735,9 +1735,8 @@ void eval_sdpa_softmax_vulkan(array in, array& out, Stream s) {
         "SDPA softmax requires float16 or float32 tensors.");
   }
 
-  array in_work = use_f16_variant ? cast_to_f32_sdpa(in, s) : in;
-  array out_work =
-      use_f16_variant ? array(out.shape(), float32, nullptr, {}) : out;
+  array in_work = in;
+  array out_work = out;
 
   in_work = ensure_sdpa_rowwise_layout(in_work, s);
   out_work.set_data(allocator::malloc(out_work.nbytes()));
@@ -1753,11 +1752,11 @@ void eval_sdpa_softmax_vulkan(array in, array& out, Stream s) {
       vulkan::dispatch_softmax_large_op(
           in_work,
           out_work,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large1_f32_f16
+          use_f16_variant ? vulkan::StaticShaderId::soft_max_large1_f16
                           : vulkan::StaticShaderId::soft_max_large1_f32,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large2_f32_f16
+          use_f16_variant ? vulkan::StaticShaderId::soft_max_large2_f16
                           : vulkan::StaticShaderId::soft_max_large2_f32,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large3_f32_f16
+          use_f16_variant ? vulkan::StaticShaderId::soft_max_large3_f16
                           : vulkan::StaticShaderId::soft_max_large3_f32,
           command_buffer,
           s);
@@ -1765,7 +1764,7 @@ void eval_sdpa_softmax_vulkan(array in, array& out, Stream s) {
       vulkan::dispatch_softmax_op(
           in_work,
           out_work,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_f32_f16
+          use_f16_variant ? vulkan::StaticShaderId::soft_max_f16
                           : vulkan::StaticShaderId::soft_max_f32,
           command_buffer,
           s);
@@ -1776,9 +1775,6 @@ void eval_sdpa_softmax_vulkan(array in, array& out, Stream s) {
     throw;
   }
   end_tracked_manual_op(s, tracked_inputs, tracked_outputs);
-  if (use_f16_variant) {
-    copy_gpu(out_work, out, CopyType::General, s);
-  }
   out.set_status(array::Status::evaluated);
 }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -1213,7 +1213,6 @@ bool try_dispatch_flash_attention_native_vulkan(
       vulkan::mark_scratch_array_written(s, kFlashAttnSplitKScratchLane);
     }
 
-    vulkan::set_force_immediate_submit(s);
     vulkan::end_command_recording(s.index);
     return true;
   } catch (const std::runtime_error& e) {

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -521,6 +521,29 @@ array cast_flash_attention_q_to_f32(const array& x, Stream s) {
   return out;
 }
 
+array make_flash_attention_output_target(
+    array& out,
+    Stream s,
+    bool& uses_out_storage) {
+  const Shape kernel_shape = {
+      out.shape(0), out.shape(2), out.shape(1), out.shape(3)};
+  uses_out_storage = out.dtype() == float32;
+  if (!uses_out_storage) {
+    return vulkan::acquire_scratch_array(
+        s, kFlashAttnOutScratchLane, kernel_shape, float32);
+  }
+
+  out.set_data(allocator::malloc(out.nbytes()));
+  array out_storage(kernel_shape, float32, nullptr, {});
+  out_storage.copy_shared_buffer(
+      out,
+      make_contiguous_strides(kernel_shape),
+      {true, true, false},
+      out.data_size(),
+      out.offset());
+  return out_storage;
+}
+
 struct FlashAttentionTuningParams {
   enum class Path {
     Scalar,
@@ -1354,11 +1377,9 @@ bool try_eval_flash_attention_vulkan(
   try {
     const bool use_causal_shader = do_causal && q_len > 1;
 
-    array out_storage = vulkan::acquire_scratch_array(
-        s,
-        kFlashAttnOutScratchLane,
-        {out.shape(0), out.shape(2), out.shape(1), out.shape(3)},
-        float32);
+    bool uses_out_storage = false;
+    array out_storage =
+        make_flash_attention_output_target(out, s, uses_out_storage);
 
     if (!try_dispatch_flash_attention_native_vulkan(
             q,
@@ -1374,12 +1395,23 @@ bool try_eval_flash_attention_vulkan(
             scale)) {
       return false;
     }
-    vulkan::mark_scratch_array_written(s, kFlashAttnOutScratchLane);
+    if (!uses_out_storage) {
+      vulkan::mark_scratch_array_written(s, kFlashAttnOutScratchLane);
+    }
 
     array out_transposed = swapaxes_in_eval(out_storage, 1, 2);
     trace_flash_attention_array("out_storage", out_storage);
     trace_flash_attention_array("out_transposed", out_transposed);
-    copy_gpu(out_transposed, out, CopyType::General, s);
+    if (uses_out_storage) {
+      out.copy_shared_buffer(
+          out_transposed,
+          out_transposed.strides(),
+          out_transposed.flags(),
+          out_transposed.data_size(),
+          out_transposed.offset());
+    } else {
+      copy_gpu(out_transposed, out, CopyType::General, s);
+    }
     out.set_status(array::Status::evaluated);
     return true;
   } catch (const std::runtime_error& e) {

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -54,6 +54,7 @@ namespace {
 constexpr char kSoftmaxLargeMaxScratchLane[] = "softmax.large.tmp_max";
 constexpr char kSoftmaxLargeSumScratchLane[] = "softmax.large.tmp_sum";
 constexpr char kCumsumMultipassScratchLane[] = "cumsum.multipass.tmp";
+constexpr char kArgsortLargeScratchLane[] = "argsort.large.tmp";
 constexpr uint32_t kDescriptorSetBatchSize = 32;
 constexpr uint32_t kVendorIdAmd = 0x1002u;
 constexpr uint32_t kVendorIdIntel = 0x8086u;
@@ -2759,12 +2760,11 @@ void dispatch_argsort_op(
 
   if (large_sort) {
     const uint32_t wg_unroll = ncols_padded / 1024u;
-    array tmp(
+    array tmp = acquire_scratch_array(
+        s,
+        kArgsortLargeScratchLane,
         {static_cast<int>(nrows), static_cast<int>(ncols_padded), 2},
-        int32,
-        nullptr,
-        {});
-    tmp.set_data(allocator::malloc(tmp.nbytes()));
+        int32);
 
     const std::array<BoundArray, 3> bound_arrays = {{
         {&in, "src0"},
@@ -2781,6 +2781,7 @@ void dispatch_argsort_op(
         s,
         grid,
         {1024u, wg_unroll});
+    mark_scratch_array_written(s, kArgsortLargeScratchLane);
     return;
   }
 

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -1400,14 +1400,6 @@ ComputePipeline* KernelManager::get_pipeline(
     pipeline_key.bindings.push_back(make_descriptor_binding_key(binding));
   }
 
-  {
-    std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
-    auto it = pipelines_.find(pipeline_key);
-    if (it != pipelines_.end()) {
-      return it->second.get();
-    }
-  }
-
   VkDevice device = VulkanContext::get().device();
   const auto pipeline_options =
       pipeline_creation_options(shader_id, specialization_constants);
@@ -1415,6 +1407,12 @@ ComputePipeline* KernelManager::get_pipeline(
   if (!shader) {
     throw std::runtime_error(
         std::string("Shader not found: ") + static_shader_name(shader_id));
+  }
+
+  std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
+  auto it = pipelines_.find(pipeline_key);
+  if (it != pipelines_.end()) {
+    return it->second.get();
   }
 
   const bool use_push_descriptor =
@@ -1545,19 +1543,7 @@ ComputePipeline* KernelManager::get_pipeline(
   pipeline_ptr->supports_push_descriptor = use_push_descriptor;
 
   auto* result = pipeline_ptr.get();
-  {
-    std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
-    auto it = pipelines_.find(pipeline_key);
-    if (it != pipelines_.end()) {
-      vkDestroyPipeline(device, pipeline, nullptr);
-      vkDestroyPipelineLayout(device, pipeline_layout, nullptr);
-      if (descriptor_layout != VK_NULL_HANDLE) {
-        vkDestroyDescriptorSetLayout(device, descriptor_layout, nullptr);
-      }
-      return it->second.get();
-    }
-    pipelines_.emplace(std::move(pipeline_key), std::move(pipeline_ptr));
-  }
+  pipelines_.emplace(std::move(pipeline_key), std::move(pipeline_ptr));
 
   return result;
 }
@@ -1601,14 +1587,6 @@ ComputePipeline* KernelManager::get_pipeline(
     pipeline_key.bindings.push_back(make_descriptor_binding_key(binding));
   }
 
-  {
-    std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
-    auto it = pipelines_.find(pipeline_key);
-    if (it != pipelines_.end()) {
-      return it->second.get();
-    }
-  }
-
   VkDevice device = VulkanContext::get().device();
   const auto pipeline_options =
       pipeline_creation_options(shader_name, specialization_constants);
@@ -1617,6 +1595,12 @@ ComputePipeline* KernelManager::get_pipeline(
   ShaderModule* shader = get_shader(shader_name);
   if (!shader) {
     throw std::runtime_error("Shader not found: " + shader_name);
+  }
+
+  std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
+  auto it = pipelines_.find(pipeline_key);
+  if (it != pipelines_.end()) {
+    return it->second.get();
   }
 
   // Create descriptor set layout
@@ -1750,19 +1734,7 @@ ComputePipeline* KernelManager::get_pipeline(
   pipeline_ptr->supports_push_descriptor = use_push_descriptor;
 
   auto* result = pipeline_ptr.get();
-  {
-    std::lock_guard<std::mutex> lock(pipeline_cache_mutex_);
-    auto it = pipelines_.find(pipeline_key);
-    if (it != pipelines_.end()) {
-      vkDestroyPipeline(device, pipeline, nullptr);
-      vkDestroyPipelineLayout(device, pipeline_layout, nullptr);
-      if (descriptor_layout != VK_NULL_HANDLE) {
-        vkDestroyDescriptorSetLayout(device, descriptor_layout, nullptr);
-      }
-      return it->second.get();
-    }
-    pipelines_.emplace(std::move(pipeline_key), std::move(pipeline_ptr));
-  }
+  pipelines_.emplace(std::move(pipeline_key), std::move(pipeline_ptr));
 
   return result;
 }
@@ -1838,6 +1810,7 @@ vk::DescriptorSet KernelManager::allocate_descriptor_set(
     allocInfo.setSetLayouts(layouts);
 
     try {
+      std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
       auto descriptor_sets = device.allocateDescriptorSets(allocInfo);
       if (descriptor_sets.empty()) {
         throw std::runtime_error("Failed to allocate descriptor set batch.");
@@ -1897,6 +1870,7 @@ void KernelManager::free_descriptor_set(VkDescriptorSet set) {
       descriptor_set_layouts_.erase(set);
     }
     VkDevice device = VulkanContext::get().device();
+    std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
     vkFreeDescriptorSets(device, descriptor_pool_, 1, &set);
   }
 }
@@ -2006,6 +1980,7 @@ void KernelManager::reclaim_descriptor_set_epoch(
   }
   if (!freeable_sets.empty()) {
     VkDevice device = VulkanContext::get().device();
+    std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
     vkFreeDescriptorSets(
         device,
         descriptor_pool_,
@@ -2080,6 +2055,7 @@ void KernelManager::reclaim_descriptor_sets(
   }
   if (!freeable_sets.empty()) {
     VkDevice device = VulkanContext::get().device();
+    std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
     vkFreeDescriptorSets(
         device,
         descriptor_pool_,
@@ -2127,6 +2103,7 @@ void KernelManager::reclaim_all_descriptor_sets() {
   }
 
   VkDevice device = VulkanContext::get().device();
+  std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
   vkFreeDescriptorSets(
       device,
       descriptor_pool_,
@@ -2206,6 +2183,7 @@ void KernelManager::purge_descriptor_sets_for_layouts(
   }
 
   VkDevice device = VulkanContext::get().device();
+  std::lock_guard<std::mutex> pool_lock(descriptor_pool_mutex_);
   vkFreeDescriptorSets(
       device,
       descriptor_pool_,

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -241,7 +241,8 @@ PipelineCreationOptions pipeline_creation_options(
     const std::vector<uint32_t>& specialization_constants) {
   PipelineCreationOptions options;
 
-  if ((shader_name == "soft_max_f32" || shader_name == "soft_max_f32_f16") &&
+  if ((shader_name == "soft_max_f32" || shader_name == "soft_max_f32_f16" ||
+       shader_name == "soft_max_bf16") &&
       !specialization_constants.empty()) {
     options.required_subgroup_size = specialization_constants[0];
     return options;

--- a/mlx/backend/vulkan/kernels/div.comp
+++ b/mlx/backend/vulkan/kernels/div.comp
@@ -7,6 +7,30 @@ const uint num_threads = 256;
 
 layout(local_size_x = num_threads, local_size_y = 1, local_size_z = 1) in;
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+FLOAT_TYPE load_b(uint idx) {
+#if defined(DATA_B_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_b[idx])));
+#else
+    return FLOAT_TYPE(data_b[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 void main() {
     uint idx = get_idx();
 
@@ -20,15 +44,15 @@ void main() {
         uint i00, i01, i02, i03;
         get_indices(idx, i00, i01, i02, i03);
 
-        precise FLOAT_TYPE x = FLOAT_TYPE(data_a[get_aoffset() + src0_idx(i00, i01, i02, i03)]);
-        precise FLOAT_TYPE y = FLOAT_TYPE(data_b[get_boffset() + src1_idx(i00, i01, i02, i03)]);
+        precise FLOAT_TYPE x = load_a(get_aoffset() + src0_idx(i00, i01, i02, i03));
+        precise FLOAT_TYPE y = load_b(get_boffset() + src1_idx(i00, i01, i02, i03));
         precise FLOAT_TYPE result = x / y;
 #if REFINE_DIV
         if (y != FLOAT_TYPE(0.0) && !isnan(result) && !isinf(result)) {
         result += (x - result * y) / y;
         }
 #endif
-        data_d[get_doffset() + dst_idx(i00, i01, i02, i03)] = D_TYPE(result);
+        store_d(get_doffset() + dst_idx(i00, i01, i02, i03), result);
 
         idx += num_threads;
     }

--- a/mlx/backend/vulkan/kernels/max_rows.comp
+++ b/mlx/backend/vulkan/kernels/max_rows.comp
@@ -14,6 +14,22 @@ layout(constant_id = 0) const uint BLOCK_SIZE = 32;
 
 shared FLOAT_TYPE tmp[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 void main() {
     const uint row = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
     const uint col = gl_LocalInvocationID.x;
@@ -28,7 +44,7 @@ void main() {
 
     tmp[col] = FLOAT_TYPE(-3.402823466e+38);
     for (uint i = col; i < p.n_cols; i += BLOCK_SIZE) {
-        const FLOAT_TYPE value = FLOAT_TYPE(data_a[src_idx + i]);
+        const FLOAT_TYPE value = load_a(src_idx + i);
         if (isnan(value)) {
             tmp[col] = value;
             break;
@@ -50,6 +66,6 @@ void main() {
     }
 
     if (col == 0) {
-        data_d[dst_idx] = D_TYPE(tmp[0]);
+        store_d(dst_idx, tmp[0]);
     }
 }

--- a/mlx/backend/vulkan/kernels/min_rows.comp
+++ b/mlx/backend/vulkan/kernels/min_rows.comp
@@ -14,6 +14,22 @@ layout(constant_id = 0) const uint BLOCK_SIZE = 32;
 
 shared FLOAT_TYPE tmp[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 void main() {
     const uint row = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
     const uint col = gl_LocalInvocationID.x;
@@ -28,7 +44,7 @@ void main() {
 
     tmp[col] = FLOAT_TYPE(3.402823466e+38);
     for (uint i = col; i < p.n_cols; i += BLOCK_SIZE) {
-        const FLOAT_TYPE value = FLOAT_TYPE(data_a[src_idx + i]);
+        const FLOAT_TYPE value = load_a(src_idx + i);
         if (isnan(value)) {
             tmp[col] = value;
             break;
@@ -50,6 +66,6 @@ void main() {
     }
 
     if (col == 0) {
-        data_d[dst_idx] = D_TYPE(tmp[0]);
+        store_d(dst_idx, tmp[0]);
     }
 }

--- a/mlx/backend/vulkan/kernels/prod_rows.comp
+++ b/mlx/backend/vulkan/kernels/prod_rows.comp
@@ -14,6 +14,22 @@ layout(constant_id = 0) const uint BLOCK_SIZE = 32;
 
 shared FLOAT_TYPE tmp[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 void main() {
     const uint row = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
     const uint col = gl_LocalInvocationID.x;
@@ -28,7 +44,7 @@ void main() {
 
     tmp[col] = FLOAT_TYPE(1.0);
     for (uint i = col; i < p.n_cols; i += BLOCK_SIZE) {
-        tmp[col] *= FLOAT_TYPE(data_a[src_idx + i]);
+        tmp[col] *= load_a(src_idx + i);
     }
 
     barrier();
@@ -40,6 +56,6 @@ void main() {
     }
 
     if (col == 0) {
-        data_d[dst_idx] = D_TYPE(tmp[0]);
+        store_d(dst_idx, tmp[0]);
     }
 }

--- a/mlx/backend/vulkan/kernels/soft_max.comp
+++ b/mlx/backend/vulkan/kernels/soft_max.comp
@@ -37,6 +37,38 @@ layout (binding = 3) buffer D {D_TYPE data_d[];};
 
 shared FLOAT_TYPE vals[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+FLOAT_TYPE load_b(uint idx) {
+#if defined(DATA_B_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_b[idx])));
+#else
+    return FLOAT_TYPE(data_b[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
+FLOAT_TYPE load_d(uint idx) {
+#if defined(DATA_D_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_d[idx])));
+#else
+    return FLOAT_TYPE(data_d[idx]);
+#endif
+}
+
 bool use_subgroup_reduction() {
     return gl_NumSubgroups == 1;
 }
@@ -124,12 +156,12 @@ void soft_max(uint num_iters) {
 
         FLOAT_TYPE a = FLOAT_TYPE(0);
         if (col < p.KX) {
-            a = data_a[rowx * p.KX + col];
+            a = load_a(rowx * p.KX + col);
         }
 
         FLOAT_TYPE b = FLOAT_TYPE(0);
         if (p.KY > 0 && col < p.KX) {
-            b = data_b[rowy_start + col];
+            b = load_b(rowy_start + col);
         }
 
         FLOAT_TYPE v = a * p.scale + slope * b;
@@ -149,7 +181,7 @@ void soft_max(uint num_iters) {
         [[unroll]] for (uint col0 = 0; col0 < num_iters * BLOCK_SIZE; col0 += BLOCK_SIZE) {
             const uint col = col0 + tid;
             if (col < p.KX) {
-                data_d[rowx * p.KX + col] = D_TYPE(FLOAT_TYPE(0.0f));
+                store_d(rowx * p.KX + col, FLOAT_TYPE(0.0f));
             }
         }
         return;
@@ -173,8 +205,8 @@ void soft_max(uint num_iters) {
             const FLOAT_TYPE diff = data_cache[idx] - max_val;
             val = abs(diff) <= FLOAT_TYPE(1e-6f) ? FLOAT_TYPE(1.0f) : exp(diff);
         } else {
-            const FLOAT_TYPE diff = FLOAT_TYPE(data_a[i]) * p.scale +
-                (p.KY > 0 ? slope * FLOAT_TYPE(data_b[rowy_start + col]) : FLOAT_TYPE(0.0f)) -
+            const FLOAT_TYPE diff = load_a(i) * p.scale +
+                (p.KY > 0 ? slope * load_b(rowy_start + col) : FLOAT_TYPE(0.0f)) -
                 max_val;
             val = abs(diff) <= FLOAT_TYPE(1e-6f) ? FLOAT_TYPE(1.0f) : exp(diff);
         }
@@ -204,13 +236,13 @@ void soft_max(uint num_iters) {
         }
 
         const FLOAT_TYPE normalized =
-            (idx < DATA_CACHE_SIZE ? data_cache[idx] : FLOAT_TYPE(data_d[rowx*p.KX + col])) *
+            (idx < DATA_CACHE_SIZE ? data_cache[idx] : load_d(rowx*p.KX + col)) *
             rcpdivisor;
         normalized_sum += normalized;
         if (idx < DATA_CACHE_SIZE) {
-            data_d[rowx*p.KX + col] = D_TYPE(normalized);
+            store_d(rowx*p.KX + col, normalized);
         } else {
-            data_d[rowx*p.KX + col] = D_TYPE(normalized);
+            store_d(rowx*p.KX + col, normalized);
         }
     }
 
@@ -218,8 +250,9 @@ void soft_max(uint num_iters) {
     if (tid == 0 && p.KX > 0) {
         // Keep the row sum pinned to exactly 1 for finite rows while the
         // fully-masked case above still returns all zeros.
-        data_d[rowx * p.KX] =
-            D_TYPE(FLOAT_TYPE(data_d[rowx * p.KX]) + (FLOAT_TYPE(1.0f) - normalized_sum));
+        store_d(
+            rowx * p.KX,
+            load_d(rowx * p.KX) + (FLOAT_TYPE(1.0f) - normalized_sum));
     }
 }
 

--- a/mlx/backend/vulkan/kernels/soft_max.comp
+++ b/mlx/backend/vulkan/kernels/soft_max.comp
@@ -214,7 +214,7 @@ void soft_max(uint num_iters) {
         if (idx < DATA_CACHE_SIZE) {
             data_cache[idx] = val;
         } else {
-            data_d[i] = D_TYPE(val);
+            store_d(i, val);
         }
     }
 

--- a/mlx/backend/vulkan/kernels/soft_max.comp
+++ b/mlx/backend/vulkan/kernels/soft_max.comp
@@ -239,11 +239,7 @@ void soft_max(uint num_iters) {
             (idx < DATA_CACHE_SIZE ? data_cache[idx] : load_d(rowx*p.KX + col)) *
             rcpdivisor;
         normalized_sum += normalized;
-        if (idx < DATA_CACHE_SIZE) {
-            store_d(rowx*p.KX + col, normalized);
-        } else {
-            store_d(rowx*p.KX + col, normalized);
-        }
+        store_d(rowx*p.KX + col, normalized);
     }
 
     normalized_sum = reduce_sum(normalized_sum, tid);

--- a/mlx/backend/vulkan/kernels/soft_max_large1.comp
+++ b/mlx/backend/vulkan/kernels/soft_max_large1.comp
@@ -30,12 +30,12 @@ void main() {
 
         FLOAT_TYPE a = FLOAT_TYPE(0);
         if (col < p.KX) {
-            a = data_a[rowx * p.KX + col];
+            a = load_a(rowx * p.KX + col);
         }
 
         FLOAT_TYPE b = FLOAT_TYPE(0);
         if (p.KY > 0 && col < p.KX) {
-            b = data_b[rowy_start + col];
+            b = load_b(rowy_start + col);
         }
 
         FLOAT_TYPE v = a * p.scale + slope * b;

--- a/mlx/backend/vulkan/kernels/soft_max_large2.comp
+++ b/mlx/backend/vulkan/kernels/soft_max_large2.comp
@@ -57,12 +57,12 @@ void main() {
         // compute exp(a*scale+b*slope), add it to sum
         const uint i = rowx * p.KX + col;
         FLOAT_TYPE val;
-        const FLOAT_TYPE diff = FLOAT_TYPE(data_a[i]) * p.scale +
-            (p.KY > 0 ? slope * FLOAT_TYPE(data_b[rowy_start + col]) : FLOAT_TYPE(0.0f)) -
+        const FLOAT_TYPE diff = load_a(i) * p.scale +
+            (p.KY > 0 ? slope * load_b(rowy_start + col) : FLOAT_TYPE(0.0f)) -
             max_val;
         val = abs(diff) <= FLOAT_TYPE(1e-6f) ? FLOAT_TYPE(1.0f) : exp(diff);
         sum += val;
-        data_d[i] = D_TYPE(val);
+        store_d(i, val);
     }
 
     // reduce across the workgroup

--- a/mlx/backend/vulkan/kernels/soft_max_large3.comp
+++ b/mlx/backend/vulkan/kernels/soft_max_large3.comp
@@ -61,6 +61,7 @@ void main() {
             continue;
         }
 
-        data_d[rowx*p.KX + col] *= D_TYPE(rcpdivisor);
+        const uint elem_idx = rowx*p.KX + col;
+        store_d(elem_idx, load_d(elem_idx) * rcpdivisor);
     }
 }

--- a/mlx/backend/vulkan/kernels/soft_max_large_common.glsl
+++ b/mlx/backend/vulkan/kernels/soft_max_large_common.glsl
@@ -36,6 +36,38 @@ layout (binding = 5) buffer S {float data_s[];};
 
 shared FLOAT_TYPE vals[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+FLOAT_TYPE load_b(uint idx) {
+#if defined(DATA_B_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_b[idx])));
+#else
+    return FLOAT_TYPE(data_b[idx]);
+#endif
+}
+
+FLOAT_TYPE load_d(uint idx) {
+#if defined(DATA_D_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_d[idx])));
+#else
+    return FLOAT_TYPE(data_d[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 float get_slope(uint rowx) {
     float slope = 1.0f;
 

--- a/mlx/backend/vulkan/kernels/sum_rows.comp
+++ b/mlx/backend/vulkan/kernels/sum_rows.comp
@@ -14,6 +14,22 @@ layout (constant_id = 0) const uint BLOCK_SIZE = 32;
 
 shared FLOAT_TYPE tmp[BLOCK_SIZE];
 
+FLOAT_TYPE load_a(uint idx) {
+#if defined(DATA_A_BF16)
+    return FLOAT_TYPE(bf16_to_fp32(uint(data_a[idx])));
+#else
+    return FLOAT_TYPE(data_a[idx]);
+#endif
+}
+
+void store_d(uint idx, FLOAT_TYPE value) {
+#if defined(DATA_D_BF16)
+    data_d[idx] = D_TYPE(fp32_to_bf16(float(value)));
+#else
+    data_d[idx] = D_TYPE(value);
+#endif
+}
+
 void main() {
     const uint row = gl_WorkGroupID.z * 262144 + gl_WorkGroupID.y * 512 + gl_WorkGroupID.x;
     const uint col = gl_LocalInvocationID.x;
@@ -30,7 +46,7 @@ void main() {
     tmp[col] = FLOAT_TYPE(0.0);
 
     for (uint i = col; i < p.n_cols; i += BLOCK_SIZE) {
-        tmp[col] += FLOAT_TYPE(data_a[src_idx + i]);
+        tmp[col] += load_a(src_idx + i);
     }
 
     barrier();
@@ -42,6 +58,6 @@ void main() {
     }
 
     if (col == 0) {
-        data_d[dst_idx] = D_TYPE(tmp[0] * weight);
+        store_d(dst_idx, tmp[0] * weight);
     }
 }

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2041,10 +2041,6 @@ void process_shaders() {
            {std::string("f32"), std::string("f16"), std::string("bf16")}) {
         for (const auto& dst :
              {std::string("f32"), std::string("f16"), std::string("bf16")}) {
-          if (op == "div" &&
-              (src0 == "bf16" || src1 == "bf16" || dst == "bf16")) {
-            continue;
-          }
           if (op == "add_rms" &&
               (src0 == "bf16" || src1 == "bf16" || dst == "bf16")) {
             continue;
@@ -2860,6 +2856,16 @@ void process_shaders() {
           base_dict,
           {{"A_TYPE", "float"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "soft_max_bf16",
+      "soft_max.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
+  string_to_spv(
       "soft_max_back_f32",
       "soft_max_back.comp",
       merge_maps(
@@ -2921,6 +2927,36 @@ void process_shaders() {
       merge_maps(
           base_dict,
           {{"A_TYPE", "float"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "soft_max_large1_bf16",
+      "soft_max_large1.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
+  string_to_spv(
+      "soft_max_large2_bf16",
+      "soft_max_large2.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
+  string_to_spv(
+      "soft_max_large3_bf16",
+      "soft_max_large3.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
 
   string_to_spv(
       "rope_norm_f32",
@@ -3076,17 +3112,53 @@ void process_shaders() {
       "sum_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "sum_rows_bf16",
+      "sum_rows.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
+  string_to_spv(
       "prod_rows_f32",
       "prod_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "prod_rows_bf16",
+      "prod_rows.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
   string_to_spv(
       "max_rows_f32",
       "max_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "max_rows_bf16",
+      "max_rows.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
+  string_to_spv(
       "min_rows_f32",
       "min_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "min_rows_bf16",
+      "min_rows.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "uint16_t"},
+           {"D_TYPE", "uint16_t"},
+           {"DATA_A_BF16", "1"},
+           {"DATA_D_BF16", "1"}}));
   string_to_spv(
       "sum_rows_u8_u32",
       "integer_rows.comp",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2856,6 +2856,14 @@ void process_shaders() {
           base_dict,
           {{"A_TYPE", "float"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "soft_max_f16",
+      "soft_max.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "float16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "float16_t"}}));
+  string_to_spv(
       "soft_max_bf16",
       "soft_max.comp",
       merge_maps(
@@ -2927,6 +2935,30 @@ void process_shaders() {
       merge_maps(
           base_dict,
           {{"A_TYPE", "float"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "soft_max_large1_f16",
+      "soft_max_large1.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "float16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "float16_t"}}));
+  string_to_spv(
+      "soft_max_large2_f16",
+      "soft_max_large2.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "float16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "float16_t"}}));
+  string_to_spv(
+      "soft_max_large3_f16",
+      "soft_max_large3.comp",
+      merge_maps(
+          base_dict,
+          {{"A_TYPE", "float16_t"},
+           {"B_TYPE", "float"},
+           {"D_TYPE", "float16_t"}}));
   string_to_spv(
       "soft_max_large1_bf16",
       "soft_max_large1.comp",
@@ -3112,6 +3144,11 @@ void process_shaders() {
       "sum_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "sum_rows_f16",
+      "sum_rows.comp",
+      merge_maps(
+          base_dict, {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}}));
+  string_to_spv(
       "sum_rows_bf16",
       "sum_rows.comp",
       merge_maps(
@@ -3124,6 +3161,11 @@ void process_shaders() {
       "prod_rows_f32",
       "prod_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "prod_rows_f16",
+      "prod_rows.comp",
+      merge_maps(
+          base_dict, {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}}));
   string_to_spv(
       "prod_rows_bf16",
       "prod_rows.comp",
@@ -3138,6 +3180,11 @@ void process_shaders() {
       "max_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
   string_to_spv(
+      "max_rows_f16",
+      "max_rows.comp",
+      merge_maps(
+          base_dict, {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}}));
+  string_to_spv(
       "max_rows_bf16",
       "max_rows.comp",
       merge_maps(
@@ -3150,6 +3197,11 @@ void process_shaders() {
       "min_rows_f32",
       "min_rows.comp",
       merge_maps(base_dict, {{"A_TYPE", "float"}, {"D_TYPE", "float"}}));
+  string_to_spv(
+      "min_rows_f16",
+      "min_rows.comp",
+      merge_maps(
+          base_dict, {{"A_TYPE", "float16_t"}, {"D_TYPE", "float16_t"}}));
   string_to_spv(
       "min_rows_bf16",
       "min_rows.comp",

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -2540,6 +2540,15 @@ bool apply_block_mask_vulkan(
 
 } // namespace
 
+namespace vulkan {
+
+void clear_mul_mm_transpose_cache() {
+  std::lock_guard<std::mutex> lock(mul_mm_transpose_cache_mutex());
+  mul_mm_transpose_cache().clear();
+}
+
+} // namespace vulkan
+
 bool try_eval_matmul_vulkan(
     const std::vector<array>& inputs,
     array& out,

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -12,13 +12,16 @@
 #include "mlx/backend/vulkan/vulkan.h"
 #include "mlx/primitives.h"
 #include "mlx/transforms.h"
+#include "mlx/transforms_impl.h"
 #include "mlx/utils.h"
 
 #include <array>
 #include <atomic>
 #include <cstdlib>
+#include <deque>
 #include <iostream>
 #include <limits>
+#include <mutex>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -38,6 +41,32 @@ constexpr char kMulMmACastScratchLane[] = "mul_mm.a_f16";
 constexpr char kMulMmBCastScratchLane[] = "mul_mm.b_f16";
 constexpr char kMulMmOutScratchLane[] = "mul_mm.out_work";
 constexpr char kMulMmSplitKScratchLane[] = "mul_mm.split_k";
+constexpr size_t kMulMmTransposeCacheLimit = 16;
+
+struct MulMmTransposeCacheEntry {
+  std::weak_ptr<array::Data> source;
+  const array::Data* source_id{nullptr};
+  Shape source_shape;
+  Strides source_strides;
+  int64_t source_offset{0};
+  Dtype source_dtype;
+  array transposed;
+};
+
+std::mutex& mul_mm_transpose_cache_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::deque<MulMmTransposeCacheEntry>& mul_mm_transpose_cache() {
+  static std::deque<MulMmTransposeCacheEntry> cache;
+  return cache;
+}
+
+bool cacheable_mul_mm_transpose_source(const array& source) {
+  return !source.has_primitive() && source.status() == array::Status::available &&
+      (source.dtype() == float16 || source.dtype() == bfloat16);
+}
 constexpr char kBlockMaskedMMLhsScratchLane[] = "block_masked_mm.lhs";
 constexpr char kBlockMaskedMMRhsScratchLane[] = "block_masked_mm.rhs";
 
@@ -848,6 +877,96 @@ bool ensure_vulkan_buffer(array& arr, Stream s) {
   return has_vulkan_buffer(arr);
 }
 
+bool same_mul_mm_transpose_source(
+    const MulMmTransposeCacheEntry& entry,
+    const std::shared_ptr<array::Data>& source_data,
+    const array& source) {
+  auto locked_source = entry.source.lock();
+  return locked_source.get() == source_data.get() &&
+      entry.source_id == source_data.get() &&
+      entry.source_shape == source.shape() &&
+      entry.source_strides == source.strides() &&
+      entry.source_offset == source.offset() &&
+      entry.source_dtype == source.dtype();
+}
+
+std::optional<array> find_cached_mul_mm_transpose(const array& source) {
+  auto source_data = source.data_shared_ptr();
+  if (source_data == nullptr) {
+    return std::nullopt;
+  }
+
+  std::lock_guard<std::mutex> lock(mul_mm_transpose_cache_mutex());
+  auto& cache = mul_mm_transpose_cache();
+  for (auto it = cache.begin(); it != cache.end();) {
+    if (it->source.expired()) {
+      it = cache.erase(it);
+      continue;
+    }
+    if (same_mul_mm_transpose_source(*it, source_data, source)) {
+      auto cached = it->transposed;
+      auto entry = std::move(*it);
+      cache.erase(it);
+      cache.push_back(std::move(entry));
+      return cached;
+    }
+    ++it;
+  }
+  return std::nullopt;
+}
+
+void cache_mul_mm_transpose(const array& source, const array& transposed) {
+  if (!cacheable_mul_mm_transpose_source(source)) {
+    return;
+  }
+  auto source_data = source.data_shared_ptr();
+  if (source_data == nullptr || transposed.data_shared_ptr() == nullptr) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(mul_mm_transpose_cache_mutex());
+  auto& cache = mul_mm_transpose_cache();
+  for (auto it = cache.begin(); it != cache.end();) {
+    if (it->source.expired() ||
+        same_mul_mm_transpose_source(*it, source_data, source)) {
+      it = cache.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  cache.push_back(MulMmTransposeCacheEntry{
+      source_data,
+      source_data.get(),
+      source.shape(),
+      source.strides(),
+      source.offset(),
+      source.dtype(),
+      transposed});
+  while (cache.size() > kMulMmTransposeCacheLimit) {
+    cache.pop_front();
+  }
+}
+
+array materialize_mul_mm_transpose(array b, Stream s) {
+  array b_t = swapaxes_in_eval(b, -1, -2);
+  if (is_row_contiguous_zero_offset(b_t)) {
+    return b_t;
+  }
+  if (!ensure_vulkan_buffer(b_t, s)) {
+    return b_t;
+  }
+  if (detail::in_tracing() || detail::retain_graph() ||
+      !cacheable_mul_mm_transpose_source(b)) {
+    return contiguous_copy_gpu(b_t, s);
+  }
+  if (auto cached = find_cached_mul_mm_transpose(b)) {
+    return *cached;
+  }
+  b_t = contiguous_copy_gpu(b_t, s);
+  cache_mul_mm_transpose(b, b_t);
+  return b_t;
+}
+
 void zero_initialize_output(array& out, Stream s) {
   if (out.size() == 0) {
     return;
@@ -1123,12 +1242,13 @@ bool try_eval_mul_mm_vulkan(
     return false;
   }
 
-  array b_t = swapaxes_in_eval(b, -1, -2);
+  array b_t = materialize_mul_mm_transpose(b, s);
   if (!is_row_contiguous_zero_offset(b_t)) {
     if (!ensure_vulkan_buffer(b_t, s)) {
       return false;
     }
     b_t = contiguous_copy_gpu(b_t, s);
+    cache_mul_mm_transpose(b, b_t);
   }
   if (!is_row_contiguous_zero_offset(b_t)) {
     return false;

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -64,7 +64,8 @@ std::deque<MulMmTransposeCacheEntry>& mul_mm_transpose_cache() {
 }
 
 bool cacheable_mul_mm_transpose_source(const array& source) {
-  return !source.has_primitive() && source.status() == array::Status::available &&
+  return !source.has_primitive() &&
+      source.status() == array::Status::available &&
       (source.dtype() == float16 || source.dtype() == bfloat16);
 }
 constexpr char kBlockMaskedMMLhsScratchLane[] = "block_masked_mm.lhs";
@@ -934,20 +935,21 @@ void cache_mul_mm_transpose(const array& source, const array& transposed) {
       ++it;
     }
   }
-  cache.push_back(MulMmTransposeCacheEntry{
-      source_data,
-      source_data.get(),
-      source.shape(),
-      source.strides(),
-      source.offset(),
-      source.dtype(),
-      transposed});
+  cache.push_back(
+      MulMmTransposeCacheEntry{
+          source_data,
+          source_data.get(),
+          source.shape(),
+          source.strides(),
+          source.offset(),
+          source.dtype(),
+          transposed});
   while (cache.size() > kMulMmTransposeCacheLimit) {
     cache.pop_front();
   }
 }
 
-array materialize_mul_mm_transpose(array b, Stream s) {
+array materialize_mul_mm_transpose(array b, Stream s, bool allow_cache = true) {
   array b_t = swapaxes_in_eval(b, -1, -2);
   if (is_row_contiguous_zero_offset(b_t)) {
     return b_t;
@@ -955,7 +957,7 @@ array materialize_mul_mm_transpose(array b, Stream s) {
   if (!ensure_vulkan_buffer(b_t, s)) {
     return b_t;
   }
-  if (detail::in_tracing() || detail::retain_graph() ||
+  if (detail::in_tracing() || detail::retain_graph() || !allow_cache ||
       !cacheable_mul_mm_transpose_source(b)) {
     return contiguous_copy_gpu(b_t, s);
   }
@@ -1223,10 +1225,12 @@ bool try_eval_mul_mm_vulkan(
     return true;
   }
 
+  bool b_uses_cast_scratch = false;
   if (a.dtype() == bfloat16 &&
       !vulkan::VulkanContext::get().shader_bfloat16_supported()) {
     a = cast_to_float16_scratch(a, s, kMulMmACastScratchLane);
     b = cast_to_float16_scratch(b, s, kMulMmBCastScratchLane);
+    b_uses_cast_scratch = true;
   }
 
   // Keep BF16 inputs in BF16 and dispatch matmul_bf16* directly.
@@ -1242,13 +1246,15 @@ bool try_eval_mul_mm_vulkan(
     return false;
   }
 
-  array b_t = materialize_mul_mm_transpose(b, s);
+  array b_t = materialize_mul_mm_transpose(b, s, !b_uses_cast_scratch);
   if (!is_row_contiguous_zero_offset(b_t)) {
     if (!ensure_vulkan_buffer(b_t, s)) {
       return false;
     }
     b_t = contiguous_copy_gpu(b_t, s);
-    cache_mul_mm_transpose(b, b_t);
+    if (!b_uses_cast_scratch) {
+      cache_mul_mm_transpose(b, b_t);
+    }
   }
   if (!is_row_contiguous_zero_offset(b_t)) {
     return false;

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -11,6 +11,7 @@
 #include "mlx/backend/vulkan/shader_compiler.h"
 #include "mlx/backend/vulkan/vulkan.h"
 #include "mlx/primitives.h"
+#include "mlx/transforms.h"
 #include "mlx/utils.h"
 
 #include <array>
@@ -208,16 +209,14 @@ std::vector<vulkan::StaticShaderId> matvec_shader_candidates(
       return {
           vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_bf16,
           vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_bf16_subgroup,
-          vulkan::StaticShaderId::
-              mul_mat_vec_bf16_bf16_bf16_subgroup_no_shmem,
+          vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_bf16_subgroup_no_shmem,
       };
     }
     if (out_dtype == float32) {
       if (prefer_subgroup_matvec()) {
         return {
             vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_f32_subgroup,
-            vulkan::StaticShaderId::
-                mul_mat_vec_bf16_bf16_f32_subgroup_no_shmem,
+            vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_f32_subgroup_no_shmem,
             vulkan::StaticShaderId::mul_mat_vec_bf16_bf16_f32,
         };
       }
@@ -811,6 +810,23 @@ bool ensure_vulkan_buffer(array& arr, Stream s) {
   }
 
   if (arr.has_primitive()) {
+    auto data = arr.data_shared_ptr();
+    if (arr.status() != array::Status::unscheduled &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      arr.set_status(array::Status::unscheduled);
+    }
+    async_eval(arr);
+    if (has_vulkan_buffer(arr)) {
+      return true;
+    }
+    if (!arr.has_primitive()) {
+      data = arr.data_shared_ptr();
+      if (data == nullptr || data->buffer.ptr() == nullptr) {
+        return false;
+      }
+      arr = contiguous_copy_gpu(arr, s);
+      return has_vulkan_buffer(arr);
+    }
     arr = contiguous_copy_gpu(arr, s);
     return has_vulkan_buffer(arr);
   }
@@ -824,7 +840,7 @@ bool ensure_vulkan_buffer(array& arr, Stream s) {
   }
 
   auto data = arr.data_shared_ptr();
-  if (data == nullptr || !vulkan::is_vulkan_buffer(data->buffer)) {
+  if (data == nullptr || data->buffer.ptr() == nullptr) {
     return false;
   }
 
@@ -956,8 +972,7 @@ bool try_eval_matvec_vulkan(
     return false;
   }
 
-  const bool needs_out_copy =
-      !is_row_contiguous_zero_offset(out) ||
+  const bool needs_out_copy = !is_row_contiguous_zero_offset(out) ||
       (out.dtype() != float32 &&
        !(matrix.dtype() == bfloat16 &&
          (vec_shader_dtype == float16 || vec_shader_dtype == bfloat16) &&
@@ -1003,9 +1018,9 @@ bool try_eval_matvec_vulkan(
                   << " matrix_dtype=" << matrix.dtype()
                   << " vec_shape=" << vec.shape()
                   << " vec_dtype=" << vec.dtype()
-                  << " out_shape=" << out.shape() << " out_dtype="
-                  << out.dtype() << " needs_out_copy=" << needs_out_copy
-                  << "\n";
+                  << " out_shape=" << out.shape()
+                  << " out_dtype=" << out.dtype()
+                  << " needs_out_copy=" << needs_out_copy << "\n";
       }
       if (needs_out_copy) {
         vulkan::mark_scratch_array_written(s, kMatvecOutScratchLane);

--- a/mlx/backend/vulkan/primitives.cpp
+++ b/mlx/backend/vulkan/primitives.cpp
@@ -11,10 +11,11 @@
 #include "mlx/backend/vulkan/kernels.h"
 #include "mlx/backend/vulkan/primitives_utils.h"
 #include "mlx/backend/vulkan/shader_compiler.h"
+#include "mlx/transforms.h"
 
 #include <algorithm>
-#include <sstream>
 #include <memory>
+#include <sstream>
 #include <utility>
 
 namespace mlx::core {
@@ -66,7 +67,11 @@ namespace mlx::core {
 namespace {
 
 template <typename Fn>
-array eval_with_optional_f32_promotion(array x, Stream s, Dtype out_dtype, Fn&& fn) {
+array eval_with_optional_f32_promotion(
+    array x,
+    Stream s,
+    Dtype out_dtype,
+    Fn&& fn) {
   if (out_dtype == float16 || out_dtype == bfloat16) {
     auto y = fn(astype(x, float32, s), float32);
     return astype(y, out_dtype, s);
@@ -157,7 +162,8 @@ void main() {
 }
 
 void extract_complex_real_key_gpu(const array& in, array& out, Stream s) {
-  if (in.dtype() != complex64 || out.dtype() != float32 || in.size() != out.size()) {
+  if (in.dtype() != complex64 || out.dtype() != float32 ||
+      in.size() != out.size()) {
     throw std::runtime_error("Invalid complex sort key extraction.");
   }
 
@@ -194,7 +200,8 @@ void extract_complex_real_key_gpu(const array& in, array& out, Stream s) {
       0,
       sizeof(PushConstants),
       &pc);
-  vkCmdDispatch(dispatch.command_buffer, (pc.total_elements + 255u) / 256u, 1, 1);
+  vkCmdDispatch(
+      dispatch.command_buffer, (pc.total_elements + 255u) / 256u, 1, 1);
   vulkan::end_command_recording(s.index);
 }
 
@@ -297,6 +304,19 @@ bool ensure_vulkan_buffer_power(array& arr, Stream s) {
     return true;
   }
   if (arr.has_primitive()) {
+    if (arr.status() != array::Status::unscheduled &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      arr.set_status(array::Status::unscheduled);
+    }
+    async_eval(arr);
+    data = arr.data_shared_ptr();
+    if (data != nullptr && vulkan::is_vulkan_buffer(data->buffer)) {
+      return true;
+    }
+    if (!arr.has_primitive() &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      return false;
+    }
     arr = contiguous_copy_gpu(arr, s);
     data = arr.data_shared_ptr();
     return data != nullptr && vulkan::is_vulkan_buffer(data->buffer);
@@ -317,6 +337,19 @@ bool ensure_vulkan_buffer_compare(array& arr, Stream s) {
     return true;
   }
   if (arr.has_primitive()) {
+    if (arr.status() != array::Status::unscheduled &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      arr.set_status(array::Status::unscheduled);
+    }
+    async_eval(arr);
+    data = arr.data_shared_ptr();
+    if (data != nullptr && vulkan::is_vulkan_buffer(data->buffer)) {
+      return true;
+    }
+    if (!arr.has_primitive() &&
+        (data == nullptr || data->buffer.ptr() == nullptr)) {
+      return false;
+    }
     arr = contiguous_copy_gpu(arr, s);
     data = arr.data_shared_ptr();
     return data != nullptr && vulkan::is_vulkan_buffer(data->buffer);
@@ -651,7 +684,8 @@ std::string build_equal_shader(
         uses_bfloat16 || uses_float16 || a_dtype == float32 ||
         b_dtype == float32) {
       os << " || (isnan(" << equal_input_expr(a_dtype, "a_buf", "a_idx")
-         << ") && isnan(" << equal_input_expr(b_dtype, "b_buf", "b_idx") << "))";
+         << ") && isnan(" << equal_input_expr(b_dtype, "b_buf", "b_idx")
+         << "))";
     }
   }
   os << ";\n";
@@ -1729,7 +1763,8 @@ bool try_eval_bitwise_invert_vulkan(
     return true;
   }
 
-  const auto in_offset = static_cast<uint64_t>(in.offset() / size_of(in.dtype()));
+  const auto in_offset =
+      static_cast<uint64_t>(in.offset() / size_of(in.dtype()));
   const auto out_offset =
       static_cast<uint64_t>(out_kernel.offset() / size_of(out_kernel.dtype()));
   const auto total = static_cast<uint64_t>(out_kernel.data_size());
@@ -1938,8 +1973,7 @@ bool try_eval_select_vulkan(
   array y_kernel = collapse_select_leading_dims(y, s);
   array out_kernel = collapse_select_leading_dims(out_storage, s);
 
-  const bool can_use_static_select =
-      condition.shape() == inputs[0].shape() &&
+  const bool can_use_static_select = condition.shape() == inputs[0].shape() &&
       is_supported_elementwise_layout(cond_kernel) &&
       is_supported_elementwise_layout(x_kernel) &&
       is_supported_elementwise_layout(y_kernel) &&
@@ -2345,10 +2379,7 @@ void ArcSinh::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto s = stream();
   auto y = eval_with_optional_f32_promotion(
-      inputs[0],
-      s,
-      out.dtype(),
-      [&](array x, Dtype calc_dtype) {
+      inputs[0], s, out.dtype(), [&](array x, Dtype calc_dtype) {
         auto one = array(1.0f, calc_dtype);
         return log(add(x, sqrt(add(multiply(x, x, s), one, s), s), s), s);
       });
@@ -2370,7 +2401,8 @@ void Cosh::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto s = stream();
   auto x = inputs[0];
-  auto y = multiply(add(exp(x, s), exp(negative(x, s), s), s), array(0.5f, out.dtype()), s);
+  auto y = multiply(
+      add(exp(x, s), exp(negative(x, s), s), s), array(0.5f, out.dtype()), s);
   copy_gpu(y, out, CopyType::General, s);
 }
 void Hadamard::eval_gpu(const std::vector<array>& inputs, array& out) {
@@ -2378,7 +2410,8 @@ void Hadamard::eval_gpu(const std::vector<array>& inputs, array& out) {
   auto s = stream();
   auto in = inputs[0];
 
-  if (in.dtype() != float32 && in.dtype() != float16 && in.dtype() != bfloat16) {
+  if (in.dtype() != float32 && in.dtype() != float16 &&
+      in.dtype() != bfloat16) {
     throw std::runtime_error("Hadamard has no Vulkan implementation.");
   }
 
@@ -2524,7 +2557,10 @@ void Sinh::eval_gpu(const std::vector<array>& inputs, array& out) {
   assert(inputs.size() == 1);
   auto s = stream();
   auto x = inputs[0];
-  auto y = multiply(subtract(exp(x, s), exp(negative(x, s), s), s), array(0.5f, out.dtype()), s);
+  auto y = multiply(
+      subtract(exp(x, s), exp(negative(x, s), s), s),
+      array(0.5f, out.dtype()),
+      s);
   copy_gpu(y, out, CopyType::General, s);
 }
 

--- a/mlx/backend/vulkan/primitives_utils.cpp
+++ b/mlx/backend/vulkan/primitives_utils.cpp
@@ -188,6 +188,17 @@ std::string gather_index_suffix(Dtype dtype) {
   MLX_VK_BINARY_CASE(                                                      \
       OP, float32, bfloat16, bfloat16, true, PREFIX##_f32_bf16_bf16_rte)
 
+#define MLX_VK_BF16_DIVIDE_CASES()                                          \
+  MLX_VK_BF16_BINARY_CASES(Divide, div)                                     \
+  MLX_VK_BINARY_CASE(                                                       \
+      Divide, bfloat16, float32, float32, false, div_bf16_f32_f32)          \
+  MLX_VK_BINARY_CASE(                                                       \
+      Divide, bfloat16, float32, float32, true, div_bf16_f32_f32_rte)       \
+  MLX_VK_BINARY_CASE(                                                       \
+      Divide, float32, bfloat16, float32, false, div_f32_bf16_f32)          \
+  MLX_VK_BINARY_CASE(                                                       \
+      Divide, float32, bfloat16, float32, true, div_f32_bf16_f32_rte)
+
 #define MLX_VK_INTEGER_BINARY_CASES(OP, PREFIX)                               \
   MLX_VK_BINARY_CASE(OP, int32, int32, int32, false, PREFIX##_i32_i32_i32)    \
   MLX_VK_BINARY_CASE(OP, int64, int64, int64, false, PREFIX##_i64_i64_i64)    \
@@ -203,6 +214,7 @@ std::optional<vulkan::StaticShaderId> binary_shader_id(
   MLX_VK_FLOAT_BINARY_CASES(Add, add);
   MLX_VK_BF16_BINARY_CASES(Add, add);
   MLX_VK_FLOAT_BINARY_CASES(Divide, div);
+  MLX_VK_BF16_DIVIDE_CASES();
   MLX_VK_FLOAT_BINARY_CASES(Maximum, maximum);
   MLX_VK_BF16_BINARY_CASES(Maximum, maximum);
   MLX_VK_FLOAT_BINARY_CASES(Minimum, minimum);

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -13,6 +13,10 @@
 #include "mlx/ops.h"
 #include "mlx/primitives.h"
 #include "mlx/transforms.h"
+#include "mlx/transforms_impl.h"
+
+#include <deque>
+#include <mutex>
 
 namespace mlx::core {
 namespace {
@@ -24,6 +28,143 @@ bool is_supported_quantized_bits(int bits) {
 
 bool is_supported_quantized_output_dtype(Dtype dtype) {
   return dtype == float16 || dtype == bfloat16 || dtype == float32;
+}
+
+constexpr size_t kDequantizedWeightCacheLimit = 8;
+
+struct CachedArrayIdentity {
+  std::weak_ptr<array::Data> data;
+  const array::Data* id{nullptr};
+  Shape shape;
+  Strides strides;
+  int64_t offset{0};
+  Dtype dtype;
+};
+
+struct DequantizedWeightCacheEntry {
+  CachedArrayIdentity w;
+  CachedArrayIdentity scales;
+  std::optional<CachedArrayIdentity> biases;
+  QuantizationMode mode;
+  int group_size{0};
+  int bits{0};
+  array dequantized;
+};
+
+std::mutex& dequantized_weight_cache_mutex() {
+  static std::mutex mutex;
+  return mutex;
+}
+
+std::deque<DequantizedWeightCacheEntry>& dequantized_weight_cache() {
+  static std::deque<DequantizedWeightCacheEntry> cache;
+  return cache;
+}
+
+bool cacheable_dequant_source(const array& arr) {
+  return !arr.has_primitive() && arr.status() == array::Status::available &&
+      arr.data_shared_ptr() != nullptr;
+}
+
+std::optional<CachedArrayIdentity> make_cached_array_identity(
+    const array& arr) {
+  if (!cacheable_dequant_source(arr)) {
+    return std::nullopt;
+  }
+  auto data = arr.data_shared_ptr();
+  return CachedArrayIdentity{
+      data, data.get(), arr.shape(), arr.strides(), arr.offset(), arr.dtype()};
+}
+
+bool same_cached_array_identity(
+    const CachedArrayIdentity& cached,
+    const array& arr) {
+  auto data = arr.data_shared_ptr();
+  auto locked = cached.data.lock();
+  return data != nullptr && locked.get() == data.get() &&
+      cached.id == data.get() && cached.shape == arr.shape() &&
+      cached.strides == arr.strides() && cached.offset == arr.offset() &&
+      cached.dtype == arr.dtype();
+}
+
+bool dequantized_weight_cache_entry_alive(
+    const DequantizedWeightCacheEntry& entry) {
+  return !entry.w.data.expired() && !entry.scales.data.expired() &&
+      (!entry.biases.has_value() || !entry.biases->data.expired());
+}
+
+std::optional<array> find_cached_dequantized_weight(
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    QuantizationMode mode,
+    int group_size,
+    int bits) {
+  if (detail::in_tracing() || detail::retain_graph()) {
+    return std::nullopt;
+  }
+  std::lock_guard<std::mutex> lock(dequantized_weight_cache_mutex());
+  auto& cache = dequantized_weight_cache();
+  for (auto it = cache.begin(); it != cache.end();) {
+    if (!dequantized_weight_cache_entry_alive(*it)) {
+      it = cache.erase(it);
+      continue;
+    }
+    const bool biases_match =
+        (!biases.has_value() && !it->biases.has_value()) ||
+        (biases.has_value() && it->biases.has_value() &&
+         same_cached_array_identity(*it->biases, *biases));
+    if (it->mode == mode && it->group_size == group_size &&
+        it->bits == bits && biases_match &&
+        same_cached_array_identity(it->w, w) &&
+        same_cached_array_identity(it->scales, scales)) {
+      auto cached = it->dequantized;
+      auto entry = std::move(*it);
+      cache.erase(it);
+      cache.push_back(std::move(entry));
+      return cached;
+    }
+    ++it;
+  }
+  return std::nullopt;
+}
+
+void cache_dequantized_weight(
+    const array& w,
+    const array& scales,
+    const std::optional<array>& biases,
+    QuantizationMode mode,
+    int group_size,
+    int bits,
+    const array& dequantized) {
+  if (detail::in_tracing() || detail::retain_graph() ||
+      dequantized.data_shared_ptr() == nullptr) {
+    return;
+  }
+  auto w_id = make_cached_array_identity(w);
+  auto scales_id = make_cached_array_identity(scales);
+  std::optional<CachedArrayIdentity> biases_id;
+  if (biases.has_value()) {
+    biases_id = make_cached_array_identity(*biases);
+  }
+  if (!w_id.has_value() || !scales_id.has_value() ||
+      (biases.has_value() && !biases_id.has_value())) {
+    return;
+  }
+
+  std::lock_guard<std::mutex> lock(dequantized_weight_cache_mutex());
+  auto& cache = dequantized_weight_cache();
+  cache.push_back(DequantizedWeightCacheEntry{
+      *w_id,
+      *scales_id,
+      biases_id,
+      mode,
+      group_size,
+      bits,
+      dequantized});
+  while (cache.size() > kDequantizedWeightCacheLimit) {
+    cache.pop_front();
+  }
 }
 
 bool fused_nvfp4_qqmm_enabled() {
@@ -1771,25 +1912,35 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   if (!fused_dispatched) {
     trace_qmm("dequant_fallback", "reason=fused_conditions_not_met");
-    array w_deq(expanded_quantized_shape(w, bits_), float32, nullptr, {});
-    if (mode_ == QuantizationMode::Affine &&
-        !vulkan::affine_dequantize_to_float32(
-            w, scales, *biases, w_deq, s, group_size_, bits_)) {
-      throw std::runtime_error(
-          "[QuantizedMatmul::eval_gpu] Failed to dequantize weights on Vulkan.");
-    }
-    if (mode_ == QuantizationMode::Nvfp4 &&
-        !vulkan::nvfp4_dequantize_to_float32(
-            w, inputs[2], std::nullopt, w_deq, s)) {
-      throw std::runtime_error(
-          "[QuantizedMatmul::eval_gpu] Failed to dequantize FP weights on Vulkan.");
-    }
-    if ((mode_ == QuantizationMode::Mxfp4 ||
-         mode_ == QuantizationMode::Mxfp8) &&
-        !vulkan::fp_dequantize_to_float32(
-            w, inputs[2], w_deq, s, group_size_, bits_)) {
-      throw std::runtime_error(
-          "[QuantizedMatmul::eval_gpu] Failed to dequantize FP weights on Vulkan.");
+    std::optional<array> cache_biases =
+        mode_ == QuantizationMode::Affine ? biases : std::nullopt;
+    auto cached_w_deq = find_cached_dequantized_weight(
+        w, inputs[2], cache_biases, mode_, group_size_, bits_);
+    array w_deq = cached_w_deq.value_or(
+        array(expanded_quantized_shape(w, bits_), float32, nullptr, {}));
+    if (!cached_w_deq.has_value()) {
+      if (mode_ == QuantizationMode::Affine &&
+          !vulkan::affine_dequantize_to_float32(
+              w, scales, *biases, w_deq, s, group_size_, bits_)) {
+        throw std::runtime_error(
+            "[QuantizedMatmul::eval_gpu] Failed to dequantize weights on Vulkan.");
+      }
+      if (mode_ == QuantizationMode::Nvfp4 &&
+          !vulkan::nvfp4_dequantize_to_float32(
+              w, inputs[2], std::nullopt, w_deq, s)) {
+        throw std::runtime_error(
+            "[QuantizedMatmul::eval_gpu] Failed to dequantize FP weights on Vulkan.");
+      }
+      if ((mode_ == QuantizationMode::Mxfp4 ||
+           mode_ == QuantizationMode::Mxfp8) &&
+          !vulkan::fp_dequantize_to_float32(
+              w, inputs[2], w_deq, s, group_size_, bits_)) {
+        throw std::runtime_error(
+            "[QuantizedMatmul::eval_gpu] Failed to dequantize FP weights on Vulkan.");
+      }
+      w_deq.set_status(array::Status::evaluated);
+      cache_dequantized_weight(
+          w, inputs[2], cache_biases, mode_, group_size_, bits_, w_deq);
     }
 
     array rhs_f32 = transpose_ ? swapaxes_in_eval(w_deq, -1, -2) : w_deq;

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1055,6 +1055,11 @@ void main() {
 
 namespace vulkan {
 
+void clear_dequantized_weight_cache() {
+  std::lock_guard<std::mutex> lock(dequantized_weight_cache_mutex());
+  dequantized_weight_cache().clear();
+}
+
 bool affine_quantize_from_float32(
     const array& in,
     array& w,

--- a/mlx/backend/vulkan/reduce.cpp
+++ b/mlx/backend/vulkan/reduce.cpp
@@ -448,7 +448,7 @@ bool try_eval_reduce_sum_rows_vulkan(
 
   const bool use_f32_staging_io =
       (sum_reduce || prod_reduce || max_reduce || min_reduce) &&
-      (f16_io || bf16_io || bool_sum || bool_prod);
+      (f16_io || bool_sum || bool_prod);
   const bool use_i32_staging_io = (sum_reduce || prod_reduce) &&
       ((in.dtype() == int8 || in.dtype() == int16) && out.dtype() == int32);
   const bool use_u8_staging_io = logic_reduce || bool_min_max;
@@ -725,12 +725,16 @@ bool try_eval_reduce_sum_rows_vulkan(
         }
         auto command_buffer = vulkan::begin_command_recording(s.index);
         const auto shader_id = integer_shader ? *integer_shader
-            : sum_reduce   ? vulkan::StaticShaderId::sum_rows_f32
-            : prod_reduce  ? vulkan::StaticShaderId::prod_rows_f32
+            : sum_reduce   ? (bf16_io ? vulkan::StaticShaderId::sum_rows_bf16
+                                      : vulkan::StaticShaderId::sum_rows_f32)
+            : prod_reduce  ? (bf16_io ? vulkan::StaticShaderId::prod_rows_bf16
+                                      : vulkan::StaticShaderId::prod_rows_f32)
             : bool_min_max ? (max_reduce ? vulkan::StaticShaderId::any_rows_u8
                                          : vulkan::StaticShaderId::all_rows_u8)
-            : max_reduce   ? vulkan::StaticShaderId::max_rows_f32
-            : min_reduce   ? vulkan::StaticShaderId::min_rows_f32
+            : max_reduce   ? (bf16_io ? vulkan::StaticShaderId::max_rows_bf16
+                                      : vulkan::StaticShaderId::max_rows_f32)
+            : min_reduce   ? (bf16_io ? vulkan::StaticShaderId::min_rows_bf16
+                                      : vulkan::StaticShaderId::min_rows_f32)
             : reduce_type == Reduce::And ? vulkan::StaticShaderId::all_rows_u8
                                          : vulkan::StaticShaderId::any_rows_u8;
         vulkan::dispatch_sum_rows_op(

--- a/mlx/backend/vulkan/reduce.cpp
+++ b/mlx/backend/vulkan/reduce.cpp
@@ -448,7 +448,7 @@ bool try_eval_reduce_sum_rows_vulkan(
 
   const bool use_f32_staging_io =
       (sum_reduce || prod_reduce || max_reduce || min_reduce) &&
-      (f16_io || bool_sum || bool_prod);
+      (bool_sum || bool_prod);
   const bool use_i32_staging_io = (sum_reduce || prod_reduce) &&
       ((in.dtype() == int8 || in.dtype() == int16) && out.dtype() == int32);
   const bool use_u8_staging_io = logic_reduce || bool_min_max;
@@ -726,14 +726,18 @@ bool try_eval_reduce_sum_rows_vulkan(
         auto command_buffer = vulkan::begin_command_recording(s.index);
         const auto shader_id = integer_shader ? *integer_shader
             : sum_reduce   ? (bf16_io ? vulkan::StaticShaderId::sum_rows_bf16
+                              : f16_io ? vulkan::StaticShaderId::sum_rows_f16
                                       : vulkan::StaticShaderId::sum_rows_f32)
             : prod_reduce  ? (bf16_io ? vulkan::StaticShaderId::prod_rows_bf16
+                              : f16_io ? vulkan::StaticShaderId::prod_rows_f16
                                       : vulkan::StaticShaderId::prod_rows_f32)
             : bool_min_max ? (max_reduce ? vulkan::StaticShaderId::any_rows_u8
                                          : vulkan::StaticShaderId::all_rows_u8)
             : max_reduce   ? (bf16_io ? vulkan::StaticShaderId::max_rows_bf16
+                              : f16_io ? vulkan::StaticShaderId::max_rows_f16
                                       : vulkan::StaticShaderId::max_rows_f32)
             : min_reduce   ? (bf16_io ? vulkan::StaticShaderId::min_rows_bf16
+                              : f16_io ? vulkan::StaticShaderId::min_rows_f16
                                       : vulkan::StaticShaderId::min_rows_f32)
             : reduce_type == Reduce::And ? vulkan::StaticShaderId::all_rows_u8
                                          : vulkan::StaticShaderId::any_rows_u8;

--- a/mlx/backend/vulkan/softmax.cpp
+++ b/mlx/backend/vulkan/softmax.cpp
@@ -73,7 +73,7 @@ bool try_eval_softmax_vulkan(
 
   const bool use_f16_variant = f16_io;
   const bool use_bf16_variant = bf16_io;
-  const bool use_f32_staging_io = f16_io;
+  const bool use_f32_staging_io = false;
   if (use_f32_staging_io) {
     array in_f32(in.shape(), float32, nullptr, {});
     copy_gpu(in, in_f32, CopyType::General, s);
@@ -134,15 +134,15 @@ bool try_eval_softmax_vulkan(
           out_kernel,
           use_bf16_variant ? vulkan::StaticShaderId::soft_max_large1_bf16
               : use_f16_variant
-              ? vulkan::StaticShaderId::soft_max_large1_f32_f16
+              ? vulkan::StaticShaderId::soft_max_large1_f16
               : vulkan::StaticShaderId::soft_max_large1_f32,
           use_bf16_variant ? vulkan::StaticShaderId::soft_max_large2_bf16
               : use_f16_variant
-              ? vulkan::StaticShaderId::soft_max_large2_f32_f16
+              ? vulkan::StaticShaderId::soft_max_large2_f16
               : vulkan::StaticShaderId::soft_max_large2_f32,
           use_bf16_variant ? vulkan::StaticShaderId::soft_max_large3_bf16
               : use_f16_variant
-              ? vulkan::StaticShaderId::soft_max_large3_f32_f16
+              ? vulkan::StaticShaderId::soft_max_large3_f16
               : vulkan::StaticShaderId::soft_max_large3_f32,
           command_buffer,
           s);
@@ -151,7 +151,7 @@ bool try_eval_softmax_vulkan(
           in_kernel,
           out_kernel,
           use_bf16_variant      ? vulkan::StaticShaderId::soft_max_bf16
-              : use_f16_variant ? vulkan::StaticShaderId::soft_max_f32_f16
+              : use_f16_variant ? vulkan::StaticShaderId::soft_max_f16
                                 : vulkan::StaticShaderId::soft_max_f32,
           command_buffer,
           s);

--- a/mlx/backend/vulkan/softmax.cpp
+++ b/mlx/backend/vulkan/softmax.cpp
@@ -72,7 +72,8 @@ bool try_eval_softmax_vulkan(
   }
 
   const bool use_f16_variant = f16_io;
-  const bool use_f32_staging_io = f16_io || bf16_io;
+  const bool use_bf16_variant = bf16_io;
+  const bool use_f32_staging_io = f16_io;
   if (use_f32_staging_io) {
     array in_f32(in.shape(), float32, nullptr, {});
     copy_gpu(in, in_f32, CopyType::General, s);
@@ -131,20 +132,27 @@ bool try_eval_softmax_vulkan(
       vulkan::dispatch_softmax_large_op(
           in_kernel,
           out_kernel,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large1_f32_f16
-                          : vulkan::StaticShaderId::soft_max_large1_f32,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large2_f32_f16
-                          : vulkan::StaticShaderId::soft_max_large2_f32,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_large3_f32_f16
-                          : vulkan::StaticShaderId::soft_max_large3_f32,
+          use_bf16_variant ? vulkan::StaticShaderId::soft_max_large1_bf16
+              : use_f16_variant
+              ? vulkan::StaticShaderId::soft_max_large1_f32_f16
+              : vulkan::StaticShaderId::soft_max_large1_f32,
+          use_bf16_variant ? vulkan::StaticShaderId::soft_max_large2_bf16
+              : use_f16_variant
+              ? vulkan::StaticShaderId::soft_max_large2_f32_f16
+              : vulkan::StaticShaderId::soft_max_large2_f32,
+          use_bf16_variant ? vulkan::StaticShaderId::soft_max_large3_bf16
+              : use_f16_variant
+              ? vulkan::StaticShaderId::soft_max_large3_f32_f16
+              : vulkan::StaticShaderId::soft_max_large3_f32,
           command_buffer,
           s);
     } else {
       vulkan::dispatch_softmax_op(
           in_kernel,
           out_kernel,
-          use_f16_variant ? vulkan::StaticShaderId::soft_max_f32_f16
-                          : vulkan::StaticShaderId::soft_max_f32,
+          use_bf16_variant      ? vulkan::StaticShaderId::soft_max_bf16
+              : use_f16_variant ? vulkan::StaticShaderId::soft_max_f32_f16
+                                : vulkan::StaticShaderId::soft_max_f32,
           command_buffer,
           s);
     }


### PR DESCRIPTION
## Summary

Addresses the fable review findings for the Vulkan backend async pipeline and inference hot-path performance. This branch builds on `feat/vulkan` and keeps work on the GPU stream without blocking host sync in normal execution paths.

## Fable review coverage

| Item | Status | Commit |
|------|--------|--------|
| Flash attention forced submit | Done | `68e430e2e` |
| Device-local allocator + split caches | Done | `3ac62fff9` |
| Host readback mirror for non-mappable buffers | Done | `621acb2a2` |
| Blocking `ensure_vulkan_buffer*` in binary/primitives/matmul | Done | `3f9eeb2d9`, `3696fa2f3`, `a08304a1e` |
| Native bf16 shaders (div, softmax, row reductions) | Done | `d227dd52e` |
| `copy_gpu_inplace` blocking sync | Done | `152b08afb` |
| SDPA decode fallback KV copy churn | Done | `90be0064f` |
| `mul_mm` B transpose per-call copy | Done | `36c82d14b` |
| QuantizedMatmul dequant fallback full-weight churn | Done | `dffd946db` |
| Dynamic copy shader layout recompiles (u32) | Done | `aa93dc3b3` |

## Key changes

### Async pipeline
- Replace blocking `eval()` with `async_eval()` in `ensure_vulkan_buffer*` paths (binary, primitives, matmul)
- `copy_gpu_inplace`: async source materialization; retain sync only under tracing/graph retention
- Flash attention: avoid forced command buffer submit

### Memory / allocation
- Prefer device-local Vulkan allocations with separate host-visible cache
- Host readback mirror for accessing non-mappable device-local buffers

### Inference hot paths
- SDPA decode fallback: reuse K cast path, fuse V cast+transpose, layout guard for matvec
- Matmul: bounded LRU cache (16 entries) for stable bf16/f16 B transposes
- QuantizedMatmul: cache dequantized weights in fallback path
- Dynamic general-copy shaders: shape/strides via push constants (u32), keyed by rank/dtype

### Shaders
- Native bf16 support for div, softmax, and row reductions

## Testing

```
./dev.sh test-cpp          # 249/249 passed
DEVICE=gpu ./dev.sh test-py # 699 passed, 13 skipped
./dev.sh generate --max-tokens 16  # coherent
./dev.sh model-report      # 10/10 models coherent
```

## Benchmarks (Qwen3)

| Model | prompt_tps | generation_tps | peak_memory_gb |
|-------|-----------:|---------------:|---------------:|
| Qwen3-0.6B-bf16 | 2859.020 | 65.514 | 2.723 |
| Qwen3-0.6B-8bit | 1485.466 | 85.773 | 2.165 |
| Qwen3.6-35B-A3B-8bit | 127.179 | 22.345 | 40.039 |

vs previous best for Qwen3.6-35B-A3B-8bit (124.666 / 21.113 prompt/gen tps): **+2.0% prompt, +5.0% generation**, same ~40 GB memory.

## Not in scope (future work)

- Compiled push constants
- FA output scratch reuse
- Argsort scratch lanes
- Tail barrier tuning
- Conv permute optimization
- Fence GPU→GPU paths
- GatherQMM, scatter composed loop, unary Erf staging