### PR TITLE
[Vulkan] Expose subgroup_clustered in device_info

### DIFF
--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -132,7 +132,9 @@ device_info(int device_index) {
         {"resource_limit", static_cast<size_t>(limits.maxMemoryAllocationCount)},
         {"subgroup_size", static_cast<size_t>(ctx.subgroup_size())},
         {"subgroup_min_size", static_cast<size_t>(ctx.subgroup_min_size())},
-        {"subgroup_max_size", static_cast<size_t>(ctx.subgroup_max_size())}};
+        {"subgroup_max_size", static_cast<size_t>(ctx.subgroup_max_size())},
+        {"subgroup_clustered",
+         static_cast<size_t>(ctx.subgroup_clustered_supported())}};
   };
 
   static auto device_info_ = init_device_info();

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -495,6 +495,7 @@ void VulkanContext::init() {
   bool shader_bfloat16_supported = false;
   bool shader_buffer_atomic_float32_supported = false;
   bool subgroup_size_control_supported = false;
+  bool subgroup_clustered_supported = false;
   bool subgroup_require_full_support = false;
   uint32_t subgroup_min_size = 0;
   uint32_t subgroup_max_size = 0;
@@ -756,6 +757,12 @@ void VulkanContext::init() {
     subgroup_size_control_props.pNext = &shader_integer_dot_product_props;
     physical_device.getProperties2(&props2);
     subgroup_size = subgroup_props.subgroupSize;
+    subgroup_clustered_supported =
+        static_cast<bool>(
+            subgroup_props.supportedStages & vk::ShaderStageFlagBits::eCompute) &&
+        static_cast<bool>(
+            subgroup_props.supportedOperations &
+            vk::SubgroupFeatureFlagBits::eClustered);
 
     // Build enabled features
     vk::PhysicalDeviceFeatures2 enabled_features;
@@ -1071,6 +1078,7 @@ void VulkanContext::init() {
     this->shader_bfloat16_supported_ = false;
     this->subgroup_size_control_supported_ = subgroup_size_control_supported;
     this->subgroup_require_full_support_ = subgroup_require_full_support;
+    this->subgroup_clustered_supported_ = subgroup_clustered_supported;
     this->subgroup_min_size_ = subgroup_min_size;
     this->subgroup_max_size_ = subgroup_max_size;
     this->subgroup_size_ = subgroup_size;
@@ -1151,6 +1159,7 @@ void VulkanContext::cleanup() {
   shader_bfloat16_supported_ = false;
   subgroup_size_control_supported_ = false;
   subgroup_require_full_support_ = false;
+  subgroup_clustered_supported_ = false;
   subgroup_min_size_ = 0;
   subgroup_max_size_ = 0;
   subgroup_size_ = 0;

--- a/mlx/backend/vulkan/vulkan.h
+++ b/mlx/backend/vulkan/vulkan.h
@@ -92,6 +92,9 @@ class VulkanContext {
   bool subgroup_require_full_support() const {
     return subgroup_require_full_support_;
   }
+  bool subgroup_clustered_supported() const {
+    return subgroup_clustered_supported_;
+  }
   uint32_t subgroup_min_size() const {
     return subgroup_min_size_;
   }
@@ -181,6 +184,7 @@ class VulkanContext {
   mutable bool shader_bfloat16_supported_{false};
   bool subgroup_size_control_supported_{false};
   bool subgroup_require_full_support_{false};
+  bool subgroup_clustered_supported_{false};
   uint32_t subgroup_min_size_{0};
   uint32_t subgroup_max_size_{0};
   uint32_t subgroup_size_{0};


### PR DESCRIPTION
## Summary
Expose `VK_SUBGROUP_FEATURE_CLUSTERED_BIT` via `device_info()[\"subgroup_clustered\"]` so mlx-lm packed GDN (and other custom kernels) can gate `subgroupClusteredAdd` before pipeline creation.

Used by [goniz/mlx-lm#3](https://github.com/goniz/mlx-lm/pull/3) / [mlx-vulkan#67](https://github.com/goniz/mlx-vulkan/pull/67).

## Test plan
- [x] `./dev.sh build`
- [x] `device_info` reports `subgroup_clustered=1` on Strix Halo