### PR TITLE
[Vulkan] Fix quantized/fast review findings

### DIFF
--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -4,11 +4,9 @@
 #include <cstdlib>
 #include <iostream>
 #include <limits>
-#include <mutex>
 #include <numeric>
 #include <optional>
 #include <sstream>
-#include <unordered_map>
 
 #include "mlx/backend/common/broadcasting.h"
 #include "mlx/backend/common/utils.h"
@@ -36,7 +34,6 @@ namespace {
 constexpr char kFlashAttnMaskOptScratchLane[] = "flash_attn.mask_opt";
 constexpr char kFlashAttnSplitKScratchLane[] = "flash_attn.split_k";
 constexpr char kFlashAttnOutScratchLane[] = "flash_attn.out_storage";
-constexpr char kFlashAttnCausalMaskScratchLane[] = "flash_attn.causal_mask";
 constexpr char kFlashAttnQCastScratchLane[] = "flash_attn.q_cast";
 constexpr char kFlashAttnKCastScratchLane[] = "flash_attn.k_cast";
 constexpr char kFlashAttnVCastScratchLane[] = "flash_attn.v_cast";
@@ -313,15 +310,6 @@ CustomKernelFunction make_vulkan_kernel(
 array apply_diag_mask_inf_vulkan(const array& scores, int n_past, Stream s);
 array ensure_sdpa_rowwise_layout(array arr, Stream s);
 void eval_sdpa_binary_add_vulkan(array lhs, array rhs, array& out, Stream s);
-
-struct FlashAttentionCausalMaskCacheEntry {
-  Shape shape;
-  bool valid{false};
-};
-
-std::mutex flash_attention_causal_mask_cache_mutex;
-std::unordered_map<int, FlashAttentionCausalMaskCacheEntry>
-    flash_attention_causal_mask_cache;
 
 std::optional<bool> experimental_flash_attention_override() {
   static const std::optional<bool> enabled = []() -> std::optional<bool> {
@@ -953,41 +941,6 @@ void insert_compute_barrier(VkCommandBuffer command_buffer) {
       nullptr,
       0,
       nullptr);
-}
-
-array make_flash_attention_causal_mask(
-    const array& q,
-    const array& k,
-    Stream s) {
-  Shape shape = {q.shape(0), 1, q.shape(2), k.shape(2)};
-  array mask = vulkan::acquire_scratch_array(
-      s, kFlashAttnCausalMaskScratchLane, shape, float16);
-
-  bool needs_refresh = true;
-  {
-    std::lock_guard<std::mutex> lock(flash_attention_causal_mask_cache_mutex);
-    auto& entry = flash_attention_causal_mask_cache[s.index];
-    needs_refresh = !entry.valid || entry.shape != shape;
-    entry.shape = shape;
-    entry.valid = true;
-  }
-
-  if (!needs_refresh) {
-    mask.set_status(array::Status::available);
-    return mask;
-  }
-
-  array mask_f16 = zeros(shape, float16, s);
-  if (mask_f16.dtype() != float16) {
-    throw std::runtime_error("Unexpected causal mask dtype.");
-  }
-  const int n_past = k.shape(2) - q.shape(2);
-  mask_f16 = apply_diag_mask_inf_vulkan(mask_f16, n_past, s);
-  eval(mask_f16);
-  copy_gpu_inplace(mask_f16, mask, CopyType::General, s);
-  mask.set_status(array::Status::evaluated);
-  vulkan::mark_scratch_array_written(s, kFlashAttnCausalMaskScratchLane);
-  return mask;
 }
 
 bool try_dispatch_flash_attention_native_vulkan(
@@ -2101,6 +2054,7 @@ bool try_eval_sdpa_heads_vulkan(
       array v_t = vulkan::acquire_scratch_array(
           s, kFlashAttnVCastScratchLane, v_t_shape, float16);
       copy_gpu(v_src, v_t, CopyType::General, s);
+      vulkan::mark_scratch_array_written(s, kFlashAttnVCastScratchLane);
       v_t.set_status(array::Status::evaluated);
 
       {

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -616,6 +616,7 @@ struct Nvfp4DequantPushConstants {
 struct Nvfp4QuantPushConstants {
   uint32_t ne;
   uint32_t has_global_scale;
+  uint32_t base_group;
 };
 
 struct FusedAffineMatmulPushConstants {

--- a/mlx/backend/vulkan/kernels/quantize_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/quantize_nvfp4.comp
@@ -6,6 +6,7 @@
 layout(push_constant) uniform parameter {
     uint ne;
     uint has_global_scale;
+    uint base_group;
 } p;
 
 layout(local_size_x = 1, local_size_y = 1, local_size_z = 1) in;
@@ -61,7 +62,7 @@ uint quant_nvfp4(float x) {
 }
 
 void main() {
-    const uint group = gl_GlobalInvocationID.x;
+    const uint group = p.base_group + gl_GlobalInvocationID.x;
     const uint group_base = group * 16u;
     if (group_base >= p.ne) {
         return;

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1611,19 +1611,35 @@ bool nvfp4_quantize_from_float32(
   push_constants.ne = static_cast<uint32_t>(in.size());
   push_constants.has_global_scale = global_scale.has_value() ? 1u : 0u;
   const uint32_t num_groups = static_cast<uint32_t>(scales.size());
+  if (static_cast<size_t>(num_groups) != scales.size()) {
+    return false;
+  }
 
-  auto command_buffer = vulkan::begin_command_recording(s.index);
-  dispatch_nvfp4_quant_op(
-      in_work,
-      w,
-      scales,
-      global_scale_work,
-      StaticShaderId::quantize_nvfp4_f32,
-      command_buffer,
-      s,
-      push_constants,
-      {num_groups, 1, 1});
-  vulkan::end_command_recording(s.index);
+  const auto limits = VulkanContext::get()
+                          .physical_device()
+                          .getProperties()
+                          .limits;
+  const uint32_t max_groups_x = std::min(
+      kMaxComputeWorkGroupCount, limits.maxComputeWorkGroupCount[0]);
+
+  auto command_buffer = begin_command_recording(s.index);
+  for (uint32_t base_group = 0; base_group < num_groups;
+       base_group += max_groups_x) {
+    const uint32_t chunk =
+        std::min(max_groups_x, num_groups - base_group);
+    push_constants.base_group = base_group;
+    dispatch_nvfp4_quant_op(
+        in_work,
+        w,
+        scales,
+        global_scale_work,
+        StaticShaderId::quantize_nvfp4_f32,
+        command_buffer,
+        s,
+        push_constants,
+        {chunk, 1, 1});
+  }
+  end_command_recording(s.index);
   return true;
 }
 

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -29,6 +29,23 @@ bool is_supported_quantized_output_dtype(Dtype dtype) {
   return dtype == float16 || dtype == bfloat16 || dtype == float32;
 }
 
+// Match matmul.cpp: Vulkan requires workgroup counts <= 65535 on common GPUs.
+constexpr uint32_t kMaxComputeWorkGroupCount = 65535;
+
+bool dispatch_grid_within_limits(uint32_t x, uint32_t y = 1, uint32_t z = 1) {
+  const auto limits = vulkan::VulkanContext::get()
+                          .physical_device()
+                          .getProperties()
+                          .limits;
+  const uint32_t max_x = std::min(
+      kMaxComputeWorkGroupCount, limits.maxComputeWorkGroupCount[0]);
+  const uint32_t max_y = std::min(
+      kMaxComputeWorkGroupCount, limits.maxComputeWorkGroupCount[1]);
+  const uint32_t max_z = std::min(
+      kMaxComputeWorkGroupCount, limits.maxComputeWorkGroupCount[2]);
+  return x > 0 && y > 0 && z > 0 && x <= max_x && y <= max_y && z <= max_z;
+}
+
 constexpr size_t kDequantizedWeightCacheLimit = 8;
 
 struct CachedArrayIdentity {
@@ -61,7 +78,8 @@ std::deque<DequantizedWeightCacheEntry>& dequantized_weight_cache() {
 }
 
 bool cacheable_dequant_source(const array& arr) {
-  return !arr.has_primitive() && arr.status() == array::Status::available &&
+  return !arr.has_primitive() && !arr.is_donatable() &&
+      arr.status() == array::Status::available &&
       arr.data_shared_ptr() != nullptr;
 }
 
@@ -364,46 +382,16 @@ Shape expanded_quantized_shape(const array& w, int bits) {
   return out_shape;
 }
 
-array nvfp4_quantize_dequantize(
-    const array& in,
-    Stream s,
-    const std::optional<array>& global_scale) {
-  array xhat = reshape(in, {-1, 16}, s);
-  array scales =
-      divide(max(abs(xhat, s), -1, true, s), array(6.0f, in.dtype()), s);
-  array scale_encode = global_scale.has_value()
-      ? divide(array(448.0f * 6.0f, float32), *global_scale, s)
-      : array(1.0f, float32);
-  array scales_enc = to_fp8(multiply(scales, scale_encode, s), s);
-  array scale = divide(from_fp8(scales_enc, in.dtype(), s), scale_encode, s);
+Shape packed_quantized_shape(const array& x, int bits) {
+  auto out_shape = x.shape();
+  out_shape.back() = x.shape(-1) * bits / 32;
+  return out_shape;
+}
 
-  array lut = astype(
-      array(
-          {+0.0f,
-           +0.5f,
-           +1.0f,
-           +1.5f,
-           +2.0f,
-           +3.0f,
-           +4.0f,
-           +6.0f,
-           -0.0f,
-           -0.5f,
-           -1.0f,
-           -1.5f,
-           -2.0f,
-           -3.0f,
-           -4.0f,
-           -6.0f}),
-      in.dtype(),
-      s);
-  array idx = argmin(
-      abs(subtract(expand_dims(divide(xhat, scale, s), -1, s), lut, s), s),
-      -1,
-      false,
-      s);
-  array dequant = multiply(gather(lut, idx, 0, {1}, s), scale, s);
-  return reshape(dequant, in.shape(), s);
+Shape quantized_scales_shape(const array& x, int group_size) {
+  auto out_shape = x.shape();
+  out_shape.back() = x.shape(-1) / group_size;
+  return out_shape;
 }
 
 bool fp_dequantize_to_float32_fallback(
@@ -783,6 +771,10 @@ void main() {
           bits == 4 ? "dynamic_gather_mxfp4_qmm" : "dynamic_gather_mxfp8_qmm") +
       "_x" + std::to_string(static_cast<int>(x.dtype().val())) + "_o" +
       std::to_string(static_cast<int>(out.dtype().val()));
+  const uint32_t grid_x = (pc.total + 255u) / 256u;
+  if (!dispatch_grid_within_limits(grid_x)) {
+    return false;
+  }
   auto dispatch = vulkan::dispatch_dynamic_compute_begin(
       shader_name, os.str(), 6, arrays, sizeof(PushConstants), s);
   vkCmdPushConstants(
@@ -792,7 +784,7 @@ void main() {
       0,
       sizeof(PushConstants),
       &pc);
-  vkCmdDispatch(dispatch.command_buffer, (pc.total + 255u) / 256u, 1, 1);
+  vkCmdDispatch(dispatch.command_buffer, grid_x, 1, 1);
   vulkan::end_command_recording(s.index);
   return true;
 }
@@ -1035,6 +1027,10 @@ void main() {
                     : "dynamic_gather_mxfp8_qmm_matvec_wg64") +
       "_x" + std::to_string(static_cast<int>(x.dtype().val())) + "_o" +
       std::to_string(static_cast<int>(out.dtype().val()));
+  // One workgroup per output element (col, row, batch)
+  if (!dispatch_grid_within_limits(cols, rows, batches)) {
+    return false;
+  }
   auto dispatch = vulkan::dispatch_dynamic_compute_begin(
       shader_name, os.str(), 6, arrays, sizeof(PushConstants), s);
   vkCmdPushConstants(
@@ -1044,7 +1040,6 @@ void main() {
       0,
       sizeof(PushConstants),
       &pc);
-  // One workgroup per output element (col, row, batch)
   vkCmdDispatch(dispatch.command_buffer, cols, rows, batches);
   vulkan::end_command_recording(s.index);
   return true;
@@ -1806,13 +1801,16 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
               make_contiguous_strides(out.shape()),
               flags,
               out.size());
-          out.detach();
+          if (!detail::in_tracing() && !detail::retain_graph()) {
+            out.detach();
+          }
           out.set_status(array::Status::evaluated);
           trace_qmm("fused_bf16", "reshaped_output=1");
           return;
         }
 
         out.copy_shared_buffer(out_work);
+        out.set_status(array::Status::evaluated);
         trace_qmm("fused_bf16", "reshaped_output=0");
         return;
       }
@@ -1924,8 +1922,9 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
 
   if (!fused_dispatched) {
     trace_qmm("dequant_fallback", "reason=fused_conditions_not_met");
-    std::optional<array> cache_biases =
-        mode_ == QuantizationMode::Affine ? biases : std::nullopt;
+    std::optional<array> cache_biases = mode_ == QuantizationMode::Affine
+        ? std::make_optional(inputs[3])
+        : std::nullopt;
     auto cached_w_deq = find_cached_dequantized_weight(
         w, inputs[2], cache_biases, mode_, group_size_, bits_);
     array w_deq = cached_w_deq.value_or(
@@ -2001,7 +2000,9 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     if (out_work.dtype() == out.dtype()) {
       out.copy_shared_buffer(
           out_work, make_contiguous_strides(out.shape()), flags, out.size());
-      out.detach();
+      if (!detail::in_tracing() && !detail::retain_graph()) {
+        out.detach();
+      }
       out.set_status(array::Status::evaluated);
       return;
     }
@@ -2011,13 +2012,16 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         out_work, make_contiguous_strides(out.shape()), flags, out.size());
     out.set_data(allocator::malloc(out.nbytes()));
     copy_gpu(out_view, out, CopyType::GeneralGeneral, s);
-    out.detach();
+    if (!detail::in_tracing() && !detail::retain_graph()) {
+      out.detach();
+    }
     out.set_status(array::Status::evaluated);
     return;
   }
 
   if (out_work.dtype() == out.dtype()) {
     out.copy_shared_buffer(out_work);
+    out.set_status(array::Status::evaluated);
     return;
   }
 
@@ -2136,6 +2140,7 @@ void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       }
       if (out_work.dtype() == out.dtype()) {
         out.copy_shared_buffer(out_work);
+        out.set_status(array::Status::evaluated);
         return;
       }
       out.set_data(allocator::malloc(out.nbytes()));
@@ -2145,6 +2150,19 @@ void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   }
 
   array x_f32 = ensure_float32_row_contiguous(inputs[0], s);
+  array x_packed(packed_quantized_shape(x_f32, bits_), uint32, nullptr, {});
+  array x_scales(quantized_scales_shape(x_f32, group_size_), uint8, nullptr, {});
+  if (!vulkan::nvfp4_quantize_from_float32(
+          x_f32, x_packed, x_scales, global_scale_x, s)) {
+    throw std::runtime_error(
+        "[QQMatmul::eval_gpu] Failed to quantize lhs on Vulkan.");
+  }
+  array xhat(x_f32.shape(), float32, nullptr, {});
+  if (!vulkan::nvfp4_dequantize_to_float32(
+          x_packed, x_scales, global_scale_x, xhat, s)) {
+    throw std::runtime_error(
+        "[QQMatmul::eval_gpu] Failed to quantize-dequantize lhs on Vulkan.");
+  }
 
   array what(expanded_quantized_shape(inputs[1], bits_), float32, nullptr, {});
   if (!vulkan::nvfp4_dequantize_to_float32(
@@ -2156,7 +2174,7 @@ void QQMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
   array rhs =
       ensure_row_contiguous_zero_offset(swapaxes_in_eval(what, -1, -2), s);
   array result(out.shape(), float32, nullptr, {});
-  if (!try_eval_matmul_vulkan({x_f32, rhs}, result, s)) {
+  if (!try_eval_matmul_vulkan({xhat, rhs}, result, s)) {
     throw std::runtime_error(
         "[QQMatmul::eval_gpu] Failed to dispatch Vulkan fallback matmul.");
   }
@@ -2364,6 +2382,15 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     push_constants.group_size = static_cast<uint32_t>(group_size_);
     push_constants.num_groups = num_groups;
 
+    const std::array<uint32_t, 3> grid = matvec8_shader.has_value()
+        ? std::array<uint32_t, 3>{cols, rows, batches}
+        : std::array<uint32_t, 3>{
+              (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
+    if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
+      throw std::runtime_error(
+          "[GatherQMM::eval_gpu] Gather dispatch grid exceeds Vulkan workgroup count limits.");
+    }
+
     auto command_buffer = vulkan::begin_command_recording(s.index);
     vulkan::dispatch_gather_affine_matmul_op(
         w,
@@ -2377,15 +2404,13 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         command_buffer,
         s,
         push_constants,
-        matvec8_shader.has_value()
-            ? std::array<uint32_t, 3>{cols, rows, batches}
-            : std::array<uint32_t, 3>{
-                  (cols + 15u) / 16u, (rows + 15u) / 16u, batches});
+        grid);
     vulkan::end_command_recording(s.index);
   }
 
   if (out.dtype() == out_work.dtype()) {
     out.copy_shared_buffer(out_work);
+    out.set_status(array::Status::evaluated);
     return;
   }
   out.set_data(allocator::malloc(out.nbytes()));


### PR DESCRIPTION
## Summary
- Fix NVFP4 `QQMatmul` fallback to quantize–dequantize the LHS (matching fused/Mxfp semantics); remove dead lazy `nvfp4_quantize_dequantize` helper.
- Key affine dequant cache on original scales/biases; reject donatable cache sources; clamp GatherQMM dispatch grids; set `evaluated` and gate `detach` under tracing/retain_graph.
- Mark SDPA decode `v_t` scratch writes; delete unused FA causal-mask helper that contained host `eval()`.
- Intentionally **do not** apply an `int16` edge-dim guard to the native bf16 fused QMM path — that regresses large-vocab models (e.g. Qwen3.6-27B-8bit) by forcing a broken f32 dequant fallback.

## Benchmarks
```
./dev.sh benchmark bf16
Averages: prompt_tps=2831.561, generation_tps=67.032, peak_memory=2.102

./dev.sh benchmark 8bit
Averages: prompt_tps=1500.760, generation_tps=90.202, peak_memory=1.559
```

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh test-cpp`
- [x] `./dev.sh test-py`
- [x] `./dev.sh generate` (Qwen3-0.6B-bf16)
- [x] `./dev.sh model-report --models mlx-community/Qwen3.6-27B-8bit` (coherent after dropping bf16 int16 guard)
- [x] `./dev.sh benchmark bf16` / `./dev.sh benchmark 8bit`


Made with [Cursor](https://cursor.com)