### PR TITLE
Optimize Vulkan GatherQMM prefill

### DIFF
--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -607,7 +607,7 @@ const std::array<KernelSpec, 42> kKernelSpecs = {
         sizeof(GatherAffineMatmulPushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
-        {0, 1},
+        {0, 1, 2},
         sizeof(GatherAffineTileMetadataPushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
@@ -4187,8 +4187,9 @@ void dispatch_gather_affine_coop_matmul_op(
     const GatherAffineTileMetadataPushConstants& metadata_push_constants,
     const GatherAffineCoopMatmulPushConstants& matmul_push_constants,
     const std::array<uint32_t, 3>& grid) {
-  const std::array<BoundArray, 2> metadata_arrays = {{
+  const std::array<BoundArray, 3> metadata_arrays = {{
       {&rhs_indices, "RHS_INDICES"},
+      {&x, "X"},
       {&metadata, "METADATA"},
   }};
   dispatch_with_spec(
@@ -4205,6 +4206,30 @@ void dispatch_gather_affine_coop_matmul_op(
   barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
   barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
   barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+  vkCmdPipelineBarrier(
+      cmd_buffer,
+      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+      0,
+      1,
+      &barrier,
+      0,
+      nullptr,
+      0,
+      nullptr);
+
+  auto range_push_constants = metadata_push_constants;
+  range_push_constants.scan_ranges = 1u;
+  dispatch_with_spec(
+      StaticShaderId::gather_affine_qmm_rhs_metadata,
+      KernelSpecId::GatherAffineTileMetadata,
+      metadata_arrays,
+      range_push_constants,
+      metadata_push_constants.rows,
+      cmd_buffer,
+      s,
+      std::array<uint32_t, 3>{metadata_push_constants.max_tiles, 1u, 1u});
+
   vkCmdPipelineBarrier(
       cmd_buffer,
       VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -240,6 +240,12 @@ PipelineCreationOptions pipeline_creation_options(
     const std::vector<uint32_t>& specialization_constants) {
   PipelineCreationOptions options;
 
+  if (shader_name == "gather_affine_qmm_rhs_bf16_bf16_cm1") {
+    options.require_full_subgroups = true;
+    options.required_subgroup_size = 64;
+    return options;
+  }
+
   if ((shader_name == "soft_max_f32" || shader_name == "soft_max_f32_f16" ||
        shader_name == "soft_max_bf16") &&
       !specialization_constants.empty()) {
@@ -430,6 +436,8 @@ enum class KernelSpecId {
   Nvfp4Quant,
   FusedAffineMatmul,
   GatherAffineMatmul,
+  GatherAffineTileMetadata,
+  GatherAffineCoopMatmul,
   Nvfp4QMatmul,
   LayerNormAffine,
   RMSNormBack,
@@ -461,7 +469,7 @@ KernelSpec make_kernel_spec(
       grid_kind};
 }
 
-const std::array<KernelSpec, 40> kKernelSpecs = {
+const std::array<KernelSpec, 42> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2},
         sizeof(BinaryPushConstants),
@@ -597,6 +605,14 @@ const std::array<KernelSpec, 40> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2, 3, 4, 5, 6},
         sizeof(GatherAffineMatmulPushConstants),
+        DispatchGridKind::Linear1D),
+    make_kernel_spec(
+        {0, 1},
+        sizeof(GatherAffineTileMetadataPushConstants),
+        DispatchGridKind::Linear1D),
+    make_kernel_spec(
+        {0, 1, 2, 3, 4, 5},
+        sizeof(GatherAffineCoopMatmulPushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
         {0, 1, 2, 3, 4, 5},
@@ -4155,6 +4171,72 @@ void dispatch_gather_affine_matmul_op(
       s,
       grid,
       matmul_specialization_constants({}));
+}
+
+void dispatch_gather_affine_coop_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& biases,
+    const array& x,
+    const array& rhs_indices,
+    array& metadata,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const GatherAffineTileMetadataPushConstants& metadata_push_constants,
+    const GatherAffineCoopMatmulPushConstants& matmul_push_constants,
+    const std::array<uint32_t, 3>& grid) {
+  const std::array<BoundArray, 2> metadata_arrays = {{
+      {&rhs_indices, "RHS_INDICES"},
+      {&metadata, "METADATA"},
+  }};
+  dispatch_with_spec(
+      StaticShaderId::gather_affine_qmm_rhs_metadata,
+      KernelSpecId::GatherAffineTileMetadata,
+      metadata_arrays,
+      metadata_push_constants,
+      metadata_push_constants.rows,
+      cmd_buffer,
+      s,
+      std::array<uint32_t, 3>{1u, 1u, 1u});
+
+  VkMemoryBarrier barrier{};
+  barrier.sType = VK_STRUCTURE_TYPE_MEMORY_BARRIER;
+  barrier.srcAccessMask = VK_ACCESS_SHADER_WRITE_BIT;
+  barrier.dstAccessMask = VK_ACCESS_SHADER_READ_BIT;
+  vkCmdPipelineBarrier(
+      cmd_buffer,
+      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+      VK_PIPELINE_STAGE_COMPUTE_SHADER_BIT,
+      0,
+      1,
+      &barrier,
+      0,
+      nullptr,
+      0,
+      nullptr);
+
+  const std::array<BoundArray, 6> matmul_arrays = {{
+      {&w, "W"},
+      {&scales, "SCALES"},
+      {&biases, "BIASES"},
+      {&x, "X"},
+      {&metadata, "METADATA"},
+      {&out, "OUT"},
+  }};
+  dispatch_with_spec(
+      shader_id,
+      KernelSpecId::GatherAffineCoopMatmul,
+      matmul_arrays,
+      matmul_push_constants,
+      checked_mul_u32(
+          matmul_push_constants.rows,
+          matmul_push_constants.cols,
+          "gather cooperative qmm elements"),
+      cmd_buffer,
+      s,
+      grid);
 }
 
 void dispatch_nvfp4_qmatmul_op(

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -652,6 +652,28 @@ struct GatherAffineMatmulPushConstants {
   uint32_t num_groups;
 };
 
+struct GatherAffineTileMetadataPushConstants {
+  uint32_t rows;
+  uint32_t expert_count;
+  uint32_t max_tiles;
+};
+
+struct GatherAffineCoopMatmulPushConstants {
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t K;
+  uint32_t packed_row_bytes;
+  uint32_t x_row_stride;
+  uint32_t out_row_stride;
+  uint32_t scale_matrix_stride;
+  uint32_t scale_row_stride;
+  uint32_t bias_matrix_stride;
+  uint32_t bias_row_stride;
+  uint32_t w_matrix_stride_bytes;
+  uint32_t group_size;
+  uint32_t max_tiles;
+};
+
 struct Nvfp4QMatmulPushConstants {
   uint32_t rows;
   uint32_t cols;
@@ -1147,6 +1169,21 @@ void dispatch_gather_affine_matmul_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const GatherAffineMatmulPushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid);
+
+void dispatch_gather_affine_coop_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& biases,
+    const array& x,
+    const array& rhs_indices,
+    array& metadata,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const GatherAffineTileMetadataPushConstants& metadata_push_constants,
+    const GatherAffineCoopMatmulPushConstants& matmul_push_constants,
     const std::array<uint32_t, 3>& grid);
 
 void dispatch_nvfp4_qmatmul_op(

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -656,6 +656,9 @@ struct GatherAffineTileMetadataPushConstants {
   uint32_t rows;
   uint32_t expert_count;
   uint32_t max_tiles;
+  uint32_t K;
+  uint32_t x_row_stride;
+  uint32_t scan_ranges;
 };
 
 struct GatherAffineCoopMatmulPushConstants {

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
@@ -81,6 +81,28 @@ void main() {
     const uint row_start = data_metadata[1u + p.max_tiles + tile];
     const uint col_start = gl_WorkGroupID.x * BN;
     const uint valid_rows = data_metadata[1u + 2u * p.max_tiles + tile];
+    const bool use_fp32_tile =
+        data_metadata[1u + 3u * p.max_tiles + tile] != 0u;
+
+    if (use_fp32_tile) {
+        for (uint index = lane; index < BM * BN; index += 64u) {
+            const uint row = index / BN;
+            const uint col = index - row * BN;
+            const uint src_row = row_start + row;
+            const uint src_col = col_start + col;
+            if (row < valid_rows && src_col < p.cols) {
+                float acc = 0.0f;
+                for (uint k = 0u; k < p.K; ++k) {
+                    const float x = bf16_to_fp32(
+                        uint(data_x[src_row * p.x_row_stride + k]));
+                    acc = fma(x, dequant_w(expert, src_col, k), acc);
+                }
+                data_out[src_row * p.out_row_stride + src_col] =
+                    uint16_t(fp32_to_bf16(acc));
+            }
+        }
+        return;
+    }
 
     coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matrix_a0;
     coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matrix_a1;

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
@@ -1,0 +1,178 @@
+#version 450
+
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_KHR_cooperative_matrix : require
+#extension GL_KHR_memory_scope_semantics : require
+#extension GL_KHR_shader_subgroup_basic : require
+
+#include "types.glsl"
+
+layout(local_size_x = 64, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer W {
+    uint8_t data_w[];
+};
+layout(binding = 1) readonly buffer SCALES {
+    uint16_t data_scales[];
+};
+layout(binding = 2) readonly buffer BIASES {
+    uint16_t data_biases[];
+};
+layout(binding = 3) readonly buffer X {
+    uint16_t data_x[];
+};
+layout(binding = 4) readonly buffer METADATA {
+    uint data_metadata[];
+};
+layout(binding = 5) writeonly buffer OUT {
+    uint16_t data_out[];
+};
+
+layout(push_constant) uniform parameter {
+    uint rows;
+    uint cols;
+    uint K;
+    uint packed_row_bytes;
+    uint x_row_stride;
+    uint out_row_stride;
+    uint scale_matrix_stride;
+    uint scale_row_stride;
+    uint bias_matrix_stride;
+    uint bias_row_stride;
+    uint w_matrix_stride_bytes;
+    uint group_size;
+    uint max_tiles;
+} p;
+
+const uint BM = 32u;
+const uint BN = 16u;
+const uint BK = 16u;
+const uint SHMEM_STRIDE = BK / 2u + 4u;
+
+shared f16vec2 xs[BM * SHMEM_STRIDE];
+shared f16vec2 ws[BN * SHMEM_STRIDE];
+shared float output_stage[BM * BN];
+
+float dequant_w(const uint expert, const uint col, const uint k) {
+    const uint group = k / p.group_size;
+    const uint row_base = expert * p.w_matrix_stride_bytes +
+        col * p.packed_row_bytes;
+    const uint scale_base = expert * p.scale_matrix_stride +
+        col * p.scale_row_stride;
+    const uint bias_base = expert * p.bias_matrix_stride +
+        col * p.bias_row_stride;
+    return bf16_to_fp32(uint(data_scales[scale_base + group])) *
+        float(data_w[row_base + k]) +
+        bf16_to_fp32(uint(data_biases[bias_base + group]));
+}
+
+void main() {
+    const uint tile = gl_WorkGroupID.y;
+    const uint tile_count = data_metadata[0];
+    if (tile >= tile_count) {
+        return;
+    }
+
+    const uint lane = gl_LocalInvocationID.x;
+    const uint expert = data_metadata[1u + tile];
+    const uint row_start = data_metadata[1u + p.max_tiles + tile];
+    const uint col_start = gl_WorkGroupID.x * BN;
+    const uint valid_rows = data_metadata[1u + 2u * p.max_tiles + tile];
+
+    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matrix_a0;
+    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseA> matrix_a1;
+    coopmat<float16_t, gl_ScopeSubgroup, 16, 16, gl_MatrixUseB> matrix_b;
+    coopmat<float, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> accum0 =
+        coopmat<float, gl_ScopeSubgroup, 16, 16,
+            gl_MatrixUseAccumulator>(0.0f);
+    coopmat<float, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> accum1 =
+        coopmat<float, gl_ScopeSubgroup, 16, 16,
+            gl_MatrixUseAccumulator>(0.0f);
+
+    for (uint kb = 0u; kb < p.K; kb += BK) {
+        for (uint pair_idx = lane; pair_idx < BM * (BK / 2u);
+             pair_idx += 64u) {
+            const uint row = pair_idx / (BK / 2u);
+            const uint pair = pair_idx - row * (BK / 2u);
+            const uint k0 = kb + pair * 2u;
+            const uint src_row = row_start + row;
+            float16_t x0 = float16_t(0.0f);
+            float16_t x1 = float16_t(0.0f);
+            if (row < valid_rows && k0 < p.K) {
+                x0 = float16_t(bf16_to_fp32(
+                    uint(data_x[src_row * p.x_row_stride + k0])));
+            }
+            if (row < valid_rows && k0 + 1u < p.K) {
+                x1 = float16_t(bf16_to_fp32(
+                    uint(data_x[src_row * p.x_row_stride + k0 + 1u])));
+            }
+            xs[row * SHMEM_STRIDE + pair] = f16vec2(x0, x1);
+        }
+
+        for (uint pair_idx = lane; pair_idx < BN * (BK / 2u);
+             pair_idx += 64u) {
+            const uint col = pair_idx / (BK / 2u);
+            const uint pair = pair_idx - col * (BK / 2u);
+            const uint src_col = col_start + col;
+            const uint k0 = kb + pair * 2u;
+            float16_t w0 = float16_t(0.0f);
+            float16_t w1 = float16_t(0.0f);
+            if (src_col < p.cols && k0 < p.K) {
+                w0 = float16_t(dequant_w(expert, src_col, k0));
+            }
+            if (src_col < p.cols && k0 + 1u < p.K) {
+                w1 = float16_t(dequant_w(expert, src_col, k0 + 1u));
+            }
+            ws[col * SHMEM_STRIDE + pair] = f16vec2(w0, w1);
+        }
+        barrier();
+
+        coopMatLoad(
+            matrix_a0,
+            xs,
+            0u,
+            SHMEM_STRIDE,
+            gl_CooperativeMatrixLayoutRowMajor);
+        coopMatLoad(
+            matrix_a1,
+            xs,
+            16u * SHMEM_STRIDE,
+            SHMEM_STRIDE,
+            gl_CooperativeMatrixLayoutRowMajor);
+        coopMatLoad(
+            matrix_b,
+            ws,
+            0u,
+            SHMEM_STRIDE,
+            gl_CooperativeMatrixLayoutColumnMajor);
+        accum0 = coopMatMulAdd(matrix_a0, matrix_b, accum0);
+        accum1 = coopMatMulAdd(matrix_a1, matrix_b, accum1);
+        barrier();
+    }
+
+    coopMatStore(
+        accum0,
+        output_stage,
+        0u,
+        BN,
+        gl_CooperativeMatrixLayoutRowMajor);
+    coopMatStore(
+        accum1,
+        output_stage,
+        16u * BN,
+        BN,
+        gl_CooperativeMatrixLayoutRowMajor);
+    barrier();
+
+    for (uint index = lane; index < BM * BN; index += 64u) {
+        const uint row = index / BN;
+        const uint col = index - row * BN;
+        if (row < valid_rows && col_start + col < p.cols) {
+            data_out[(row_start + row) * p.out_row_stride + col_start + col] =
+                uint16_t(fp32_to_bf16(output_stage[index]));
+        }
+    }
+}

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_coop.comp
@@ -7,6 +7,7 @@
 #extension GL_KHR_cooperative_matrix : require
 #extension GL_KHR_memory_scope_semantics : require
 #extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_vote : require
 
 #include "types.glsl"
 
@@ -113,6 +114,7 @@ void main() {
     coopmat<float, gl_ScopeSubgroup, 16, 16, gl_MatrixUseAccumulator> accum1 =
         coopmat<float, gl_ScopeSubgroup, 16, 16,
             gl_MatrixUseAccumulator>(0.0f);
+    bool requires_fp32_weight = false;
 
     for (uint kb = 0u; kb < p.K; kb += BK) {
         for (uint pair_idx = lane; pair_idx < BM * (BK / 2u);
@@ -143,10 +145,28 @@ void main() {
             float16_t w0 = float16_t(0.0f);
             float16_t w1 = float16_t(0.0f);
             if (src_col < p.cols && k0 < p.K) {
-                w0 = float16_t(dequant_w(expert, src_col, k0));
-            }
-            if (src_col < p.cols && k0 + 1u < p.K) {
-                w1 = float16_t(dequant_w(expert, src_col, k0 + 1u));
+                const uint group = k0 / p.group_size;
+                const uint row_base = expert * p.w_matrix_stride_bytes +
+                    src_col * p.packed_row_bytes;
+                const uint scale_base = expert * p.scale_matrix_stride +
+                    src_col * p.scale_row_stride;
+                const uint bias_base = expert * p.bias_matrix_stride +
+                    src_col * p.bias_row_stride;
+                const float scale = bf16_to_fp32(
+                    uint(data_scales[scale_base + group]));
+                const float bias = bf16_to_fp32(
+                    uint(data_biases[bias_base + group]));
+                if ((k0 & 63u) == 0u &&
+                    (abs(bias) > 65504.0f ||
+                     abs(scale * 255.0f + bias) > 65504.0f)) {
+                    requires_fp32_weight = true;
+                }
+                w0 = float16_t(
+                    scale * float(data_w[row_base + k0]) + bias);
+                if (k0 + 1u < p.K) {
+                    w1 = float16_t(
+                        scale * float(data_w[row_base + k0 + 1u]) + bias);
+                }
             }
             ws[col * SHMEM_STRIDE + pair] = f16vec2(w0, w1);
         }
@@ -173,6 +193,26 @@ void main() {
         accum0 = coopMatMulAdd(matrix_a0, matrix_b, accum0);
         accum1 = coopMatMulAdd(matrix_a1, matrix_b, accum1);
         barrier();
+    }
+
+    if (subgroupAny(requires_fp32_weight)) {
+        for (uint index = lane; index < BM * BN; index += 64u) {
+            const uint row = index / BN;
+            const uint col = index - row * BN;
+            const uint src_row = row_start + row;
+            const uint src_col = col_start + col;
+            if (row < valid_rows && src_col < p.cols) {
+                float acc = 0.0f;
+                for (uint k = 0u; k < p.K; ++k) {
+                    const float x = bf16_to_fp32(
+                        uint(data_x[src_row * p.x_row_stride + k]));
+                    acc = fma(x, dequant_w(expert, src_col, k), acc);
+                }
+                data_out[src_row * p.out_row_stride + src_col] =
+                    uint16_t(fp32_to_bf16(acc));
+            }
+        }
+        return;
     }
 
     coopMatStore(

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_metadata.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_metadata.comp
@@ -1,0 +1,65 @@
+#version 450
+
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer RHS_INDICES {
+    uint data_rhs_indices[];
+};
+layout(binding = 1) writeonly buffer METADATA {
+    uint data_metadata[];
+};
+
+layout(push_constant) uniform parameter {
+    uint rows;
+    uint expert_count;
+    uint max_tiles;
+} p;
+
+const uint BM = 32u;
+
+shared uint expert_starts[257];
+
+uint lower_bound_expert(const uint expert) {
+    uint lo = 0u;
+    uint hi = p.rows;
+    while (lo < hi) {
+        const uint mid = lo + (hi - lo) / 2u;
+        if (data_rhs_indices[mid] < expert) {
+            lo = mid + 1u;
+        } else {
+            hi = mid;
+        }
+    }
+    return lo;
+}
+
+void main() {
+    const uint lane = gl_LocalInvocationID.x;
+    if (lane < p.expert_count) {
+        expert_starts[lane] = lower_bound_expert(lane);
+    }
+    if (lane == 0u) {
+        expert_starts[p.expert_count] = p.rows;
+    }
+    barrier();
+
+    if (lane != 0u) {
+        return;
+    }
+
+    uint tile = 0u;
+    for (uint expert = 0u; expert < p.expert_count; ++expert) {
+        const uint begin = expert_starts[expert];
+        const uint end = expert_starts[expert + 1u];
+        for (uint row = begin; row < end; row += BM) {
+            if (tile >= p.max_tiles) {
+                break;
+            }
+            data_metadata[1u + tile] = expert;
+            data_metadata[1u + p.max_tiles + tile] = row;
+            data_metadata[1u + 2u * p.max_tiles + tile] = min(BM, end - row);
+            ++tile;
+        }
+    }
+    data_metadata[0] = tile;
+}

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_metadata.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_metadata.comp
@@ -1,11 +1,16 @@
 #version 450
 
+#extension GL_EXT_shader_16bit_storage : require
+
 layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer RHS_INDICES {
     uint data_rhs_indices[];
 };
-layout(binding = 1) writeonly buffer METADATA {
+layout(binding = 1) readonly buffer X {
+    uint16_t data_x[];
+};
+layout(binding = 2) buffer METADATA {
     uint data_metadata[];
 };
 
@@ -13,11 +18,15 @@ layout(push_constant) uniform parameter {
     uint rows;
     uint expert_count;
     uint max_tiles;
+    uint K;
+    uint x_row_stride;
+    uint scan_ranges;
 } p;
 
 const uint BM = 32u;
 
 shared uint expert_starts[257];
+shared uint requires_fp32;
 
 uint lower_bound_expert(const uint expert) {
     uint lo = 0u;
@@ -35,6 +44,37 @@ uint lower_bound_expert(const uint expert) {
 
 void main() {
     const uint lane = gl_LocalInvocationID.x;
+    if (p.scan_ranges != 0u) {
+        const uint tile = gl_WorkGroupID.x;
+        if (tile >= data_metadata[0]) {
+            return;
+        }
+        if (lane == 0u) {
+            requires_fp32 = 0u;
+        }
+        barrier();
+
+        const uint row_start = data_metadata[1u + p.max_tiles + tile];
+        const uint valid_rows =
+            data_metadata[1u + 2u * p.max_tiles + tile];
+        const uint tile_elements = valid_rows * p.K;
+        for (uint index = lane; index < tile_elements; index += 256u) {
+            const uint row = index / p.K;
+            const uint k = index - row * p.K;
+            const uint x_abs_bits = uint(data_x[
+                (row_start + row) * p.x_row_stride + k]) & 0x7fffu;
+            if (x_abs_bits >= 0x4780u && x_abs_bits < 0x7f80u) {
+                atomicOr(requires_fp32, 1u);
+                break;
+            }
+        }
+        barrier();
+        if (lane == 0u) {
+            data_metadata[1u + 3u * p.max_tiles + tile] = requires_fp32;
+        }
+        return;
+    }
+
     if (lane < p.expert_count) {
         expert_starts[lane] = lower_bound_expert(lane);
     }

--- a/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_tiled.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_affine_rhs_tiled.comp
@@ -1,0 +1,223 @@
+#version 450
+
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+#ifdef FLOAT16
+#extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
+#endif
+
+#include "types.glsl"
+
+#if !defined(TO_FLOAT_TYPE)
+#define TO_FLOAT_TYPE float
+#endif
+
+#if !defined(FROM_FLOAT_TYPE)
+#define FROM_FLOAT_TYPE(x) (x)
+#endif
+
+#if !defined(S_TYPE)
+#define S_TYPE float
+#endif
+
+#if !defined(SCALE_TO_FLOAT_TYPE)
+#define SCALE_TO_FLOAT_TYPE(x) float(x)
+#endif
+
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer W {
+    uint8_t data_w[];
+};
+layout(binding = 1) readonly buffer SCALES {
+    S_TYPE data_scales[];
+};
+layout(binding = 2) readonly buffer BIASES {
+    S_TYPE data_biases[];
+};
+layout(binding = 3) readonly buffer X {
+    B_TYPE data_x[];
+};
+layout(binding = 4) readonly buffer LHS_INDICES {
+    uint data_lhs_indices[];
+};
+layout(binding = 5) readonly buffer RHS_INDICES {
+    uint data_rhs_indices[];
+};
+layout(binding = 6) writeonly buffer OUT {
+    D_TYPE data_out[];
+};
+
+layout(push_constant) uniform parameter {
+    uint rows;
+    uint cols;
+    uint K;
+    uint packed_row_bytes;
+    uint x_batch_stride;
+    uint x_row_stride;
+    uint out_batch_stride;
+    uint out_row_stride;
+    uint scale_matrix_stride;
+    uint scale_row_stride;
+    uint bias_matrix_stride;
+    uint bias_row_stride;
+    uint w_matrix_stride_bytes;
+    uint bits;
+    uint group_size;
+    uint num_groups;
+} p;
+
+const uint BM = 32u;
+const uint BN = 16u;
+const uint BK = 32u;
+const uint TM = 4u;
+const uint TN = 2u;
+
+shared float xs[BM][BK];
+shared float ws[BN][BK];
+shared uint expert_ids[BM];
+
+uint read_quant(const uint row_base, const uint index_in_row) {
+    if (p.bits == 2u) {
+        const uint pack = index_in_row >> 2;
+        const uint shift = 2u * (index_in_row & 3u);
+        return (uint(data_w[row_base + pack]) >> shift) & 0x3u;
+    }
+    if (p.bits == 3u) {
+        const uint pack = index_in_row >> 3;
+        const uint lane = index_in_row & 7u;
+        const uint base = row_base + pack * 3u;
+        if (lane == 0u) return uint(data_w[base + 0u]) & 0x7u;
+        if (lane == 1u) return (uint(data_w[base + 0u]) >> 3u) & 0x7u;
+        if (lane == 2u) return ((uint(data_w[base + 0u]) >> 6u) & 0x3u) | ((uint(data_w[base + 1u]) & 0x1u) << 2u);
+        if (lane == 3u) return (uint(data_w[base + 1u]) >> 1u) & 0x7u;
+        if (lane == 4u) return (uint(data_w[base + 1u]) >> 4u) & 0x7u;
+        if (lane == 5u) return ((uint(data_w[base + 1u]) >> 7u) & 0x1u) | ((uint(data_w[base + 2u]) & 0x3u) << 1u);
+        if (lane == 6u) return (uint(data_w[base + 2u]) >> 2u) & 0x7u;
+        return (uint(data_w[base + 2u]) >> 5u) & 0x7u;
+    }
+    if (p.bits == 4u) {
+        const uint pack = index_in_row >> 1;
+        const uint shift = 4u * (index_in_row & 1u);
+        return (uint(data_w[row_base + pack]) >> shift) & 0xFu;
+    }
+    if (p.bits == 5u) {
+        const uint pack = index_in_row >> 3;
+        const uint lane = index_in_row & 7u;
+        const uint base = row_base + pack * 5u;
+        if (lane == 0u) return uint(data_w[base + 0u]) & 0x1Fu;
+        if (lane == 1u) return ((uint(data_w[base + 0u]) >> 5u) & 0x7u) | ((uint(data_w[base + 1u]) & 0x3u) << 3u);
+        if (lane == 2u) return (uint(data_w[base + 1u]) >> 2u) & 0x1Fu;
+        if (lane == 3u) return ((uint(data_w[base + 1u]) >> 7u) & 0x1u) | ((uint(data_w[base + 2u]) & 0xFu) << 1u);
+        if (lane == 4u) return ((uint(data_w[base + 2u]) >> 4u) & 0xFu) | ((uint(data_w[base + 3u]) & 0x1u) << 4u);
+        if (lane == 5u) return (uint(data_w[base + 3u]) >> 1u) & 0x1Fu;
+        if (lane == 6u) return ((uint(data_w[base + 3u]) >> 6u) & 0x3u) | ((uint(data_w[base + 4u]) & 0x7u) << 2u);
+        return (uint(data_w[base + 4u]) >> 3u) & 0x1Fu;
+    }
+    if (p.bits == 6u) {
+        const uint pack = index_in_row >> 2;
+        const uint lane = index_in_row & 3u;
+        const uint base = row_base + pack * 3u;
+        if (lane == 0u) return uint(data_w[base + 0u]) & 0x3Fu;
+        if (lane == 1u) return ((uint(data_w[base + 0u]) >> 6u) & 0x3u) | ((uint(data_w[base + 1u]) & 0xFu) << 2u);
+        if (lane == 2u) return ((uint(data_w[base + 1u]) >> 4u) & 0xFu) | ((uint(data_w[base + 2u]) & 0x3u) << 4u);
+        return (uint(data_w[base + 2u]) >> 2u) & 0x3Fu;
+    }
+    return uint(data_w[row_base + index_in_row]);
+}
+
+float dequant_w(const uint expert, const uint col, const uint k) {
+    const uint group = k / p.group_size;
+    const uint row_base = expert * p.w_matrix_stride_bytes +
+        col * p.packed_row_bytes;
+    const uint scale_base = expert * p.scale_matrix_stride +
+        col * p.scale_row_stride;
+    const uint bias_base = expert * p.bias_matrix_stride +
+        col * p.bias_row_stride;
+    return SCALE_TO_FLOAT_TYPE(data_scales[scale_base + group]) *
+        float(read_quant(row_base, k)) +
+        SCALE_TO_FLOAT_TYPE(data_biases[bias_base + group]);
+}
+
+void main() {
+    const uint lx = gl_LocalInvocationID.x;
+    const uint ly = gl_LocalInvocationID.y;
+    const uint linear = ly * gl_WorkGroupSize.x + lx;
+    const uint row_tile = gl_WorkGroupID.y * BM;
+    const uint col0 = gl_WorkGroupID.x * BN + lx * TN;
+    const uint valid_rows = min(BM, p.rows - row_tile);
+
+    for (uint r = linear; r < valid_rows; r += 64u) {
+        expert_ids[r] = data_rhs_indices[row_tile + r];
+    }
+    barrier();
+
+    float acc[TM][TN];
+    for (uint mr = 0u; mr < TM; ++mr) {
+        for (uint nc = 0u; nc < TN; ++nc) {
+            acc[mr][nc] = 0.0f;
+        }
+    }
+
+    for (uint kb = 0u; kb < p.K; kb += BK) {
+        for (uint i = linear; i < BM * BK; i += 64u) {
+            const uint r = i / BK;
+            const uint kk = i - r * BK;
+            const uint src_row = row_tile + r;
+            const uint src_k = kb + kk;
+            xs[r][kk] = (r < valid_rows && src_k < p.K)
+                ? TO_FLOAT_TYPE(data_x[src_row * p.x_row_stride + src_k])
+                : 0.0f;
+        }
+        barrier();
+
+        uint segment_start = 0u;
+        while (segment_start < valid_rows) {
+            const uint expert = expert_ids[segment_start];
+            uint segment_end = segment_start + 1u;
+            while (segment_end < valid_rows &&
+                   expert_ids[segment_end] == expert) {
+                ++segment_end;
+            }
+
+            for (uint i = linear; i < BN * BK; i += 64u) {
+                const uint c = i / BK;
+                const uint kk = i - c * BK;
+                const uint src_col = gl_WorkGroupID.x * BN + c;
+                const uint src_k = kb + kk;
+                ws[c][kk] = (src_col < p.cols && src_k < p.K)
+                    ? dequant_w(expert, src_col, src_k)
+                    : 0.0f;
+            }
+            barrier();
+
+            for (uint mr = 0u; mr < TM; ++mr) {
+                const uint r = ly * TM + mr;
+                if (r < segment_start || r >= segment_end) {
+                    continue;
+                }
+                for (uint kk = 0u; kk < BK; ++kk) {
+                    const float x = xs[r][kk];
+                    acc[mr][0] = fma(x, ws[lx * TN][kk], acc[mr][0]);
+                    acc[mr][1] = fma(x, ws[lx * TN + 1u][kk], acc[mr][1]);
+                }
+            }
+            barrier();
+            segment_start = segment_end;
+        }
+    }
+
+    for (uint mr = 0u; mr < TM; ++mr) {
+        const uint row = row_tile + ly * TM + mr;
+        if (row < p.rows && col0 < p.cols) {
+            data_out[row * p.out_row_stride + col0] =
+                D_TYPE(FROM_FLOAT_TYPE(acc[mr][0]));
+        }
+        if (row < p.rows && col0 + 1u < p.cols) {
+            data_out[row * p.out_row_stride + col0 + 1u] =
+                D_TYPE(FROM_FLOAT_TYPE(acc[mr][1]));
+        }
+    }
+}

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2288,6 +2288,23 @@ void process_shaders() {
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
        {"SCALE_TO_FLOAT_TYPE(x)", "bf16_to_fp32(uint(x))"},
        {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "gather_affine_qmm_rhs_f32_f32",
+      "gather_mm_affine_rhs_tiled.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "gather_affine_qmm_rhs_f16_f32",
+      "gather_mm_affine_rhs_tiled.comp",
+      {{"FLOAT16", "1"}, {"B_TYPE", "float16_t"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "gather_affine_qmm_rhs_bf16_bf16",
+      "gather_mm_affine_rhs_tiled.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"S_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"SCALE_TO_FLOAT_TYPE(x)", "bf16_to_fp32(uint(x))"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
 
   string_to_spv(
       "gather_affine_matvec8_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2305,6 +2305,18 @@ void process_shaders() {
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
        {"SCALE_TO_FLOAT_TYPE(x)", "bf16_to_fp32(uint(x))"},
        {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "gather_affine_qmm_rhs_metadata",
+      "gather_mm_affine_rhs_metadata.comp",
+      {});
+#if defined(MLX_VULKAN_COOPMAT_GLSLC_SUPPORT)
+  string_to_spv(
+      "gather_affine_qmm_rhs_bf16_bf16",
+      "gather_mm_affine_rhs_coop.comp",
+      {},
+      true,
+      true);
+#endif
 
   string_to_spv(
       "gather_affine_matvec8_f32_f32",

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -2534,7 +2534,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
 #if defined(MLX_VULKAN_COOPMAT_GLSLC_SUPPORT)
       const uint32_t max_tiles =
           (batches + 31u) / 32u + static_cast<uint32_t>(expert_count);
-      const uint32_t metadata_elements = 1u + 3u * max_tiles;
+      const uint32_t metadata_elements = 1u + 4u * max_tiles;
       array metadata(
           {static_cast<int>(metadata_elements)}, uint32, nullptr, {});
       metadata.set_data(allocator::malloc(metadata.nbytes()));
@@ -2544,6 +2544,10 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       metadata_push_constants.expert_count =
           static_cast<uint32_t>(expert_count);
       metadata_push_constants.max_tiles = max_tiles;
+      metadata_push_constants.K = k;
+      metadata_push_constants.x_row_stride =
+          static_cast<uint32_t>(x.strides(-2));
+      metadata_push_constants.scan_ranges = 0u;
 
       vulkan::GatherAffineCoopMatmulPushConstants push_constants{};
       push_constants.rows = batches;

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -340,6 +340,17 @@ bool gather_affine_matvec8_smallk_enabled() {
   return enabled;
 }
 
+bool gather_affine_coop_prefill_enabled() {
+  static const bool enabled = []() {
+    if (const char* env = std::getenv("MLX_VULKAN_GATHER_QMM_COOP");
+        env != nullptr) {
+      return std::string_view(env) != "0";
+    }
+    return true;
+  }();
+  return enabled;
+}
+
 bool fused_affine_bf16_tiled_prefill_enabled() {
   static const bool enabled = []() {
     if (const char* env = std::getenv("MLX_VULKAN_AFFINE_BF16_TILED_PREFILL");
@@ -2502,59 +2513,139 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
       ? gather_affine_qmm_rhs_shader_id(x.dtype(), out.dtype())
       : std::optional<vulkan::StaticShaderId>{};
 
+  const auto& context = vulkan::VulkanContext::get();
+  const bool supports_64_lane_subgroups = context.subgroup_size() == 64u ||
+      (context.subgroup_size_control_supported() &&
+       context.subgroup_min_size() <= 64u &&
+       context.subgroup_max_size() >= 64u);
+#if defined(MLX_VULKAN_COOPMAT_GLSLC_SUPPORT)
+  const bool use_expert_coop_qmm = use_sorted_rhs_qmm && native_bf16 &&
+      bits_ == 8 && group_size_ == 64 && expert_count <= 256 &&
+      (k % 16u) == 0u && context.coopmat_flash_attention_f32acc_supported() &&
+      supports_64_lane_subgroups && gather_affine_coop_prefill_enabled();
+#else
+  const bool use_expert_coop_qmm = false;
+#endif
+
   array out_work(out.shape(), native_bf16 ? bfloat16 : float32, nullptr, {});
   out_work.set_data(allocator::malloc(out_work.nbytes()));
   if (out_work.size() != 0) {
-    vulkan::GatherAffineMatmulPushConstants push_constants{};
-    push_constants.rows = sorted_rhs_shader.has_value() ? batches : rows;
-    push_constants.cols = cols;
-    push_constants.K = k;
-    push_constants.packed_row_bytes =
-        static_cast<uint32_t>(w.strides(-2) * sizeof(uint32_t));
-    push_constants.x_batch_stride =
-        static_cast<uint32_t>(x.shape(-2) * x.shape(-1));
-    push_constants.x_row_stride = static_cast<uint32_t>(x.strides(-2));
-    push_constants.out_batch_stride = rows * cols;
-    push_constants.out_row_stride = static_cast<uint32_t>(out_work.strides(-2));
-    push_constants.scale_matrix_stride =
-        static_cast<uint32_t>(scales.strides(-3));
-    push_constants.scale_row_stride = static_cast<uint32_t>(scales.strides(-2));
-    push_constants.bias_matrix_stride =
-        static_cast<uint32_t>(biases->strides(-3));
-    push_constants.bias_row_stride = static_cast<uint32_t>(biases->strides(-2));
-    push_constants.w_matrix_stride_bytes =
-        static_cast<uint32_t>(w.strides(-3) * sizeof(uint32_t));
-    push_constants.bits = static_cast<uint32_t>(bits_);
-    push_constants.group_size = static_cast<uint32_t>(group_size_);
-    push_constants.num_groups = num_groups;
+    if (use_expert_coop_qmm) {
+#if defined(MLX_VULKAN_COOPMAT_GLSLC_SUPPORT)
+      const uint32_t max_tiles =
+          (batches + 31u) / 32u + static_cast<uint32_t>(expert_count);
+      const uint32_t metadata_elements = 1u + 3u * max_tiles;
+      array metadata(
+          {static_cast<int>(metadata_elements)}, uint32, nullptr, {});
+      metadata.set_data(allocator::malloc(metadata.nbytes()));
 
-    const std::array<uint32_t, 3> grid = sorted_rhs_shader.has_value()
-        ? std::array<uint32_t, 3>{(cols + 15u) / 16u,
-                                  (batches + 31u) / 32u, 1u}
-        : matvec8_shader.has_value()
-        ? std::array<uint32_t, 3>{cols, rows, batches}
-        : std::array<uint32_t, 3>{
-              (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
-    if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
-      throw std::runtime_error(
-          "[GatherQMM::eval_gpu] Gather dispatch grid exceeds Vulkan workgroup count limits.");
+      vulkan::GatherAffineTileMetadataPushConstants metadata_push_constants{};
+      metadata_push_constants.rows = batches;
+      metadata_push_constants.expert_count =
+          static_cast<uint32_t>(expert_count);
+      metadata_push_constants.max_tiles = max_tiles;
+
+      vulkan::GatherAffineCoopMatmulPushConstants push_constants{};
+      push_constants.rows = batches;
+      push_constants.cols = cols;
+      push_constants.K = k;
+      push_constants.packed_row_bytes =
+          static_cast<uint32_t>(w.strides(-2) * sizeof(uint32_t));
+      push_constants.x_row_stride = static_cast<uint32_t>(x.strides(-2));
+      push_constants.out_row_stride =
+          static_cast<uint32_t>(out_work.strides(-2));
+      push_constants.scale_matrix_stride =
+          static_cast<uint32_t>(scales.strides(-3));
+      push_constants.scale_row_stride =
+          static_cast<uint32_t>(scales.strides(-2));
+      push_constants.bias_matrix_stride =
+          static_cast<uint32_t>(biases->strides(-3));
+      push_constants.bias_row_stride =
+          static_cast<uint32_t>(biases->strides(-2));
+      push_constants.w_matrix_stride_bytes =
+          static_cast<uint32_t>(w.strides(-3) * sizeof(uint32_t));
+      push_constants.group_size = static_cast<uint32_t>(group_size_);
+      push_constants.max_tiles = max_tiles;
+
+      const std::array<uint32_t, 3> grid = {(cols + 15u) / 16u, max_tiles, 1u};
+      if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
+        throw std::runtime_error(
+            "[GatherQMM::eval_gpu] Cooperative gather dispatch grid exceeds Vulkan workgroup count limits.");
+      }
+
+      auto command_buffer = vulkan::begin_command_recording(s.index);
+      vulkan::dispatch_gather_affine_coop_matmul_op(
+          w,
+          scales,
+          *biases,
+          x,
+          rhs_indices,
+          metadata,
+          out_work,
+          vulkan::StaticShaderId::gather_affine_qmm_rhs_bf16_bf16_cm1,
+          command_buffer,
+          s,
+          metadata_push_constants,
+          push_constants,
+          grid);
+      vulkan::end_command_recording(s.index);
+#endif
+    } else {
+      vulkan::GatherAffineMatmulPushConstants push_constants{};
+      push_constants.rows = sorted_rhs_shader.has_value() ? batches : rows;
+      push_constants.cols = cols;
+      push_constants.K = k;
+      push_constants.packed_row_bytes =
+          static_cast<uint32_t>(w.strides(-2) * sizeof(uint32_t));
+      push_constants.x_batch_stride =
+          static_cast<uint32_t>(x.shape(-2) * x.shape(-1));
+      push_constants.x_row_stride = static_cast<uint32_t>(x.strides(-2));
+      push_constants.out_batch_stride = rows * cols;
+      push_constants.out_row_stride =
+          static_cast<uint32_t>(out_work.strides(-2));
+      push_constants.scale_matrix_stride =
+          static_cast<uint32_t>(scales.strides(-3));
+      push_constants.scale_row_stride =
+          static_cast<uint32_t>(scales.strides(-2));
+      push_constants.bias_matrix_stride =
+          static_cast<uint32_t>(biases->strides(-3));
+      push_constants.bias_row_stride =
+          static_cast<uint32_t>(biases->strides(-2));
+      push_constants.w_matrix_stride_bytes =
+          static_cast<uint32_t>(w.strides(-3) * sizeof(uint32_t));
+      push_constants.bits = static_cast<uint32_t>(bits_);
+      push_constants.group_size = static_cast<uint32_t>(group_size_);
+      push_constants.num_groups = num_groups;
+
+      const std::array<uint32_t, 3> grid = sorted_rhs_shader.has_value()
+          ? std::array<
+                uint32_t,
+                3>{(cols + 15u) / 16u, (batches + 31u) / 32u, 1u}
+          : matvec8_shader.has_value()
+          ? std::array<uint32_t, 3>{cols, rows, batches}
+          : std::array<uint32_t, 3>{
+                (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
+      if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
+        throw std::runtime_error(
+            "[GatherQMM::eval_gpu] Gather dispatch grid exceeds Vulkan workgroup count limits.");
+      }
+
+      auto command_buffer = vulkan::begin_command_recording(s.index);
+      vulkan::dispatch_gather_affine_matmul_op(
+          w,
+          scales,
+          *biases,
+          x,
+          lhs_indices,
+          rhs_indices,
+          out_work,
+          sorted_rhs_shader.value_or(*shader_id),
+          command_buffer,
+          s,
+          push_constants,
+          grid);
+      vulkan::end_command_recording(s.index);
     }
-
-    auto command_buffer = vulkan::begin_command_recording(s.index);
-    vulkan::dispatch_gather_affine_matmul_op(
-        w,
-        scales,
-        *biases,
-        x,
-        lhs_indices,
-        rhs_indices,
-        out_work,
-        sorted_rhs_shader.value_or(*shader_id),
-        command_buffer,
-        s,
-        push_constants,
-        grid);
-    vulkan::end_command_recording(s.index);
   }
 
   if (out.dtype() == out_work.dtype()) {

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -259,6 +259,22 @@ std::optional<vulkan::StaticShaderId> gather_affine_qmm_shader_id(
   }
 }
 
+std::optional<vulkan::StaticShaderId> gather_affine_qmm_rhs_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return vulkan::StaticShaderId::gather_affine_qmm_rhs_bf16_bf16;
+  }
+  switch (x_dtype) {
+    case float32:
+      return vulkan::StaticShaderId::gather_affine_qmm_rhs_f32_f32;
+    case float16:
+      return vulkan::StaticShaderId::gather_affine_qmm_rhs_f16_f32;
+    default:
+      return std::nullopt;
+  }
+}
+
 std::optional<vulkan::StaticShaderId> gather_affine_matvec8_shader_id(
     Dtype x_dtype,
     Dtype out_dtype) {
@@ -2478,11 +2494,19 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     throw std::runtime_error("[GatherQMM::eval_gpu] Invalid x batch count.");
   }
 
+  const auto expert_count = w.size() / (w.shape(-2) * w.shape(-1));
+  const bool use_sorted_rhs_qmm = rows == 1 && batches >= 16 && right_sorted_ &&
+      x_batch_count == batches && expert_count > 0 &&
+      batches / expert_count >= 4;
+  const auto sorted_rhs_shader = use_sorted_rhs_qmm
+      ? gather_affine_qmm_rhs_shader_id(x.dtype(), out.dtype())
+      : std::optional<vulkan::StaticShaderId>{};
+
   array out_work(out.shape(), native_bf16 ? bfloat16 : float32, nullptr, {});
   out_work.set_data(allocator::malloc(out_work.nbytes()));
   if (out_work.size() != 0) {
     vulkan::GatherAffineMatmulPushConstants push_constants{};
-    push_constants.rows = rows;
+    push_constants.rows = sorted_rhs_shader.has_value() ? batches : rows;
     push_constants.cols = cols;
     push_constants.K = k;
     push_constants.packed_row_bytes =
@@ -2504,7 +2528,10 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     push_constants.group_size = static_cast<uint32_t>(group_size_);
     push_constants.num_groups = num_groups;
 
-    const std::array<uint32_t, 3> grid = matvec8_shader.has_value()
+    const std::array<uint32_t, 3> grid = sorted_rhs_shader.has_value()
+        ? std::array<uint32_t, 3>{(cols + 15u) / 16u,
+                                  (batches + 31u) / 32u, 1u}
+        : matvec8_shader.has_value()
         ? std::array<uint32_t, 3>{cols, rows, batches}
         : std::array<uint32_t, 3>{
               (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
@@ -2522,7 +2549,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         lhs_indices,
         rhs_indices,
         out_work,
-        *shader_id,
+        sorted_rhs_shader.value_or(*shader_id),
         command_buffer,
         s,
         push_constants,


### PR DESCRIPTION
## Summary
- add tiled sorted-RHS GatherQMM shader
- add cooperative affine GatherQMM prefill path

## Benchmarks

### Qwen3-0.6B bf16
```text
prompt_tps=2821.453
generation_tps=67.030
peak_memory=2.111 GB
```

### Qwen3-0.6B 8-bit
```text
prompt_tps=2818.132
generation_tps=90.178
peak_memory=1.675 GB
```