### PR TITLE
[Vulkan] Qwen3.6 MoE decode: wave64 uint32 gather matvec (~30 tok/s)

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -2441,6 +2441,19 @@ class VulkanDevice {
           details.str() + ").");
     };
 
+    // Flush shader/transfer writes before the CB ends. Intra-CB hazard
+    // tracking may leave the final producer without a trailing barrier when
+    // barrier_between_deferred_ops is off; without this, a later same-stream
+    // submission has no memory dependency on those writes.
+    if (!submit_to_transfer_queue &&
+        (!stream->unsynced_writes.empty() ||
+         stream->has_untracked_segment_writes)) {
+      trace_sync("barrier action=submit-tail reason=pending-writes");
+      insert_memory_barrier(command_buffer);
+      record_decode_barrier(stream, "submit-tail");
+      stream->has_untracked_segment_writes = false;
+    }
+
     VkResult result;
     try {
       command_buffer.end();
@@ -2483,6 +2496,9 @@ class VulkanDevice {
       }
 
       std::lock_guard<std::mutex> affinity_lock(buffer->queue_affinity_mutex);
+      // Cross-queue transfers still need an explicit timeline wait. Same-queue
+      // producers are covered by the submit-tail barrier above plus queue
+      // submission order for the common deferred decode path.
       if (!buffer->last_semaphore || buffer->last_timeline_value == 0 ||
           buffer->queue_affinity == VulkanBuffer::QueueAffinity::None ||
           buffer->queue_affinity == queue_affinity) {

--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -186,7 +186,10 @@ bool barrier_between_deferred_ops() {
       return std::string(env) != "0";
     }
 
-    return true;
+    // Default off: inter-primitive RAW/WAW/WAR is handled in begin_primitive,
+    // and intra-primitive multi-segment dependencies are barrier'd when a
+    // subsequent recording segment starts inside the same primitive.
+    return false;
   }();
   return enabled;
 }
@@ -773,6 +776,9 @@ struct StreamData {
   uint32_t decode_hazard_submit_count{0};
   uint32_t decode_transfer_submit_count{0};
   DecodeResourceSummary last_decode_resource_summary;
+  uint32_t primitive_depth{0};
+  uint32_t segments_in_current_primitive{0};
+  bool has_untracked_segment_writes{false};
 };
 
 class VulkanDevice {
@@ -1263,6 +1269,7 @@ class VulkanDevice {
   static bool is_heavy_primitive_name(const std::string& primitive) {
     return primitive_name_contains(primitive, "Matmul") ||
         primitive_name_contains(primitive, "GatherMM") ||
+        primitive_name_contains(primitive, "GatherQMM") ||
         primitive_name_contains(primitive, "BlockMaskedMM") ||
         primitive_name_contains(primitive, "SegmentedMM") ||
         primitive_name_contains(primitive, "QuantizedMatmul") ||
@@ -1281,6 +1288,7 @@ class VulkanDevice {
     uint64_t weighted = input_bytes + output_bytes;
     if (primitive_name_contains(primitive, "Matmul") ||
         primitive_name_contains(primitive, "GatherMM") ||
+        primitive_name_contains(primitive, "GatherQMM") ||
         primitive_name_contains(primitive, "BlockMaskedMM") ||
         primitive_name_contains(primitive, "SegmentedMM") ||
         primitive_name_contains(primitive, "QuantizedMatmul")) {
@@ -1463,6 +1471,25 @@ class VulkanDevice {
     retire_submissions(stream, false);
     flush_host_readback_writes(inputs);
 
+    stream->primitive_depth += 1;
+    if (stream->primitive_depth == 1) {
+      stream->segments_in_current_primitive = 0;
+    }
+
+    if (stream->recording && stream->recording_resources &&
+        stream->has_untracked_segment_writes) {
+      // A prior deferred segment in this (or an outer) primitive wrote temps
+      // that are not yet in unsynced_*. Make them visible before more work.
+      trace_sync(
+          "barrier action=primitive-head reason=untracked-segment-writes");
+      insert_memory_barrier(
+          stream->recording_resources->compute_command_buffer);
+      record_decode_barrier(stream, "untracked-segment-writes");
+      stream->has_untracked_segment_writes = false;
+      stream->unsynced_reads.clear();
+      stream->unsynced_writes.clear();
+    }
+
     if (!deferred_submission_enabled()) {
       return;
     }
@@ -1515,26 +1542,39 @@ class VulkanDevice {
       const Stream& s,
       const std::vector<array>& inputs,
       const std::vector<array>& outputs) {
+    auto* stream = get_stream(s.index);
+    if (stream->primitive_depth == 0) {
+      // Some helpers historically call end without begin; ignore.
+      return;
+    }
+    const bool outermost = stream->primitive_depth == 1;
+    stream->primitive_depth -= 1;
+    if (outermost) {
+      stream->segments_in_current_primitive = 0;
+      stream->has_untracked_segment_writes = false;
+    }
+
     if (!deferred_submission_enabled()) {
       return;
     }
 
-    auto* stream = get_stream(s.index);
     if (!stream->recording) {
       return;
     }
 
-    update_deferred_work_estimate(stream, inputs, outputs);
-    update_decode_resource_summary(stream, inputs, outputs);
+    if (outermost) {
+      update_deferred_work_estimate(stream, inputs, outputs);
+      update_decode_resource_summary(stream, inputs, outputs);
 
-    auto reads = make_access_ranges(inputs);
-    auto writes = make_access_ranges(outputs);
-    auto donation_writes = make_potential_donation_writes(inputs, outputs);
-    writes.insert(writes.end(), donation_writes.begin(), donation_writes.end());
-    stream->unsynced_reads.insert(
-        stream->unsynced_reads.end(), reads.begin(), reads.end());
-    stream->unsynced_writes.insert(
-        stream->unsynced_writes.end(), writes.begin(), writes.end());
+      auto reads = make_access_ranges(inputs);
+      auto writes = make_access_ranges(outputs);
+      auto donation_writes = make_potential_donation_writes(inputs, outputs);
+      writes.insert(writes.end(), donation_writes.begin(), donation_writes.end());
+      stream->unsynced_reads.insert(
+          stream->unsynced_reads.end(), reads.begin(), reads.end());
+      stream->unsynced_writes.insert(
+          stream->unsynced_writes.end(), writes.begin(), writes.end());
+    }
   }
 
   VkCommandBuffer begin_recording(int stream_index) {
@@ -1603,6 +1643,10 @@ class VulkanDevice {
       stream->decode_hazard_submit_count = 0;
       stream->decode_transfer_submit_count = 0;
       stream->last_decode_resource_summary.reset();
+      // Keep primitive_depth across submit/re-record so nested tracking stays
+      // balanced; only clear segment bookkeeping for the new CB.
+      stream->segments_in_current_primitive = 0;
+      stream->has_untracked_segment_writes = false;
       if (trace_sync_enabled()) {
         std::ostringstream oss;
         oss << "begin_recording(stream=" << stream_index
@@ -1612,6 +1656,15 @@ class VulkanDevice {
             << " next_epoch=" << stream->next_epoch;
         trace_sync(oss.str());
       }
+    } else if (
+        !transfer && stream->recording_resources &&
+        stream->has_untracked_segment_writes) {
+      trace_sync(
+          "barrier action=recording-head reason=untracked-segment-writes");
+      insert_memory_barrier(
+          stream->recording_resources->compute_command_buffer);
+      record_decode_barrier(stream, "untracked-segment-writes");
+      stream->has_untracked_segment_writes = false;
     }
 
     return stream->recording_transfer
@@ -1675,6 +1728,10 @@ class VulkanDevice {
         stream->recorded_ops += 1;
       }
       stream->last_op_budget_free = false;
+      if (stream->primitive_depth > 0) {
+        stream->segments_in_current_primitive += 1;
+        stream->has_untracked_segment_writes = true;
+      }
       if (exceeds_decode_hard_limits(stream)) {
         std::string submit_reason;
         (void)should_submit_recording(stream, &submit_reason);
@@ -1714,6 +1771,10 @@ class VulkanDevice {
       stream->recorded_ops += 1;
     }
     stream->last_op_budget_free = false;
+    if (stream->primitive_depth > 0) {
+      stream->segments_in_current_primitive += 1;
+      stream->has_untracked_segment_writes = true;
+    }
     std::string submit_reason;
     if (should_submit_recording(stream, &submit_reason)) {
       stream->force_immediate_submit_ = false;
@@ -1948,9 +2009,6 @@ class VulkanDevice {
       const std::vector<array>& inputs,
       const std::vector<array>& outputs) {
     stream->last_decode_resource_summary.reset();
-    if (!decode_batch_enabled()) {
-      return;
-    }
 
     for (const auto& in : inputs) {
       stream->last_decode_resource_summary.record(
@@ -2025,12 +2083,13 @@ class VulkanDevice {
   }
 
   static void insert_memory_barrier(vk::CommandBuffer command_buffer) {
+    // Prefer a RAW-oriented dependency. The previous full read|write mask on
+    // both sides forced a heavier global sync than decode typically needs.
     vk::MemoryBarrier barrier;
-    barrier.srcAccessMask = vk::AccessFlagBits::eShaderRead |
-        vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferRead |
+    barrier.srcAccessMask = vk::AccessFlagBits::eShaderWrite |
         vk::AccessFlagBits::eTransferWrite;
     barrier.dstAccessMask = vk::AccessFlagBits::eShaderRead |
-        vk::AccessFlagBits::eShaderWrite | vk::AccessFlagBits::eTransferRead |
+        vk::AccessFlagBits::eTransferRead | vk::AccessFlagBits::eShaderWrite |
         vk::AccessFlagBits::eTransferWrite;
 
     command_buffer.pipelineBarrier(

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
@@ -1,8 +1,11 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
 
 #ifdef FLOAT16
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -26,7 +29,12 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+// Process 8 output columns per workgroup so each activation load is reused,
+// matching Metal gather_qmv / llama.cpp mul_mat_vec_id NUM_COLS style.
+#define NUM_COLS 8
+#define BLOCK_SIZE 64
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
     uint8_t data_w[];
@@ -69,43 +77,128 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[256];
+shared float partial[NUM_COLS][BLOCK_SIZE];
 
 void main() {
-    const uint col = gl_WorkGroupID.x;
+    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
     const uint row = gl_WorkGroupID.y;
     const uint batch = gl_WorkGroupID.z;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col >= p.cols) {
+    if (row >= p.rows || col0 >= p.cols) {
         return;
     }
 
+    const uint num_cols = min(NUM_COLS, p.cols - col0);
     const uint lhs_batch = data_lhs_indices[batch];
     const uint rhs_batch = data_rhs_indices[batch];
-    const uint w_row_base = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
-    const uint scale_row_base = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-    const uint bias_row_base = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    float acc = 0.0f;
-    for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
-        const uint group = k / p.group_size;
-        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
-            float(data_w[w_row_base + k]) + SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
-        acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
+    uint w_row_base[NUM_COLS];
+    uint scale_row_base[NUM_COLS];
+    uint bias_row_base[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        if (c < num_cols) {
+            const uint col = col0 + c;
+            w_row_base[c] = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
+            scale_row_base[c] = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+            bias_row_base[c] = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
+        }
     }
 
-    partial[tid] = acc;
+    float acc[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        acc[c] = 0.0f;
+    }
+
+    // Prefer vec4 strides when K is divisible by 4 (Qwen MoE K=512/2048).
+    if ((p.K & 3u) == 0u) {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
+            const uint k = k0 + tid * 4u;
+            if (k < p.K) {
+                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
+                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
+                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const uint group0 = k / p.group_size;
+                        const uint group1 = (k + 1u) / p.group_size;
+                        const uint group2 = (k + 2u) / p.group_size;
+                        const uint group3 = (k + 3u) / p.group_size;
+                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
+                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
+                                float(data_w[w_row_base[c] + k + 1u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
+                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
+                                float(data_w[w_row_base[c] + k + 2u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
+                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
+                                float(data_w[w_row_base[c] + k + 3u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
+                        acc[c] = fma(x0, w0, acc[c]);
+                        acc[c] = fma(x1, w1, acc[c]);
+                        acc[c] = fma(x2, w2, acc[c]);
+                        acc[c] = fma(x3, w3, acc[c]);
+                    }
+                }
+            }
+        }
+    } else {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
+            const uint k = k0 + tid;
+            if (k < p.K) {
+                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const uint group = k / p.group_size;
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                        acc[c] = fma(xval, w, acc[c]);
+                    }
+                }
+            }
+        }
+    }
+
+    // Fast path when the workgroup is a single subgroup (typical AMD wave64).
+    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            acc[c] = subgroupAdd(acc[c]);
+        }
+        if (tid == 0u) {
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
+                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
+                }
+            }
+        }
+        return;
+    }
+
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        partial[c][tid] = acc[c];
+    }
     barrier();
-    for (uint stride = gl_WorkGroupSize.x >> 1u; stride > 0u; stride >>= 1u) {
+    for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
         if (tid < stride) {
-            partial[tid] += partial[tid + stride];
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                partial[c][tid] += partial[c][tid + stride];
+            }
         }
         barrier();
     }
 
     if (tid == 0u) {
-        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            if (c < num_cols) {
+                data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
+                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
+            }
+        }
     }
 }

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
@@ -29,15 +29,15 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-// Process 8 output columns per workgroup so each activation load is reused,
-// matching Metal gather_qmv / llama.cpp mul_mat_vec_id NUM_COLS style.
+// Metal gather_qmv / llama.cpp mul_mat_vec_id style: reuse activations across
+// several output columns. On AMD wave64 a single subgroup covers BLOCK_SIZE.
 #define NUM_COLS 8
 #define BLOCK_SIZE 64
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
-    uint8_t data_w[];
+    uint data_w[];
 };
 layout(binding = 1) readonly buffer SCALES {
     S_TYPE data_scales[];
@@ -94,15 +94,18 @@ void main() {
     const uint rhs_batch = data_rhs_indices[batch];
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    uint w_row_base[NUM_COLS];
+    uint w_row_words[NUM_COLS];
     uint scale_row_base[NUM_COLS];
     uint bias_row_base[NUM_COLS];
     [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
         if (c < num_cols) {
             const uint col = col0 + c;
-            w_row_base[c] = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
-            scale_row_base[c] = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-            bias_row_base[c] = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
+            w_row_words[c] =
+                (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
+            scale_row_base[c] =
+                rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+            bias_row_base[c] =
+                rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
         }
     }
 
@@ -111,60 +114,54 @@ void main() {
         acc[c] = 0.0f;
     }
 
-    // Prefer vec4 strides when K is divisible by 4 (Qwen MoE K=512/2048).
-    if ((p.K & 3u) == 0u) {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
-            const uint k = k0 + tid * 4u;
-            if (k < p.K) {
-                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
-                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
-                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const uint group0 = k / p.group_size;
-                        const uint group1 = (k + 1u) / p.group_size;
-                        const uint group2 = (k + 2u) / p.group_size;
-                        const uint group3 = (k + 3u) / p.group_size;
-                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
-                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
-                                float(data_w[w_row_base[c] + k + 1u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
-                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
-                                float(data_w[w_row_base[c] + k + 2u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
-                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
-                                float(data_w[w_row_base[c] + k + 3u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
-                        acc[c] = fma(x0, w0, acc[c]);
-                        acc[c] = fma(x1, w1, acc[c]);
-                        acc[c] = fma(x2, w2, acc[c]);
-                        acc[c] = fma(x3, w3, acc[c]);
-                    }
+    // 8-bit affine weights are packed 4-per-uint32. Walk K in uint packs so
+    // each thread issues wide loads; activations are reused across NUM_COLS.
+    if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
+        const uint packs = p.K >> 2;
+        for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
+            const uint k = pidx << 2;
+            const uint group = k / p.group_size;
+            const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+            const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
+            const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
+            const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
+
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    const float s =
+                        SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]);
+                    const float b =
+                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                    const uint packed = data_w[w_row_words[c] + pidx];
+                    acc[c] = fma(x0, float(packed & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x1, float((packed >> 8) & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x2, float((packed >> 16) & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x3, float((packed >> 24) & 0xffu) * s + b, acc[c]);
                 }
             }
         }
     } else {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
-            const uint k = k0 + tid;
-            if (k < p.K) {
-                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const uint group = k / p.group_size;
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                        acc[c] = fma(xval, w, acc[c]);
-                    }
+        for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
+            const uint group = k / p.group_size;
+            const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+            const uint byte_off = k;
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    const uint word = data_w[w_row_words[c] + (byte_off >> 2)];
+                    const uint q = (word >> ((byte_off & 3u) * 8u)) & 0xffu;
+                    const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
+                            float(q) +
+                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                    acc[c] = fma(xval, w, acc[c]);
                 }
             }
         }
     }
 
-    // Fast path when the workgroup is a single subgroup (typical AMD wave64).
+    // Fast path: one subgroup covers the whole workgroup (AMD wave64).
     if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
         [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
             acc[c] = subgroupAdd(acc[c]);

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8.comp
@@ -1,6 +1,5 @@
 #version 450
 
-#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
@@ -29,9 +28,7 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-// Metal gather_qmv / llama.cpp mul_mat_vec_id style: reuse activations across
-// several output columns. On AMD wave64 a single subgroup covers BLOCK_SIZE.
-#define NUM_COLS 8
+// Wave64-sized workgroup: one subgroup covers the full reduce on AMD.
 #define BLOCK_SIZE 64
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
@@ -77,125 +74,87 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[NUM_COLS][BLOCK_SIZE];
+shared float partial[BLOCK_SIZE];
 
 void main() {
-    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
+    const uint col = gl_WorkGroupID.x;
     const uint row = gl_WorkGroupID.y;
     const uint batch = gl_WorkGroupID.z;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col0 >= p.cols) {
+    if (row >= p.rows || col >= p.cols) {
         return;
     }
 
-    const uint num_cols = min(NUM_COLS, p.cols - col0);
     const uint lhs_batch = data_lhs_indices[batch];
     const uint rhs_batch = data_rhs_indices[batch];
+    const uint w_row_words =
+        (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
+    const uint scale_row_base =
+        rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+    const uint bias_row_base =
+        rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    uint w_row_words[NUM_COLS];
-    uint scale_row_base[NUM_COLS];
-    uint bias_row_base[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        if (c < num_cols) {
-            const uint col = col0 + c;
-            w_row_words[c] =
-                (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
-            scale_row_base[c] =
-                rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-            bias_row_base[c] =
-                rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
-        }
-    }
-
-    float acc[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        acc[c] = 0.0f;
-    }
-
-    // 8-bit affine weights are packed 4-per-uint32. Walk K in uint packs so
-    // each thread issues wide loads; activations are reused across NUM_COLS.
+    float acc = 0.0f;
     if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
         const uint packs = p.K >> 2;
         for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
             const uint k = pidx << 2;
             const uint group = k / p.group_size;
-            const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-            const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
-            const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
-            const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
-
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    const float s =
-                        SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]);
-                    const float b =
-                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                    const uint packed = data_w[w_row_words[c] + pidx];
-                    acc[c] = fma(x0, float(packed & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x1, float((packed >> 8) & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x2, float((packed >> 16) & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x3, float((packed >> 24) & 0xffu) * s + b, acc[c]);
-                }
-            }
+            const float s =
+                SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]);
+            const float b =
+                SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            const uint packed = data_w[w_row_words + pidx];
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k]),
+                float(packed & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]),
+                float((packed >> 8) & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]),
+                float((packed >> 16) & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]),
+                float((packed >> 24) & 0xffu) * s + b,
+                acc);
         }
     } else {
         for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
             const uint group = k / p.group_size;
-            const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-            const uint byte_off = k;
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    const uint word = data_w[w_row_words[c] + (byte_off >> 2)];
-                    const uint q = (word >> ((byte_off & 3u) * 8u)) & 0xffu;
-                    const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
-                            float(q) +
-                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                    acc[c] = fma(xval, w, acc[c]);
-                }
-            }
+            const uint word = data_w[w_row_words + (k >> 2)];
+            const uint q = (word >> ((k & 3u) * 8u)) & 0xffu;
+            const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
+                    float(q) +
+                SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
         }
     }
 
-    // Fast path: one subgroup covers the whole workgroup (AMD wave64).
     if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            acc[c] = subgroupAdd(acc[c]);
-        }
+        acc = subgroupAdd(acc);
         if (tid == 0u) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
-                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
-                }
-            }
+            data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+                D_TYPE(FROM_FLOAT_TYPE(acc));
         }
         return;
     }
 
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        partial[c][tid] = acc[c];
-    }
+    partial[tid] = acc;
     barrier();
     for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
         if (tid < stride) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                partial[c][tid] += partial[c][tid + stride];
-            }
+            partial[tid] += partial[tid + stride];
         }
         barrier();
     }
-
     if (tid == 0u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            if (c < num_cols) {
-                data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
-                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
-            }
-        }
+        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(partial[0]));
     }
 }

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
@@ -28,7 +28,9 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+#define BLOCK_SIZE 256
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
     uint data_w[];
@@ -71,7 +73,9 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[8];
+// Size to the workgroup so gl_SubgroupID is always in-range for any legal
+// subgroup size (NumSubgroups <= BLOCK_SIZE).
+shared float partial[BLOCK_SIZE];
 
 void main() {
     const uint col = gl_WorkGroupID.x;
@@ -96,7 +100,7 @@ void main() {
     float acc = 0.0f;
     if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
         const uint packs = p.K >> 2;
-        for (uint pidx = tid; pidx < packs; pidx += gl_WorkGroupSize.x) {
+        for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
             const uint k = pidx << 2;
             const uint group = k / p.group_size;
             const float s =
@@ -122,7 +126,7 @@ void main() {
                 acc);
         }
     } else {
-        for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
+        for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
             const uint group = k / p.group_size;
             const uint word = data_w[w_row_words + (k >> 2)];
             const uint q = (word >> ((k & 3u) * 8u)) & 0xffu;
@@ -131,6 +135,16 @@ void main() {
                 SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
             acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
         }
+    }
+
+    // Prefer a single-subgroup reduce when the WG is exactly one wave.
+    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+        acc = subgroupAdd(acc);
+        if (tid == 0u) {
+            data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+                D_TYPE(FROM_FLOAT_TYPE(acc));
+        }
+        return;
     }
 
     acc = subgroupAdd(acc);

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
@@ -1,6 +1,5 @@
 #version 450
 
-#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
@@ -29,12 +28,7 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-// Metal gather_qmv / llama.cpp mul_mat_vec_id style: reuse activations across
-// several output columns. On AMD wave64 a single subgroup covers BLOCK_SIZE.
-#define NUM_COLS 8
-#define BLOCK_SIZE 64
-
-layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
     uint data_w[];
@@ -77,125 +71,79 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[NUM_COLS][BLOCK_SIZE];
+shared float partial[8];
 
 void main() {
-    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
+    const uint col = gl_WorkGroupID.x;
     const uint row = gl_WorkGroupID.y;
     const uint batch = gl_WorkGroupID.z;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col0 >= p.cols) {
+    if (row >= p.rows || col >= p.cols) {
         return;
     }
 
-    const uint num_cols = min(NUM_COLS, p.cols - col0);
     const uint lhs_batch = data_lhs_indices[batch];
     const uint rhs_batch = data_rhs_indices[batch];
+    const uint w_row_words =
+        (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
+    const uint scale_row_base =
+        rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+    const uint bias_row_base =
+        rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    uint w_row_words[NUM_COLS];
-    uint scale_row_base[NUM_COLS];
-    uint bias_row_base[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        if (c < num_cols) {
-            const uint col = col0 + c;
-            w_row_words[c] =
-                (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
-            scale_row_base[c] =
-                rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-            bias_row_base[c] =
-                rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
-        }
-    }
-
-    float acc[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        acc[c] = 0.0f;
-    }
-
-    // 8-bit affine weights are packed 4-per-uint32. Walk K in uint packs so
-    // each thread issues wide loads; activations are reused across NUM_COLS.
+    float acc = 0.0f;
     if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
         const uint packs = p.K >> 2;
-        for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
+        for (uint pidx = tid; pidx < packs; pidx += gl_WorkGroupSize.x) {
             const uint k = pidx << 2;
             const uint group = k / p.group_size;
-            const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-            const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
-            const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
-            const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
-
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    const float s =
-                        SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]);
-                    const float b =
-                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                    const uint packed = data_w[w_row_words[c] + pidx];
-                    acc[c] = fma(x0, float(packed & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x1, float((packed >> 8) & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x2, float((packed >> 16) & 0xffu) * s + b, acc[c]);
-                    acc[c] = fma(
-                        x3, float((packed >> 24) & 0xffu) * s + b, acc[c]);
-                }
-            }
+            const float s =
+                SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]);
+            const float b =
+                SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            const uint packed = data_w[w_row_words + pidx];
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k]),
+                float(packed & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]),
+                float((packed >> 8) & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]),
+                float((packed >> 16) & 0xffu) * s + b,
+                acc);
+            acc = fma(
+                TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]),
+                float((packed >> 24) & 0xffu) * s + b,
+                acc);
         }
     } else {
-        for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
+        for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
             const uint group = k / p.group_size;
-            const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-            const uint byte_off = k;
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    const uint word = data_w[w_row_words[c] + (byte_off >> 2)];
-                    const uint q = (word >> ((byte_off & 3u) * 8u)) & 0xffu;
-                    const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
-                            float(q) +
-                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                    acc[c] = fma(xval, w, acc[c]);
-                }
-            }
+            const uint word = data_w[w_row_words + (k >> 2)];
+            const uint q = (word >> ((k & 3u) * 8u)) & 0xffu;
+            const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
+                    float(q) +
+                SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
         }
     }
 
-    // Fast path: one subgroup covers the whole workgroup (AMD wave64).
-    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            acc[c] = subgroupAdd(acc[c]);
-        }
-        if (tid == 0u) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
-                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
-                }
-            }
-        }
-        return;
-    }
-
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        partial[c][tid] = acc[c];
+    acc = subgroupAdd(acc);
+    if (gl_SubgroupInvocationID == 0u) {
+        partial[gl_SubgroupID] = acc;
     }
     barrier();
-    for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
-        if (tid < stride) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                partial[c][tid] += partial[c][tid + stride];
-            }
-        }
-        barrier();
-    }
-
     if (tid == 0u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            if (c < num_cols) {
-                data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
-                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
-            }
+        float total = 0.0f;
+        for (uint i = 0u; i < gl_NumSubgroups; ++i) {
+            total += partial[i];
         }
+        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(total));
     }
 }

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
@@ -1,8 +1,11 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
 
 #ifdef FLOAT16
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -26,7 +29,8 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
-#define BLOCK_SIZE 128
+#define NUM_COLS 8
+#define BLOCK_SIZE 64
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
@@ -71,43 +75,126 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[BLOCK_SIZE];
+shared float partial[NUM_COLS][BLOCK_SIZE];
 
 void main() {
-    const uint col = gl_WorkGroupID.x;
+    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
     const uint row = gl_WorkGroupID.y;
     const uint batch = gl_WorkGroupID.z;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col >= p.cols) {
+    if (row >= p.rows || col0 >= p.cols) {
         return;
     }
 
+    const uint num_cols = min(NUM_COLS, p.cols - col0);
     const uint lhs_batch = data_lhs_indices[batch];
     const uint rhs_batch = data_rhs_indices[batch];
-    const uint w_row_base = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
-    const uint scale_row_base = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-    const uint bias_row_base = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    float acc = 0.0f;
-    for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
-        const uint group = k / p.group_size;
-        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
-            float(data_w[w_row_base + k]) + SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
-        acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
+    uint w_row_base[NUM_COLS];
+    uint scale_row_base[NUM_COLS];
+    uint bias_row_base[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        if (c < num_cols) {
+            const uint col = col0 + c;
+            w_row_base[c] = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
+            scale_row_base[c] = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+            bias_row_base[c] = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
+        }
     }
 
-    partial[tid] = acc;
+    float acc[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        acc[c] = 0.0f;
+    }
+
+    if ((p.K & 3u) == 0u) {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
+            const uint k = k0 + tid * 4u;
+            if (k < p.K) {
+                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
+                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
+                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const uint group0 = k / p.group_size;
+                        const uint group1 = (k + 1u) / p.group_size;
+                        const uint group2 = (k + 2u) / p.group_size;
+                        const uint group3 = (k + 3u) / p.group_size;
+                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
+                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
+                                float(data_w[w_row_base[c] + k + 1u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
+                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
+                                float(data_w[w_row_base[c] + k + 2u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
+                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
+                                float(data_w[w_row_base[c] + k + 3u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
+                        acc[c] = fma(x0, w0, acc[c]);
+                        acc[c] = fma(x1, w1, acc[c]);
+                        acc[c] = fma(x2, w2, acc[c]);
+                        acc[c] = fma(x3, w3, acc[c]);
+                    }
+                }
+            }
+        }
+    } else {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
+            const uint k = k0 + tid;
+            if (k < p.K) {
+                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const uint group = k / p.group_size;
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                        acc[c] = fma(xval, w, acc[c]);
+                    }
+                }
+            }
+        }
+    }
+
+    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            acc[c] = subgroupAdd(acc[c]);
+        }
+        if (tid == 0u) {
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
+                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
+                }
+            }
+        }
+        return;
+    }
+
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        partial[c][tid] = acc[c];
+    }
     barrier();
     for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
         if (tid < stride) {
-            partial[tid] += partial[tid + stride];
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                partial[c][tid] += partial[c][tid + stride];
+            }
         }
         barrier();
     }
 
     if (tid == 0u) {
-        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            if (c < num_cols) {
+                data_out[batch * p.out_batch_stride + row * p.out_row_stride + col0 + c] =
+                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
+            }
+        }
     }
 }

--- a/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_affine8_smallk.comp
@@ -29,13 +29,15 @@
 #define SCALE_TO_FLOAT_TYPE(x) float(x)
 #endif
 
+// Metal gather_qmv / llama.cpp mul_mat_vec_id style: reuse activations across
+// several output columns. On AMD wave64 a single subgroup covers BLOCK_SIZE.
 #define NUM_COLS 8
 #define BLOCK_SIZE 64
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
-    uint8_t data_w[];
+    uint data_w[];
 };
 layout(binding = 1) readonly buffer SCALES {
     S_TYPE data_scales[];
@@ -92,15 +94,18 @@ void main() {
     const uint rhs_batch = data_rhs_indices[batch];
     const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-    uint w_row_base[NUM_COLS];
+    uint w_row_words[NUM_COLS];
     uint scale_row_base[NUM_COLS];
     uint bias_row_base[NUM_COLS];
     [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
         if (c < num_cols) {
             const uint col = col0 + c;
-            w_row_base[c] = rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes;
-            scale_row_base[c] = rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-            bias_row_base[c] = rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
+            w_row_words[c] =
+                (rhs_batch * p.w_matrix_stride_bytes + col * p.packed_row_bytes) >> 2;
+            scale_row_base[c] =
+                rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+            bias_row_base[c] =
+                rhs_batch * p.bias_matrix_stride + col * p.bias_row_stride;
         }
     }
 
@@ -109,58 +114,54 @@ void main() {
         acc[c] = 0.0f;
     }
 
-    if ((p.K & 3u) == 0u) {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
-            const uint k = k0 + tid * 4u;
-            if (k < p.K) {
-                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
-                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
-                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const uint group0 = k / p.group_size;
-                        const uint group1 = (k + 1u) / p.group_size;
-                        const uint group2 = (k + 2u) / p.group_size;
-                        const uint group3 = (k + 3u) / p.group_size;
-                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
-                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
-                                float(data_w[w_row_base[c] + k + 1u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
-                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
-                                float(data_w[w_row_base[c] + k + 2u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
-                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
-                                float(data_w[w_row_base[c] + k + 3u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
-                        acc[c] = fma(x0, w0, acc[c]);
-                        acc[c] = fma(x1, w1, acc[c]);
-                        acc[c] = fma(x2, w2, acc[c]);
-                        acc[c] = fma(x3, w3, acc[c]);
-                    }
+    // 8-bit affine weights are packed 4-per-uint32. Walk K in uint packs so
+    // each thread issues wide loads; activations are reused across NUM_COLS.
+    if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
+        const uint packs = p.K >> 2;
+        for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
+            const uint k = pidx << 2;
+            const uint group = k / p.group_size;
+            const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+            const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
+            const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
+            const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
+
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    const float s =
+                        SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]);
+                    const float b =
+                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                    const uint packed = data_w[w_row_words[c] + pidx];
+                    acc[c] = fma(x0, float(packed & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x1, float((packed >> 8) & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x2, float((packed >> 16) & 0xffu) * s + b, acc[c]);
+                    acc[c] = fma(
+                        x3, float((packed >> 24) & 0xffu) * s + b, acc[c]);
                 }
             }
         }
     } else {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
-            const uint k = k0 + tid;
-            if (k < p.K) {
-                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const uint group = k / p.group_size;
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                        acc[c] = fma(xval, w, acc[c]);
-                    }
+        for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
+            const uint group = k / p.group_size;
+            const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+            const uint byte_off = k;
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    const uint word = data_w[w_row_words[c] + (byte_off >> 2)];
+                    const uint q = (word >> ((byte_off & 3u) * 8u)) & 0xffu;
+                    const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
+                            float(q) +
+                        SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                    acc[c] = fma(xval, w, acc[c]);
                 }
             }
         }
     }
 
+    // Fast path: one subgroup covers the whole workgroup (AMD wave64).
     if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
         [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
             acc[c] = subgroupAdd(acc[c]);

--- a/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
@@ -28,7 +28,9 @@
 #define FROM_FLOAT_TYPE(x) (x)
 #endif
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+#define BLOCK_SIZE 256
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
     uint data_w[];
@@ -60,7 +62,9 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[8];
+// Size to the workgroup so gl_SubgroupID is always in-range for any legal
+// subgroup size (NumSubgroups <= BLOCK_SIZE).
+shared float partial[BLOCK_SIZE];
 
 void main() {
     const uint col = gl_WorkGroupID.x;
@@ -79,7 +83,7 @@ void main() {
     float acc = 0.0f;
     if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
         const uint packs = p.K >> 2;
-        for (uint pidx = tid; pidx < packs; pidx += gl_WorkGroupSize.x) {
+        for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
             const uint k = pidx << 2;
             const uint group = k / p.group_size;
             const float s = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]);
@@ -91,7 +95,7 @@ void main() {
             acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]), float((packed >> 24) & 0xffu) * s + b, acc);
         }
     } else {
-        for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
+        for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
             const uint group = k / p.group_size;
             const uint word = data_w[w_row_words + (k >> 2)];
             const uint q = (word >> ((k & 3u) * 8u)) & 0xffu;
@@ -99,6 +103,14 @@ void main() {
                 float(q) + SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
             acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
         }
+    }
+
+    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+        acc = subgroupAdd(acc);
+        if (tid == 0u) {
+            data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(acc));
+        }
+        return;
     }
 
     acc = subgroupAdd(acc);

--- a/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
@@ -1,6 +1,5 @@
 #version 450
 
-#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
@@ -29,13 +28,10 @@
 #define FROM_FLOAT_TYPE(x) (x)
 #endif
 
-#define NUM_COLS 8
-#define BLOCK_SIZE 64
-
-layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
-    uint8_t data_w[];
+    uint data_w[];
 };
 layout(binding = 1) readonly buffer SCALES {
     S_TYPE data_scales[];
@@ -64,123 +60,57 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[NUM_COLS][BLOCK_SIZE];
+shared float partial[8];
 
 void main() {
-    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
+    const uint col = gl_WorkGroupID.x;
     const uint row = gl_WorkGroupID.y;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col0 >= p.cols) {
+    if (row >= p.rows || col >= p.cols) {
         return;
     }
 
-    const uint num_cols = min(NUM_COLS, p.cols - col0);
+    const uint w_row_words = (col * p.packed_row_bytes) >> 2;
+    const uint scale_row_base = col * p.scale_row_stride;
+    const uint bias_row_base = col * p.bias_row_stride;
     const uint x_row_base = row * p.x_row_stride;
 
-    uint w_row_base[NUM_COLS];
-    uint scale_row_base[NUM_COLS];
-    uint bias_row_base[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        if (c < num_cols) {
-            const uint col = col0 + c;
-            w_row_base[c] = col * p.packed_row_bytes;
-            scale_row_base[c] = col * p.scale_row_stride;
-            bias_row_base[c] = col * p.bias_row_stride;
-        }
-    }
-
-    float acc[NUM_COLS];
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        acc[c] = 0.0f;
-    }
-
-    if ((p.K & 3u) == 0u) {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
-            const uint k = k0 + tid * 4u;
-            if (k < p.K) {
-                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
-                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
-                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const uint group0 = k / p.group_size;
-                        const uint group1 = (k + 1u) / p.group_size;
-                        const uint group2 = (k + 2u) / p.group_size;
-                        const uint group3 = (k + 3u) / p.group_size;
-                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
-                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
-                                float(data_w[w_row_base[c] + k + 1u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
-                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
-                                float(data_w[w_row_base[c] + k + 2u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
-                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
-                                float(data_w[w_row_base[c] + k + 3u]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
-                        acc[c] = fma(x0, w0, acc[c]);
-                        acc[c] = fma(x1, w1, acc[c]);
-                        acc[c] = fma(x2, w2, acc[c]);
-                        acc[c] = fma(x3, w3, acc[c]);
-                    }
-                }
-            }
+    float acc = 0.0f;
+    if ((p.K & 3u) == 0u && (p.group_size & 3u) == 0u) {
+        const uint packs = p.K >> 2;
+        for (uint pidx = tid; pidx < packs; pidx += gl_WorkGroupSize.x) {
+            const uint k = pidx << 2;
+            const uint group = k / p.group_size;
+            const float s = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]);
+            const float b = SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            const uint packed = data_w[w_row_words + pidx];
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), float(packed & 0xffu) * s + b, acc);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]), float((packed >> 8) & 0xffu) * s + b, acc);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]), float((packed >> 16) & 0xffu) * s + b, acc);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]), float((packed >> 24) & 0xffu) * s + b, acc);
         }
     } else {
-        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
-            const uint k = k0 + tid;
-            if (k < p.K) {
-                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
-                const uint group = k / p.group_size;
-                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                    if (c < num_cols) {
-                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
-                                float(data_w[w_row_base[c] + k]) +
-                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
-                        acc[c] = fma(xval, w, acc[c]);
-                    }
-                }
-            }
+        for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
+            const uint group = k / p.group_size;
+            const uint word = data_w[w_row_words + (k >> 2)];
+            const uint q = (word >> ((k & 3u) * 8u)) & 0xffu;
+            const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
+                float(q) + SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
+            acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
         }
     }
 
-    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            acc[c] = subgroupAdd(acc[c]);
-        }
-        if (tid == 0u) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                if (c < num_cols) {
-                    data_out[row * p.out_row_stride + col0 + c] =
-                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
-                }
-            }
-        }
-        return;
-    }
-
-    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-        partial[c][tid] = acc[c];
+    acc = subgroupAdd(acc);
+    if (gl_SubgroupInvocationID == 0u) {
+        partial[gl_SubgroupID] = acc;
     }
     barrier();
-    for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
-        if (tid < stride) {
-            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-                partial[c][tid] += partial[c][tid + stride];
-            }
-        }
-        barrier();
-    }
-
     if (tid == 0u) {
-        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
-            if (c < num_cols) {
-                data_out[row * p.out_row_stride + col0 + c] =
-                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
-            }
+        float total = 0.0f;
+        for (uint i = 0u; i < gl_NumSubgroups; ++i) {
+            total += partial[i];
         }
+        data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(total));
     }
 }

--- a/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_affine8.comp
@@ -1,8 +1,11 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_16bit_storage : require
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
 
 #ifdef FLOAT16
 #extension GL_EXT_shader_explicit_arithmetic_types_float16 : require
@@ -26,7 +29,10 @@
 #define FROM_FLOAT_TYPE(x) (x)
 #endif
 
-layout(local_size_x = 256, local_size_y = 1, local_size_z = 1) in;
+#define NUM_COLS 8
+#define BLOCK_SIZE 64
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
     uint8_t data_w[];
@@ -58,41 +64,123 @@ layout(push_constant) uniform parameter {
     uint num_groups;
 } p;
 
-shared float partial[256];
+shared float partial[NUM_COLS][BLOCK_SIZE];
 
 void main() {
-    const uint col = gl_WorkGroupID.x;
+    const uint col0 = gl_WorkGroupID.x * NUM_COLS;
     const uint row = gl_WorkGroupID.y;
     const uint tid = gl_LocalInvocationID.x;
 
-    if (row >= p.rows || col >= p.cols) {
+    if (row >= p.rows || col0 >= p.cols) {
         return;
     }
 
-    const uint w_row_base = col * p.packed_row_bytes;
-    const uint scale_row_base = col * p.scale_row_stride;
-    const uint bias_row_base = col * p.bias_row_stride;
+    const uint num_cols = min(NUM_COLS, p.cols - col0);
     const uint x_row_base = row * p.x_row_stride;
 
-    float acc = 0.0f;
-    for (uint k = tid; k < p.K; k += gl_WorkGroupSize.x) {
-        const uint group = k / p.group_size;
-        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base + group]) *
-            float(data_w[w_row_base + k]) +
-            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base + group]);
-        acc = fma(TO_FLOAT_TYPE(data_x[x_row_base + k]), w, acc);
+    uint w_row_base[NUM_COLS];
+    uint scale_row_base[NUM_COLS];
+    uint bias_row_base[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        if (c < num_cols) {
+            const uint col = col0 + c;
+            w_row_base[c] = col * p.packed_row_bytes;
+            scale_row_base[c] = col * p.scale_row_stride;
+            bias_row_base[c] = col * p.bias_row_stride;
+        }
     }
 
-    partial[tid] = acc;
+    float acc[NUM_COLS];
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        acc[c] = 0.0f;
+    }
+
+    if ((p.K & 3u) == 0u) {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE * 4u) {
+            const uint k = k0 + tid * 4u;
+            if (k < p.K) {
+                const float x0 = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const float x1 = TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]);
+                const float x2 = TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]);
+                const float x3 = TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]);
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const uint group0 = k / p.group_size;
+                        const uint group1 = (k + 1u) / p.group_size;
+                        const uint group2 = (k + 2u) / p.group_size;
+                        const uint group3 = (k + 3u) / p.group_size;
+                        const float w0 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group0]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group0]);
+                        const float w1 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group1]) *
+                                float(data_w[w_row_base[c] + k + 1u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group1]);
+                        const float w2 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group2]) *
+                                float(data_w[w_row_base[c] + k + 2u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group2]);
+                        const float w3 = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group3]) *
+                                float(data_w[w_row_base[c] + k + 3u]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group3]);
+                        acc[c] = fma(x0, w0, acc[c]);
+                        acc[c] = fma(x1, w1, acc[c]);
+                        acc[c] = fma(x2, w2, acc[c]);
+                        acc[c] = fma(x3, w3, acc[c]);
+                    }
+                }
+            }
+        }
+    } else {
+        for (uint k0 = 0u; k0 < p.K; k0 += BLOCK_SIZE) {
+            const uint k = k0 + tid;
+            if (k < p.K) {
+                const float xval = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+                const uint group = k / p.group_size;
+                [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                    if (c < num_cols) {
+                        const float w = SCALE_TO_FLOAT_TYPE(data_scales[scale_row_base[c] + group]) *
+                                float(data_w[w_row_base[c] + k]) +
+                            SCALE_TO_FLOAT_TYPE(data_biases[bias_row_base[c] + group]);
+                        acc[c] = fma(xval, w, acc[c]);
+                    }
+                }
+            }
+        }
+    }
+
+    if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            acc[c] = subgroupAdd(acc[c]);
+        }
+        if (tid == 0u) {
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                if (c < num_cols) {
+                    data_out[row * p.out_row_stride + col0 + c] =
+                        D_TYPE(FROM_FLOAT_TYPE(acc[c]));
+                }
+            }
+        }
+        return;
+    }
+
+    [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+        partial[c][tid] = acc[c];
+    }
     barrier();
-    for (uint stride = gl_WorkGroupSize.x >> 1u; stride > 0u; stride >>= 1u) {
+    for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
         if (tid < stride) {
-            partial[tid] += partial[tid + stride];
+            [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+                partial[c][tid] += partial[c][tid + stride];
+            }
         }
         barrier();
     }
 
     if (tid == 0u) {
-        data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+        [[unroll]] for (uint c = 0; c < NUM_COLS; ++c) {
+            if (c < num_cols) {
+                data_out[row * p.out_row_stride + col0 + c] =
+                    D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
+            }
+        }
     }
 }

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1926,7 +1926,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
               ? vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               : vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16;
           const std::array<uint32_t, 3> grid = use_decode_matvec
-              ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, 1u}
+              ? std::array<uint32_t, 3>{cols, rows, 1u}
               : shader_id ==
                       vulkan::StaticShaderId::
                           fused_affine_qmm_bf16_bf16_tiled_n32
@@ -2043,8 +2043,6 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
               ? std::array<
                     uint32_t,
                     3>{(cols + 15u) / 16u, (rows + 31u) / 32u, 1u}
-              : bits_ == 8
-              ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, 1u}
               : std::array<uint32_t, 3>{cols, rows, 1u};
 
           auto command_buffer = vulkan::begin_command_recording(s.index);

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -2632,7 +2632,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
                 uint32_t,
                 3>{(cols + 15u) / 16u, (batches + 31u) / 32u, 1u}
           : matvec8_shader.has_value()
-          ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, batches}
+          ? std::array<uint32_t, 3>{cols, rows, batches}
           : std::array<uint32_t, 3>{
                 (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
       if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -1926,7 +1926,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
               ? vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16_tiled
               : vulkan::StaticShaderId::fused_affine_qmm_bf16_bf16;
           const std::array<uint32_t, 3> grid = use_decode_matvec
-              ? std::array<uint32_t, 3>{cols, rows, 1u}
+              ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, 1u}
               : shader_id ==
                       vulkan::StaticShaderId::
                           fused_affine_qmm_bf16_bf16_tiled_n32
@@ -2043,6 +2043,8 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
               ? std::array<
                     uint32_t,
                     3>{(cols + 15u) / 16u, (rows + 31u) / 32u, 1u}
+              : bits_ == 8
+              ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, 1u}
               : std::array<uint32_t, 3>{cols, rows, 1u};
 
           auto command_buffer = vulkan::begin_command_recording(s.index);
@@ -2632,7 +2634,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
                 uint32_t,
                 3>{(cols + 15u) / 16u, (batches + 31u) / 32u, 1u}
           : matvec8_shader.has_value()
-          ? std::array<uint32_t, 3>{cols, rows, batches}
+          ? std::array<uint32_t, 3>{(cols + 7u) / 8u, rows, batches}
           : std::array<uint32_t, 3>{
                 (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
       if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {


### PR DESCRIPTION
## Summary
- Optimize MoE decode gather matvec (`gather_mv_affine8` / `_smallk`) to a 64-thread workgroup with packed `uint32` weight loads and subgroup reduction (AMD wave64).
- Apply the same packed-load + subgroup reduce pattern to dense `mul_mv_affine8`.
- Default `MLX_VULKAN_BARRIER_BETWEEN_DEFERRED_OPS` off; track untracked intra-primitive segment writes and keep RAW-oriented barriers so deferred decode stays coherent without serializing every op.

## Benchmarks (AMD Radeon 8060S)

### Target: `mlx-community/Qwen3.6-35B-A3B-8bit`
| | Prefill tok/s | Decode tok/s |
|--|--:|--:|
| Baseline | ~682 | ~21.9 |
| **This PR** | **682.7** | **30.4** |
| llama.cpp expected | — | ~30–33 |

```
Averages: prompt_tps=682.721, generation_tps=30.428, peak_memory=39.664
```

Prefill held flat. Decode +~8.5 tok/s (~+39%).

### Other
**Qwen3-0.6B-bf16:** `prompt_tps=2953.155, generation_tps=68.113`
**Qwen3-0.6B-8bit:** `prompt_tps=2838.042, generation_tps=120.190`

Generate on Qwen3.6-35B-A3B-8bit remained coherent (~32 tok/s).

## Test plan
- [x] gather_qmm vs dequant reference (fp16 maxdiff ≤ 0.0625)
- [x] Qwen3.6-35B-A3B-8bit benchmark + generate
- [x] Default bf16 / 8bit benches