### PR TITLE
[codex] Fix Vulkan batched decode quantized matmul

### DIFF
--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1749,9 +1749,9 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           push_constants.group_size = static_cast<uint32_t>(group_size_);
           push_constants.num_groups = num_groups;
 
-          const bool use_decode_matvec = rows == 1;
-          const bool use_tiled_prefill = rows > 1 && group_size_ >= 32 &&
-              (group_size_ % 32) == 0 &&
+          const bool use_decode_matvec = rows == 1 || decode_lhs;
+          const bool use_tiled_prefill = rows > 1 && !decode_lhs &&
+              group_size_ >= 32 && (group_size_ % 32) == 0 &&
               fused_affine_bf16_tiled_prefill_enabled();
           const bool use_large_n_tile = use_tiled_prefill && cols >= 65536;
           const auto shader_id = use_decode_matvec

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1678,6 +1678,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   const bool vector_lhs = x.ndim() == 1;
   const bool flatten_lhs_batches = x.ndim() > 2 && w.ndim() == 2;
+  const bool decode_lhs = flatten_lhs_batches && x.shape(-2) == 1;
   array x_mat = x;
   if (vector_lhs) {
     Shape mat_shape = {1, x.shape(0)};
@@ -1835,6 +1836,8 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
        out.shape(-1) > std::numeric_limits<int16_t>::max());
   auto fused_shader = large_qmm_edge_dim
       ? std::optional<vulkan::StaticShaderId>{}
+      : decode_lhs ? (bits_ == 8 ? fused_affine_matvec8_shader_id(x_mat.dtype())
+                                 : fused_affine_matvec_shader_id(x_mat.dtype()))
       : qmm_rows > 1 && fused_affine_qmm_prefill_enabled()
       ? fused_affine_qmm_shader_id(x_mat.dtype())
       : (bits_ == 8 ? fused_affine_matvec8_shader_id(x_mat.dtype())
@@ -1861,9 +1864,9 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     const uint32_t cols = static_cast<uint32_t>(out_work.shape(-1));
     const uint32_t k = static_cast<uint32_t>(x_mat.shape(-1));
     const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
-    const bool decode_like_rows = rows == 1;
+    const bool decode_like_rows = rows == 1 || decode_lhs;
     const bool prefill_like_rows =
-        rows > 1 && fused_affine_qmm_prefill_enabled();
+        rows > 1 && !decode_lhs && fused_affine_qmm_prefill_enabled();
 
     if ((decode_like_rows || prefill_like_rows) &&
         rows == static_cast<uint32_t>(x_mat.shape(-2)) &&


### PR DESCRIPTION
## Summary
- Detect batched decode-shaped quantized matmul inputs (`[batch, 1, hidden]`).
- Route those inputs through the fused matvec shader/grid instead of the fused prefill QMM shader.
- Preserve the fast Vulkan decode path while avoiding logprob drift in batched generation.

## Root Cause
Batched decode inputs were flattened to multiple rows and selected the fused prefill QMM shader. Single-sequence decode used the fused matvec shader, so batched decode accumulated differently and produced small logprob drift that surfaced in MLX-LM generation tests.

## Validation
- `./dev.sh build`
- `./dev.sh test-cpp`: 261 passed
- `./dev.sh test-py`: 742 passed, 31 skipped
- Focused MLX-LM regression set: 6 passed
- `./dev.sh model-report`: all 10 default models generated coherent output
- Trace check on `test_batch_sliding_window`: `fused_decode 10584`, `dequant_fallback 63`
- `./dev.sh benchmark --model mlx-community/Qwen3.6-35B-A3B-8bit`: prompt_tps=129.286, generation_tps=22.246, peak_memory=39.264 GB

## Benchmark Comparison
Compared to latest matching `benchmarks/results.csv` row from 2026-07-03:

| metric | current | results.csv | delta |
|---|---:|---:|---:|
| prompt_tps | 129.286 | 129.037 | +0.249 (+0.19%) |
| generation_tps | 22.246 | 21.320 | +0.926 (+4.34%) |
| peak_memory_gb | 39.264 | 40.039 | -0.775 (-1.94%) |
