### PR TITLE
[Vulkan] NVFP4 matvec/mm support

### DIFF
--- a/mlx/backend/vulkan/allocator.cpp
+++ b/mlx/backend/vulkan/allocator.cpp
@@ -242,24 +242,64 @@ struct PreferredMemoryType {
   vk::MemoryPropertyFlags forbidden;
 };
 
-uint32_t find_memory_type_index(
+// Preference-ordered, de-duplicated memory type indices that match type_filter.
+std::vector<uint32_t> find_memory_type_indices(
     const VulkanContext& ctx,
     uint32_t type_filter,
     const std::vector<PreferredMemoryType>& preferred_types) {
   const auto mem_props = ctx.memory_properties();
+  std::vector<uint32_t> indices;
+  std::vector<char> seen(mem_props.memoryTypeCount, 0);
   for (const auto& preference : preferred_types) {
     for (uint32_t i = 0; i < mem_props.memoryTypeCount; ++i) {
-      if ((type_filter & (1u << i)) == 0) {
+      if (seen[i] || (type_filter & (1u << i)) == 0) {
         continue;
       }
       const auto flags = mem_props.memoryTypes[i].propertyFlags;
       if ((flags & preference.required) == preference.required &&
           (flags & preference.forbidden) == vk::MemoryPropertyFlags{}) {
-        return i;
+        indices.push_back(i);
+        seen[i] = 1;
       }
     }
   }
-  throw std::runtime_error("[vulkan::malloc] No suitable memory type found.");
+  return indices;
+}
+
+std::vector<PreferredMemoryType> memory_type_preferences(
+    bool unified_memory,
+    bool require_host_visible) {
+  using enum vk::MemoryPropertyFlagBits;
+  if (unified_memory) {
+    // UMA: prefer mappable device-local, then pure device-local, then host
+    // heaps so large working sets can spill past the DEVICE_LOCAL carve-out.
+    if (require_host_visible) {
+      return {
+          {eDeviceLocal | eHostVisible | eHostCoherent, {}},
+          {eHostVisible | eHostCoherent, eHostCached},
+          {eHostVisible | eHostCoherent | eHostCached, {}},
+      };
+    }
+    return {
+        {eDeviceLocal | eHostVisible | eHostCoherent, {}},
+        {eDeviceLocal, {}},
+        {eHostVisible | eHostCoherent, eHostCached},
+        {eHostVisible | eHostCoherent | eHostCached, {}},
+    };
+  }
+  if (require_host_visible) {
+    return {
+        {eHostVisible | eHostCoherent | eHostCached, {}},
+        {eHostVisible | eHostCoherent, {}},
+        {eDeviceLocal | eHostVisible | eHostCoherent, {}},
+    };
+  }
+  return {
+      {eDeviceLocal, eHostVisible},
+      {eDeviceLocal | eHostVisible | eHostCoherent, {}},
+      {eHostVisible | eHostCoherent, {}},
+      {eHostVisible | eHostCoherent | eHostCached, {}},
+  };
 }
 
 } // namespace
@@ -469,71 +509,45 @@ Buffer VulkanAllocator::malloc_impl(size_t size, bool require_host_visible) {
     }
   }
 
-  std::vector<PreferredMemoryType> preferred_memory_types;
-  if (require_host_visible && ctx.is_unified_memory()) {
-    preferred_memory_types = {
-        {vk::MemoryPropertyFlagBits::eDeviceLocal |
-             vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}},
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}}};
-  } else if (require_host_visible) {
-    preferred_memory_types = {
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent |
-             vk::MemoryPropertyFlagBits::eHostCached,
-         {}},
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}},
-        {vk::MemoryPropertyFlagBits::eDeviceLocal |
-             vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}}};
-  } else if (ctx.is_unified_memory()) {
-    preferred_memory_types = {
-        {vk::MemoryPropertyFlagBits::eDeviceLocal |
-             vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}},
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}}};
-  } else {
-    preferred_memory_types = {
-        {vk::MemoryPropertyFlagBits::eDeviceLocal,
-         vk::MemoryPropertyFlagBits::eHostVisible},
-        {vk::MemoryPropertyFlagBits::eDeviceLocal |
-             vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}},
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent,
-         {}},
-        {vk::MemoryPropertyFlagBits::eHostVisible |
-             vk::MemoryPropertyFlagBits::eHostCoherent |
-             vk::MemoryPropertyFlagBits::eHostCached,
-         {}}};
-  }
-
-  uint32_t memory_type_index = 0;
-  try {
-    memory_type_index = find_memory_type_index(
-        ctx, mem_requirements.memoryTypeBits, preferred_memory_types);
-  } catch (...) {
+  const auto preferred_memory_types =
+      memory_type_preferences(ctx.is_unified_memory(), require_host_visible);
+  const auto memory_type_indices = find_memory_type_indices(
+      ctx, mem_requirements.memoryTypeBits, preferred_memory_types);
+  if (memory_type_indices.empty()) {
     vk_device.destroyBuffer(vk_buffer);
-    throw;
+    throw std::runtime_error("[vulkan::malloc] No suitable memory type found.");
   }
 
   auto mem_props = ctx.memory_properties();
-  const auto memory_flags =
-      mem_props.memoryTypes[memory_type_index].propertyFlags;
+  vk::DeviceMemory vk_memory;
+  vk::MemoryPropertyFlags memory_flags{};
+  bool allocated = false;
+  for (uint32_t memory_type_index : memory_type_indices) {
+    vk::MemoryAllocateInfo alloc_info(mem_requirements.size, memory_type_index);
+    try {
+      vk_memory = vk_device.allocateMemory(alloc_info);
+      memory_flags = mem_props.memoryTypes[memory_type_index].propertyFlags;
+      allocated = true;
+      break;
+    } catch (const vk::OutOfDeviceMemoryError&) {
+      // Try the next preference (e.g. host heap when DEVICE_LOCAL is full).
+      continue;
+    } catch (const vk::OutOfHostMemoryError&) {
+      continue;
+    } catch (...) {
+      vk_device.destroyBuffer(vk_buffer);
+      throw;
+    }
+  }
 
-  // Use C++ Vulkan API for memory allocation
-  vk::MemoryAllocateInfo alloc_info(mem_requirements.size, memory_type_index);
-  vk::DeviceMemory vk_memory = vk_device.allocateMemory(alloc_info);
+  if (!allocated) {
+    vk_device.destroyBuffer(vk_buffer);
+    std::ostringstream msg;
+    msg << "[vulkan::malloc] Out of memory allocating " << allocation_size
+        << " bytes after trying " << memory_type_indices.size()
+        << " memory types.";
+    throw std::runtime_error(msg.str());
+  }
 
   // Bind memory - C++ API doesn't have this method, so use C function
   if (vkBindBufferMemory(vk_device, vk_buffer, vk_memory, 0) != VK_SUCCESS) {

--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -27,7 +27,9 @@ device_info(int device_index) {
     // Get memory properties
     vk::PhysicalDeviceMemoryProperties mem_props = physical_device.getMemoryProperties();
 
-    // Calculate total device memory (device-local heaps)
+    // Sum Vulkan heaps. On discrete GPUs DEVICE_LOCAL is VRAM and the rest is
+    // host. On unified-memory iGPUs both heaps are views into system RAM and the
+    // usable working set is their sum (drivers still budget them separately).
     size_t device_memory = 0;
     size_t host_memory = 0;
     for (uint32_t i = 0; i < mem_props.memoryHeapCount; i++) {
@@ -37,9 +39,6 @@ device_info(int device_index) {
         host_memory += mem_props.memoryHeaps[i].size;
       }
     }
-
-    // For integrated GPUs with unified memory, device_memory + host_memory
-    // should roughly equal total system memory available to GPU
 
     // Get device name
     std::string device_name(device_props.deviceName);
@@ -101,10 +100,16 @@ device_info(int device_index) {
 
     // Get unified memory status
     bool is_unified = ctx.is_unified_memory();
+    const size_t total_memory = device_memory + host_memory;
+    // Soft allocator limits / recommended working set: on UMA include the host
+    // heap so large models can spill past the DEVICE_LOCAL carve-out.
+    const size_t memory_size = is_unified ? total_memory : device_memory;
+    const size_t max_recommended_working_set_size =
+        is_unified ? total_memory : device_memory;
 
     // Vulkan doesn't have a direct free memory query like CUDA,
-    // so free_memory reports the total (we could track this in allocator later)
-    size_t free_memory = device_memory;
+    // so free_memory reports the allocator's world size.
+    size_t free_memory = memory_size;
 
     return {
         {"device_name", device_name},
@@ -113,14 +118,15 @@ device_info(int device_index) {
         {"architecture", "Vulkan"},
         {"driver_version", driver_version},
         {"api_version", api_version},
-        {"memory_size", device_memory},
+        {"memory_size", memory_size},
+        {"device_local_memory_size", device_memory},
         {"host_memory_size", host_memory},
-        {"total_memory_size", device_memory + host_memory},
-        {"total_memory", device_memory + host_memory},
+        {"total_memory_size", total_memory},
+        {"total_memory", total_memory},
         {"free_memory", free_memory},
         {"max_buffer_length", limits.maxStorageBufferRange},
-        {"max_recommended_working_set_size", device_memory},
-        {"unified_memory", is_unified},
+        {"max_recommended_working_set_size", max_recommended_working_set_size},
+        {"unified_memory", is_unified ? size_t{1} : size_t{0}},
         {"max_work_group_size", max_work_group_size},
         {"max_compute_work_group_count_x", static_cast<size_t>(limits.maxComputeWorkGroupCount[0])},
         {"max_compute_work_group_count_y", static_cast<size_t>(limits.maxComputeWorkGroupCount[1])},

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -448,6 +448,7 @@ enum class KernelSpecId {
   GatherAffineTileMetadata,
   GatherAffineCoopMatmul,
   Nvfp4QMatmul,
+  GatherNvfp4Matmul,
   LayerNormAffine,
   RMSNormBack,
   Argsort,
@@ -478,7 +479,7 @@ KernelSpec make_kernel_spec(
       grid_kind};
 }
 
-const std::array<KernelSpec, 44> kKernelSpecs = {
+const std::array<KernelSpec, 45> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2},
         sizeof(BinaryPushConstants),
@@ -634,6 +635,10 @@ const std::array<KernelSpec, 44> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2, 3, 4, 5},
         sizeof(Nvfp4QMatmulPushConstants),
+        DispatchGridKind::Linear1D),
+    make_kernel_spec(
+        {0, 1, 2, 3, 4, 5},
+        sizeof(GatherNvfp4MatmulPushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
         {0, 1, 2, 3},
@@ -4420,6 +4425,43 @@ void dispatch_nvfp4_qmatmul_op(
       push_constants,
       checked_mul_u32(
           push_constants.rows, push_constants.cols, "nvfp4 qmatmul elements"),
+      cmd_buffer,
+      s,
+      grid);
+}
+
+void dispatch_gather_nvfp4_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& x,
+    const array& lhs_indices,
+    const array& rhs_indices,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const GatherNvfp4MatmulPushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid) {
+  const std::array<BoundArray, 6> bound_arrays = {{
+      {&w, "W"},
+      {&scales, "SCALES"},
+      {&x, "X"},
+      {&lhs_indices, "LHS_INDICES"},
+      {&rhs_indices, "RHS_INDICES"},
+      {&out, "OUT"},
+  }};
+  dispatch_with_spec(
+      shader_id,
+      KernelSpecId::GatherNvfp4Matmul,
+      bound_arrays,
+      push_constants,
+      checked_mul_u32(
+          checked_mul_u32(
+              push_constants.rows,
+              push_constants.cols,
+              "gather nvfp4 qmm matrix"),
+          grid[2],
+          "gather nvfp4 qmm elements"),
       cmd_buffer,
       s,
       grid);

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -449,6 +449,7 @@ enum class KernelSpecId {
   GatherAffineCoopMatmul,
   Nvfp4QMatmul,
   GatherNvfp4Matmul,
+  Nvfp4DenseMatmul,
   LayerNormAffine,
   RMSNormBack,
   Argsort,
@@ -479,7 +480,7 @@ KernelSpec make_kernel_spec(
       grid_kind};
 }
 
-const std::array<KernelSpec, 45> kKernelSpecs = {
+const std::array<KernelSpec, 46> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2},
         sizeof(BinaryPushConstants),
@@ -639,6 +640,10 @@ const std::array<KernelSpec, 45> kKernelSpecs = {
     make_kernel_spec(
         {0, 1, 2, 3, 4, 5},
         sizeof(GatherNvfp4MatmulPushConstants),
+        DispatchGridKind::Linear1D),
+    make_kernel_spec(
+        {0, 1, 2, 3},
+        sizeof(Nvfp4DenseMatmulPushConstants),
         DispatchGridKind::Linear1D),
     make_kernel_spec(
         {0, 1, 2, 3},
@@ -4462,6 +4467,36 @@ void dispatch_gather_nvfp4_matmul_op(
               "gather nvfp4 qmm matrix"),
           grid[2],
           "gather nvfp4 qmm elements"),
+      cmd_buffer,
+      s,
+      grid);
+}
+
+void dispatch_nvfp4_dense_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& x,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const Nvfp4DenseMatmulPushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid) {
+  const std::array<BoundArray, 4> bound_arrays = {{
+      {&w, "W"},
+      {&scales, "SCALES"},
+      {&x, "X"},
+      {&out, "OUT"},
+  }};
+  dispatch_with_spec(
+      shader_id,
+      KernelSpecId::Nvfp4DenseMatmul,
+      bound_arrays,
+      push_constants,
+      checked_mul_u32(
+          push_constants.rows,
+          push_constants.cols,
+          "nvfp4 dense matmul elements"),
       cmd_buffer,
       s,
       grid);

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -714,6 +714,7 @@ struct GatherNvfp4MatmulPushConstants {
   uint32_t w_matrix_stride_words;
   uint32_t group_size;
   uint32_t num_groups;
+  uint32_t batches;
 };
 
 struct Nvfp4DenseMatmulPushConstants {

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -700,6 +700,22 @@ struct Nvfp4QMatmulPushConstants {
   uint32_t has_global_scale_w;
 };
 
+struct GatherNvfp4MatmulPushConstants {
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t K;
+  uint32_t packed_row_words;
+  uint32_t x_batch_stride;
+  uint32_t x_row_stride;
+  uint32_t out_batch_stride;
+  uint32_t out_row_stride;
+  uint32_t scale_matrix_stride;
+  uint32_t scale_row_stride;
+  uint32_t w_matrix_stride_words;
+  uint32_t group_size;
+  uint32_t num_groups;
+};
+
 struct LayerNormAffinePushConstants {
   uint32_t ne;
   uint32_t axis_size;
@@ -1224,6 +1240,19 @@ void dispatch_nvfp4_qmatmul_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const Nvfp4QMatmulPushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid);
+
+void dispatch_gather_nvfp4_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& x,
+    const array& lhs_indices,
+    const array& rhs_indices,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const GatherNvfp4MatmulPushConstants& push_constants,
     const std::array<uint32_t, 3>& grid);
 
 // Get workgroup dimensions for element-wise operations.

--- a/mlx/backend/vulkan/kernels.h
+++ b/mlx/backend/vulkan/kernels.h
@@ -716,6 +716,18 @@ struct GatherNvfp4MatmulPushConstants {
   uint32_t num_groups;
 };
 
+struct Nvfp4DenseMatmulPushConstants {
+  uint32_t rows;
+  uint32_t cols;
+  uint32_t K;
+  uint32_t packed_row_words;
+  uint32_t x_row_stride;
+  uint32_t out_row_stride;
+  uint32_t scale_row_stride;
+  uint32_t group_size;
+  uint32_t num_groups;
+};
+
 struct LayerNormAffinePushConstants {
   uint32_t ne;
   uint32_t axis_size;
@@ -1253,6 +1265,17 @@ void dispatch_gather_nvfp4_matmul_op(
     vk::CommandBuffer cmd_buffer,
     const Stream& s,
     const GatherNvfp4MatmulPushConstants& push_constants,
+    const std::array<uint32_t, 3>& grid);
+
+void dispatch_nvfp4_dense_matmul_op(
+    const array& w,
+    const array& scales,
+    const array& x,
+    array& out,
+    StaticShaderId shader_id,
+    vk::CommandBuffer cmd_buffer,
+    const Stream& s,
+    const Nvfp4DenseMatmulPushConstants& push_constants,
     const std::array<uint32_t, 3>& grid);
 
 // Get workgroup dimensions for element-wise operations.

--- a/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_16bit_storage : require
@@ -20,12 +21,9 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// Fused NVFP4 gather matmul (transpose weights) with shared X tiles.
-#define BM 16
-#define BN 16
-#define BK 32
-
-layout(local_size_x = BN, local_size_y = BM, local_size_z = 1) in;
+// Gather NVFP4 prefill matmul (transpose weights): one batch per workgroup Z,
+// shared X+W tiles with register blocking.
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
   uint data_w[];
@@ -62,18 +60,39 @@ layout(push_constant) uniform parameter {
   uint num_groups;
 } p;
 
-shared float As[BM][BK];
+#ifndef MLX_BM
+#define MLX_BM 32
+#endif
+#ifndef MLX_BN
+#define MLX_BN 16
+#endif
+#ifndef MLX_BK
+#define MLX_BK 32
+#endif
+#ifndef MLX_TM
+#define MLX_TM 4
+#endif
+#ifndef MLX_TN
+#define MLX_TN 2
+#endif
+
+const uint BM = MLX_BM;
+const uint BN = MLX_BN;
+const uint BK = MLX_BK;
+const uint TM = MLX_TM;
+const uint TN = MLX_TN;
+
+shared float xs[BM][BK];
+shared float ws[BN][BK];
 
 void main() {
-  const uint col0 = gl_WorkGroupID.x * BN;
-  const uint row0 = gl_WorkGroupID.y * BM;
+  const uint lx = gl_LocalInvocationID.x;
+  const uint ly = gl_LocalInvocationID.y;
   const uint batch = gl_WorkGroupID.z;
-  const uint tx = gl_LocalInvocationID.x;
-  const uint ty = gl_LocalInvocationID.y;
-  const uint col = col0 + tx;
-  const uint row = row0 + ty;
-  const uint tid = ty * BN + tx;
-  const uint wg = BM * BN;
+  const uint row0 = gl_WorkGroupID.y * BM + ly * TM;
+  const uint col0 = gl_WorkGroupID.x * BN + lx * TN;
+  const uint linear = ly * gl_WorkGroupSize.x + lx;
+  const uint thread_count = gl_WorkGroupSize.x * gl_WorkGroupSize.y;
 
   const uint lhs_batch = data_lhs_indices[batch];
   const uint rhs_batch = data_rhs_indices[batch];
@@ -81,59 +100,101 @@ void main() {
   const uint w_matrix_base = rhs_batch * p.w_matrix_stride_words;
   const uint scale_matrix_base = rhs_batch * p.scale_matrix_stride;
 
-  const uint w_row_base = w_matrix_base + col * p.packed_row_words;
-  const uint scale_row_base = scale_matrix_base + col * p.scale_row_stride;
-  const bool in_bounds = row < p.rows && col < p.cols;
+  float acc[TM][TN];
+  [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+    [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+      acc[mr][nc] = 0.0f;
+    }
+  }
 
-  float acc = 0.0f;
-  for (uint k0 = 0u; k0 < p.K; k0 += BK) {
-    for (uint i = tid; i < BM * BK; i += wg) {
+  for (uint kb = 0u; kb < p.K; kb += BK) {
+    for (uint i = linear; i < BM * BK; i += thread_count) {
       const uint r = i / BK;
       const uint kk = i - r * BK;
-      const uint gr = row0 + r;
-      const uint gk = k0 + kk;
-      float v = 0.0f;
-      if (gr < p.rows && gk < p.K) {
-        v = TO_FLOAT_TYPE(
-            data_x[x_batch_base + gr * p.x_row_stride + gk]);
+      const uint src_row = gl_WorkGroupID.y * BM + r;
+      const uint src_k = kb + kk;
+      xs[r][kk] = (src_row < p.rows && src_k < p.K)
+          ? TO_FLOAT_TYPE(
+                data_x[x_batch_base + src_row * p.x_row_stride + src_k])
+          : 0.0f;
+    }
+
+    for (uint i = linear; i < BN * (BK / 8u); i += thread_count) {
+      const uint c = i / (BK / 8u);
+      const uint packed_k = i - c * (BK / 8u);
+      const uint src_col = gl_WorkGroupID.x * BN + c;
+      const uint src_k = kb + packed_k * 8u;
+      const uint kk = packed_k * 8u;
+      if (src_col < p.cols && src_k + 7u < p.K) {
+        const uint packed =
+            data_w[w_matrix_base + src_col * p.packed_row_words + (src_k >> 3u)];
+        const float scale = nvfp4_fp8_e4m3_to_fp32(data_scales
+            [scale_matrix_base + src_col * p.scale_row_stride + (src_k >> 4u)]);
+        [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+          ws[c][kk + n] = nvfp4_decode_nibble(packed, n, scale);
+        }
+      } else {
+        [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+          float v = 0.0f;
+          const uint k = src_k + n;
+          if (src_col < p.cols && k < p.K) {
+            const uint packed = data_w
+                [w_matrix_base + src_col * p.packed_row_words + (k >> 3u)];
+            const float scale = nvfp4_fp8_e4m3_to_fp32(data_scales
+                [scale_matrix_base + src_col * p.scale_row_stride +
+                 (k >> 4u)]);
+            v = nvfp4_decode_nibble(packed, k & 7u, scale);
+          }
+          ws[c][kk + n] = v;
+        }
       }
-      As[r][kk] = v;
     }
     barrier();
 
-    if (in_bounds) {
-      const uint k_end = min(k0 + BK, p.K);
-      if ((p.group_size == 16u) && ((k0 & 7u) == 0u)) {
-        for (uint kk = 0u; kk < BK && (k0 + kk) < k_end; kk += 8u) {
-          const uint k = k0 + kk;
-          const uint packed = data_w[w_row_base + (k >> 3u)];
-          const float scale =
-              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-          acc = fma(As[ty][kk + 0u], nvfp4_decode_nibble(packed, 0u, scale), acc);
-          acc = fma(As[ty][kk + 1u], nvfp4_decode_nibble(packed, 1u, scale), acc);
-          acc = fma(As[ty][kk + 2u], nvfp4_decode_nibble(packed, 2u, scale), acc);
-          acc = fma(As[ty][kk + 3u], nvfp4_decode_nibble(packed, 3u, scale), acc);
-          acc = fma(As[ty][kk + 4u], nvfp4_decode_nibble(packed, 4u, scale), acc);
-          acc = fma(As[ty][kk + 5u], nvfp4_decode_nibble(packed, 5u, scale), acc);
-          acc = fma(As[ty][kk + 6u], nvfp4_decode_nibble(packed, 6u, scale), acc);
-          acc = fma(As[ty][kk + 7u], nvfp4_decode_nibble(packed, 7u, scale), acc);
-        }
-      } else {
-        for (uint kk = 0u; kk < BK && (k0 + kk) < k_end; ++kk) {
-          const uint k = k0 + kk;
-          const uint packed = data_w[w_row_base + (k >> 3u)];
-          const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
-          const float scale =
-              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-          acc = fma(As[ty][kk], nvfp4_lut(q) * scale, acc);
+    for (uint kk = 0u; kk < BK; ++kk) {
+#if MLX_TN == 2
+      const float w0 = ws[lx * TN + 0u][kk];
+      const float w1 = ws[lx * TN + 1u][kk];
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        acc[mr][0] = fma(x, w0, acc[mr][0]);
+        acc[mr][1] = fma(x, w1, acc[mr][1]);
+      }
+#elif MLX_TN == 4
+      const float w0 = ws[lx * TN + 0u][kk];
+      const float w1 = ws[lx * TN + 1u][kk];
+      const float w2 = ws[lx * TN + 2u][kk];
+      const float w3 = ws[lx * TN + 3u][kk];
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        acc[mr][0] = fma(x, w0, acc[mr][0]);
+        acc[mr][1] = fma(x, w1, acc[mr][1]);
+        acc[mr][2] = fma(x, w2, acc[mr][2]);
+        acc[mr][3] = fma(x, w3, acc[mr][3]);
+      }
+#else
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+          acc[mr][nc] = fma(x, ws[lx * TN + nc][kk], acc[mr][nc]);
         }
       }
+#endif
     }
     barrier();
   }
 
-  if (in_bounds) {
-    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
-        D_TYPE(FROM_FLOAT_TYPE(acc));
+  [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+    const uint row = row0 + mr;
+    if (row >= p.rows) {
+      continue;
+    }
+    [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+      const uint col = col0 + nc;
+      if (col < p.cols) {
+        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(acc[mr][nc]));
+      }
+    }
   }
 }

--- a/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
@@ -1,0 +1,93 @@
+#version 450
+
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+
+// Fused NVFP4 gather matmul (transpose weights): keep packed expert weights on
+// device and dequant-on-load. Intended for MoE decode (small rows).
+layout(local_size_x = 16, local_size_y = 16, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer W {
+  uint data_w[];
+};
+layout(binding = 1) readonly buffer SCALES {
+  uint8_t data_scales[];
+};
+layout(binding = 2) readonly buffer X {
+  float data_x[];
+};
+layout(binding = 3) readonly buffer LHS_INDICES {
+  uint data_lhs_indices[];
+};
+layout(binding = 4) readonly buffer RHS_INDICES {
+  uint data_rhs_indices[];
+};
+layout(binding = 5) writeonly buffer OUT {
+  float data_out[];
+};
+
+layout(push_constant) uniform parameter {
+  uint rows;
+  uint cols;
+  uint K;
+  uint packed_row_words;
+  uint x_batch_stride;
+  uint x_row_stride;
+  uint out_batch_stride;
+  uint out_row_stride;
+  uint scale_matrix_stride;
+  uint scale_row_stride;
+  uint w_matrix_stride_words;
+  uint group_size;
+  uint num_groups;
+} p;
+
+float fp8_e4m3_to_fp32(uint8_t x) {
+  uint v = (uint(x) & 127u) << 7;
+  float val = unpackHalf2x16(v).x * 256.0;
+  return (x & uint8_t(128u)) != 0u ? -val : val;
+}
+
+float nvfp4_lut(uint q) {
+  const float lut[16] = float[16](
+      +0.0, +0.5, +1.0, +1.5, +2.0, +3.0, +4.0, +6.0, -0.0, -0.5, -1.0, -1.5,
+      -2.0, -3.0, -4.0, -6.0);
+  return lut[q];
+}
+
+float decode_w(uint row_base, uint scale_base, uint k) {
+  const uint packed = data_w[row_base + (k >> 3u)];
+  const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
+  const float scale = fp8_e4m3_to_fp32(data_scales[scale_base + (k >> 4u)]);
+  return nvfp4_lut(q) * scale;
+}
+
+void main() {
+  const uint col = gl_GlobalInvocationID.x;
+  const uint row = gl_GlobalInvocationID.y;
+  const uint batch = gl_GlobalInvocationID.z;
+
+  if (row >= p.rows || col >= p.cols) {
+    return;
+  }
+
+  const uint lhs_batch = data_lhs_indices[batch];
+  const uint rhs_batch = data_rhs_indices[batch];
+  const uint w_row_base =
+      rhs_batch * p.w_matrix_stride_words + col * p.packed_row_words;
+  const uint scale_row_base =
+      rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+  const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
+
+  float acc = 0.0f;
+  for (uint group = 0u; group < p.num_groups; ++group) {
+    const uint group_start = group * p.group_size;
+    const uint group_end = min(group_start + p.group_size, p.K);
+    for (uint k = group_start; k < group_end; ++k) {
+      acc = fma(
+          data_x[x_row_base + k], decode_w(w_row_base, scale_row_base, k), acc);
+    }
+  }
+
+  data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] = acc;
+}

--- a/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mm_nvfp4.comp
@@ -58,6 +58,7 @@ layout(push_constant) uniform parameter {
   uint w_matrix_stride_words;
   uint group_size;
   uint num_groups;
+  uint batches;
 } p;
 
 #ifndef MLX_BM

--- a/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
@@ -1,0 +1,142 @@
+#version 450
+
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+
+// NVFP4 gather matvec for MoE decode: one workgroup per (batch, row, col),
+// threads split K and reduce with subgroup/shared memory.
+#define BLOCK_SIZE 64
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer W {
+  uint data_w[];
+};
+layout(binding = 1) readonly buffer SCALES {
+  uint8_t data_scales[];
+};
+layout(binding = 2) readonly buffer X {
+  float data_x[];
+};
+layout(binding = 3) readonly buffer LHS_INDICES {
+  uint data_lhs_indices[];
+};
+layout(binding = 4) readonly buffer RHS_INDICES {
+  uint data_rhs_indices[];
+};
+layout(binding = 5) writeonly buffer OUT {
+  float data_out[];
+};
+
+layout(push_constant) uniform parameter {
+  uint rows;
+  uint cols;
+  uint K;
+  uint packed_row_words;
+  uint x_batch_stride;
+  uint x_row_stride;
+  uint out_batch_stride;
+  uint out_row_stride;
+  uint scale_matrix_stride;
+  uint scale_row_stride;
+  uint w_matrix_stride_words;
+  uint group_size;
+  uint num_groups;
+} p;
+
+shared float partial[BLOCK_SIZE];
+
+float fp8_e4m3_to_fp32(uint8_t x) {
+  uint v = (uint(x) & 127u) << 7;
+  float val = unpackHalf2x16(v).x * 256.0;
+  return (x & uint8_t(128u)) != 0u ? -val : val;
+}
+
+float nvfp4_lut(uint q) {
+  const float lut[16] = float[16](
+      +0.0, +0.5, +1.0, +1.5, +2.0, +3.0, +4.0, +6.0, -0.0, -0.5, -1.0, -1.5,
+      -2.0, -3.0, -4.0, -6.0);
+  return lut[q];
+}
+
+float decode_nibble(uint packed, uint lane, float scale) {
+  return nvfp4_lut((packed >> (lane * 4u)) & 0xFu) * scale;
+}
+
+void main() {
+  const uint col = gl_WorkGroupID.x;
+  const uint row = gl_WorkGroupID.y;
+  const uint batch = gl_WorkGroupID.z;
+  const uint tid = gl_LocalInvocationID.x;
+
+  if (row >= p.rows || col >= p.cols) {
+    return;
+  }
+
+  const uint lhs_batch = data_lhs_indices[batch];
+  const uint rhs_batch = data_rhs_indices[batch];
+  const uint w_row_base =
+      rhs_batch * p.w_matrix_stride_words + col * p.packed_row_words;
+  const uint scale_row_base =
+      rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+  const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
+
+  float acc = 0.0f;
+  // Fast path: 8 nibbles per uint32; group_size 16 so one scale covers a pack.
+  if ((p.K & 7u) == 0u && p.group_size == 16u) {
+    const uint packs = p.K >> 3u;
+    for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
+      const uint k = pidx << 3u;
+      const uint packed = data_w[w_row_base + pidx];
+      const float scale =
+          fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+      acc = fma(data_x[x_row_base + k], decode_nibble(packed, 0u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 1u], decode_nibble(packed, 1u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 2u], decode_nibble(packed, 2u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 3u], decode_nibble(packed, 3u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 4u], decode_nibble(packed, 4u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 5u], decode_nibble(packed, 5u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 6u], decode_nibble(packed, 6u, scale), acc);
+      acc = fma(
+          data_x[x_row_base + k + 7u], decode_nibble(packed, 7u, scale), acc);
+    }
+  } else {
+    for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
+      const uint packed = data_w[w_row_base + (k >> 3u)];
+      const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
+      const float scale =
+          fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+      acc = fma(data_x[x_row_base + k], nvfp4_lut(q) * scale, acc);
+    }
+  }
+
+  if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+    acc = subgroupAdd(acc);
+    if (tid == 0u) {
+      data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+          acc;
+    }
+    return;
+  }
+
+  partial[tid] = acc;
+  barrier();
+  for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
+    if (tid < stride) {
+      partial[tid] += partial[tid + stride];
+    }
+    barrier();
+  }
+  if (tid == 0u) {
+    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+        partial[0];
+  }
+}

--- a/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
@@ -90,7 +90,59 @@ void main() {
     acc[c] = 0.0f;
   }
 
-  if ((p.K & 7u) == 0u && p.group_size == 16u) {
+  if ((p.K & 15u) == 0u && p.group_size == 16u) {
+    // One scale covers 16 K elems = two NVFP4 packs. Cut loop trips vs pack-8.
+    const uint pairs = p.K >> 4u;
+    const bool full_n = (col0 + MLX_BN) <= p.cols;
+    for (uint g = tid; g < pairs; g += BLOCK_SIZE) {
+      const uint k = g << 4u;
+      const uint pidx = g << 1u;
+      float xv[16];
+      [[unroll]] for (uint n = 0u; n < 16u; ++n) {
+        xv[n] = TO_FLOAT_TYPE(data_x[x_row_base + k + n]);
+      }
+      if (full_n) {
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+          const uint scale_row_base =
+              scale_matrix_base + col * p.scale_row_stride;
+          const uint packed0 = data_w[w_row_base + pidx];
+          const uint packed1 = data_w[w_row_base + pidx + 1u];
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(xv[n], nvfp4_decode_nibble(packed0, n, scale), acc[c]);
+          }
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(
+                xv[n + 8u], nvfp4_decode_nibble(packed1, n, scale), acc[c]);
+          }
+        }
+      } else {
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          if (col < p.cols) {
+            const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+            const uint scale_row_base =
+                scale_matrix_base + col * p.scale_row_stride;
+            const uint packed0 = data_w[w_row_base + pidx];
+            const uint packed1 = data_w[w_row_base + pidx + 1u];
+            const float scale =
+                nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+            [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+              acc[c] =
+                  fma(xv[n], nvfp4_decode_nibble(packed0, n, scale), acc[c]);
+            }
+            [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+              acc[c] = fma(
+                  xv[n + 8u], nvfp4_decode_nibble(packed1, n, scale), acc[c]);
+            }
+          }
+        }
+      }
+    }
+  } else if ((p.K & 7u) == 0u && p.group_size == 16u) {
     const uint packs = p.K >> 3u;
     for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
       const uint k = pidx << 3u;

--- a/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
@@ -65,6 +65,7 @@ layout(push_constant) uniform parameter {
   uint w_matrix_stride_words;
   uint group_size;
   uint num_groups;
+  uint batches;
 } p;
 
 shared float partial[MLX_BN][BLOCK_SIZE];

--- a/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_nvfp4.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_16bit_storage : require
@@ -22,8 +23,12 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// NVFP4 gather matvec for MoE decode: one workgroup per (batch, row, col).
+// NVFP4 gather matvec: one workgroup per (batch, row, col_tile).
+// Threads split K; BN columns share the same X loads (MoE prefill hot path).
 #define BLOCK_SIZE 64
+#ifndef MLX_BN
+#define MLX_BN 8
+#endif
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
@@ -62,97 +67,106 @@ layout(push_constant) uniform parameter {
   uint num_groups;
 } p;
 
-shared float partial[BLOCK_SIZE];
+shared float partial[MLX_BN][BLOCK_SIZE];
 
 void main() {
-  const uint col = gl_WorkGroupID.x;
+  const uint col0 = gl_WorkGroupID.x * MLX_BN;
   const uint row = gl_WorkGroupID.y;
   const uint batch = gl_WorkGroupID.z;
   const uint tid = gl_LocalInvocationID.x;
 
-  if (row >= p.rows || col >= p.cols) {
+  if (row >= p.rows || col0 >= p.cols) {
     return;
   }
 
   const uint lhs_batch = data_lhs_indices[batch];
   const uint rhs_batch = data_rhs_indices[batch];
-  const uint w_row_base =
-      rhs_batch * p.w_matrix_stride_words + col * p.packed_row_words;
-  const uint scale_row_base =
-      rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
+  const uint w_matrix_base = rhs_batch * p.w_matrix_stride_words;
+  const uint scale_matrix_base = rhs_batch * p.scale_matrix_stride;
   const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
 
-  float acc = 0.0f;
+  float acc[MLX_BN];
+  [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+    acc[c] = 0.0f;
+  }
+
   if ((p.K & 7u) == 0u && p.group_size == 16u) {
     const uint packs = p.K >> 3u;
     for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
       const uint k = pidx << 3u;
-      const uint packed = data_w[w_row_base + pidx];
-      const float scale =
-          nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k]),
-          nvfp4_decode_nibble(packed, 0u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]),
-          nvfp4_decode_nibble(packed, 1u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]),
-          nvfp4_decode_nibble(packed, 2u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]),
-          nvfp4_decode_nibble(packed, 3u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 4u]),
-          nvfp4_decode_nibble(packed, 4u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 5u]),
-          nvfp4_decode_nibble(packed, 5u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 6u]),
-          nvfp4_decode_nibble(packed, 6u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 7u]),
-          nvfp4_decode_nibble(packed, 7u, scale),
-          acc);
+      float xv[8];
+      [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+        xv[n] = TO_FLOAT_TYPE(data_x[x_row_base + k + n]);
+      }
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+          const uint scale_row_base =
+              scale_matrix_base + col * p.scale_row_stride;
+          const uint packed = data_w[w_row_base + pidx];
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(xv[n], nvfp4_decode_nibble(packed, n, scale), acc[c]);
+          }
+        }
+      }
     }
   } else {
     for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
-      const uint packed = data_w[w_row_base + (k >> 3u)];
-      const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
-      const float scale =
-          nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k]), nvfp4_lut(q) * scale, acc);
+      const float xv = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+          const uint scale_row_base =
+              scale_matrix_base + col * p.scale_row_stride;
+          const uint packed = data_w[w_row_base + (k >> 3u)];
+          const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+          acc[c] = fma(xv, nvfp4_lut(q) * scale, acc[c]);
+        }
+      }
     }
   }
 
   if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
-    acc = subgroupAdd(acc);
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      acc[c] = subgroupAdd(acc[c]);
+    }
     if (tid == 0u) {
-      data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
-          D_TYPE(FROM_FLOAT_TYPE(acc));
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+              D_TYPE(FROM_FLOAT_TYPE(acc[c]));
+        }
+      }
     }
     return;
   }
 
-  partial[tid] = acc;
+  [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+    partial[c][tid] = acc[c];
+  }
   barrier();
   for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
     if (tid < stride) {
-      partial[tid] += partial[tid + stride];
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        partial[c][tid] += partial[c][tid + stride];
+      }
     }
     barrier();
   }
   if (tid == 0u) {
-    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
-        D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      const uint col = col0 + c;
+      if (col < p.cols) {
+        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
+      }
+    }
   }
 }

--- a/mlx/backend/vulkan/kernels/gather_mv_nvfp4_rhs.comp
+++ b/mlx/backend/vulkan/kernels/gather_mv_nvfp4_rhs.comp
@@ -1,0 +1,261 @@
+#version 450
+
+#extension GL_EXT_control_flow_attributes : enable
+#extension GL_EXT_shader_8bit_storage : require
+#extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
+#extension GL_EXT_shader_16bit_storage : require
+#extension GL_KHR_shader_subgroup_basic : require
+#extension GL_KHR_shader_subgroup_arithmetic : require
+
+#include "types.glsl"
+#include "nvfp4_common.glsl"
+
+#if !defined(B_TYPE)
+#define B_TYPE float
+#endif
+#if !defined(D_TYPE)
+#define D_TYPE float
+#endif
+#if !defined(TO_FLOAT_TYPE)
+#define TO_FLOAT_TYPE float
+#endif
+#if !defined(FROM_FLOAT_TYPE)
+#define FROM_FLOAT_TYPE
+#endif
+
+// Sorted-RHS NVFP4 gather matvec (BM=2): pair consecutive MoE assignments so
+// same-expert tokens share one W dequant. Explicit pair path avoids dynamic
+// BM indexing / large shared scratch that kills occupancy.
+#define BLOCK_SIZE 64
+#ifndef MLX_BN
+#define MLX_BN 16
+#endif
+
+layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
+
+layout(binding = 0) readonly buffer W {
+  uint data_w[];
+};
+layout(binding = 1) readonly buffer SCALES {
+  uint8_t data_scales[];
+};
+layout(binding = 2) readonly buffer X {
+  B_TYPE data_x[];
+};
+layout(binding = 3) readonly buffer LHS_INDICES {
+  uint data_lhs_indices[];
+};
+layout(binding = 4) readonly buffer RHS_INDICES {
+  uint data_rhs_indices[];
+};
+layout(binding = 5) writeonly buffer OUT {
+  D_TYPE data_out[];
+};
+
+layout(push_constant) uniform parameter {
+  uint rows;
+  uint cols;
+  uint K;
+  uint packed_row_words;
+  uint x_batch_stride;
+  uint x_row_stride;
+  uint out_batch_stride;
+  uint out_row_stride;
+  uint scale_matrix_stride;
+  uint scale_row_stride;
+  uint w_matrix_stride_words;
+  uint group_size;
+  uint num_groups;
+  uint batches;
+} p;
+
+shared float partial[BLOCK_SIZE];
+
+void main() {
+  const uint col0 = gl_WorkGroupID.x * MLX_BN;
+  const uint row = gl_WorkGroupID.y;
+  const uint batch0 = gl_WorkGroupID.z * 2u;
+  const uint tid = gl_LocalInvocationID.x;
+
+  if (row >= p.rows || col0 >= p.cols || batch0 >= p.batches) {
+    return;
+  }
+
+  const bool has1 = (batch0 + 1u) < p.batches;
+  const uint batch1 = batch0 + 1u;
+  const uint expert0 = data_rhs_indices[batch0];
+  const uint expert1 = has1 ? data_rhs_indices[batch1] : 0xffffffffu;
+  const uint x0 = data_lhs_indices[batch0] * p.x_batch_stride +
+      row * p.x_row_stride;
+  const uint x1 = has1 ? (data_lhs_indices[batch1] * p.x_batch_stride +
+                               row * p.x_row_stride)
+                       : 0u;
+  const bool share = has1 && (expert0 == expert1);
+  const bool full_n = (col0 + MLX_BN) <= p.cols;
+
+  float acc0[MLX_BN];
+  float acc1[MLX_BN];
+  [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+    acc0[c] = 0.0f;
+    acc1[c] = 0.0f;
+  }
+
+  if ((p.K & 15u) == 0u && p.group_size == 16u) {
+    const uint pairs = p.K >> 4u;
+    if (share) {
+      const uint w_matrix_base = expert0 * p.w_matrix_stride_words;
+      const uint scale_matrix_base = expert0 * p.scale_matrix_stride;
+      for (uint g = tid; g < pairs; g += BLOCK_SIZE) {
+        const uint k = g << 4u;
+        const uint pidx = g << 1u;
+        float xv0[16];
+        float xv1[16];
+        [[unroll]] for (uint n = 0u; n < 16u; ++n) {
+          xv0[n] = TO_FLOAT_TYPE(data_x[x0 + k + n]);
+          xv1[n] = TO_FLOAT_TYPE(data_x[x1 + k + n]);
+        }
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          if (full_n || col < p.cols) {
+            const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+            const uint scale_row_base =
+                scale_matrix_base + col * p.scale_row_stride;
+            const uint packed0 = data_w[w_row_base + pidx];
+            const uint packed1 = data_w[w_row_base + pidx + 1u];
+            const float scale =
+                nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+            [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+              const float w0 = nvfp4_decode_nibble(packed0, n, scale);
+              const float w1 = nvfp4_decode_nibble(packed1, n, scale);
+              acc0[c] = fma(xv0[n], w0, acc0[c]);
+              acc1[c] = fma(xv1[n], w0, acc1[c]);
+              acc0[c] = fma(xv0[n + 8u], w1, acc0[c]);
+              acc1[c] = fma(xv1[n + 8u], w1, acc1[c]);
+            }
+          }
+        }
+      }
+    } else {
+      // Divergent experts (or trailing singleton): two independent matvecs.
+      for (uint pass = 0u; pass < 2u; ++pass) {
+        if (pass == 1u && !has1) {
+          break;
+        }
+        const uint expert = (pass == 0u) ? expert0 : expert1;
+        const uint x_base = (pass == 0u) ? x0 : x1;
+        const uint w_matrix_base = expert * p.w_matrix_stride_words;
+        const uint scale_matrix_base = expert * p.scale_matrix_stride;
+        for (uint g = tid; g < pairs; g += BLOCK_SIZE) {
+          const uint k = g << 4u;
+          const uint pidx = g << 1u;
+          float xv[16];
+          [[unroll]] for (uint n = 0u; n < 16u; ++n) {
+            xv[n] = TO_FLOAT_TYPE(data_x[x_base + k + n]);
+          }
+          [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+            const uint col = col0 + c;
+            if (full_n || col < p.cols) {
+              const uint w_row_base = w_matrix_base + col * p.packed_row_words;
+              const uint scale_row_base =
+                  scale_matrix_base + col * p.scale_row_stride;
+              const uint packed0 = data_w[w_row_base + pidx];
+              const uint packed1 = data_w[w_row_base + pidx + 1u];
+              const float scale =
+                  nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+              float a = (pass == 0u) ? acc0[c] : acc1[c];
+              [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+                a = fma(xv[n], nvfp4_decode_nibble(packed0, n, scale), a);
+              }
+              [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+                a = fma(xv[n + 8u], nvfp4_decode_nibble(packed1, n, scale), a);
+              }
+              if (pass == 0u) {
+                acc0[c] = a;
+              } else {
+                acc1[c] = a;
+              }
+            }
+          }
+        }
+      }
+    }
+  } else {
+    // Generic fallback (non pack-16): one batch at a time.
+    for (uint pass = 0u; pass < 2u; ++pass) {
+      if (pass == 1u && !has1) {
+        break;
+      }
+      const uint expert = (pass == 0u) ? expert0 : expert1;
+      const uint x_base = (pass == 0u) ? x0 : x1;
+      const uint w_matrix_base = expert * p.w_matrix_stride_words;
+      const uint scale_matrix_base = expert * p.scale_matrix_stride;
+      for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
+        const float xv = TO_FLOAT_TYPE(data_x[x_base + k]);
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          if (col < p.cols) {
+            const uint packed = data_w
+                [w_matrix_base + col * p.packed_row_words + (k >> 3u)];
+            const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
+            const float scale = nvfp4_fp8_e4m3_to_fp32(data_scales
+                [scale_matrix_base + col * p.scale_row_stride + (k >> 4u)]);
+            const float wv = nvfp4_lut(q) * scale;
+            if (pass == 0u) {
+              acc0[c] = fma(xv, wv, acc0[c]);
+            } else {
+              acc1[c] = fma(xv, wv, acc1[c]);
+            }
+          }
+        }
+      }
+    }
+  }
+
+  if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      acc0[c] = subgroupAdd(acc0[c]);
+      if (has1) {
+        acc1[c] = subgroupAdd(acc1[c]);
+      }
+    }
+    if (tid == 0u) {
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          data_out[batch0 * p.out_batch_stride + row * p.out_row_stride + col] =
+              D_TYPE(FROM_FLOAT_TYPE(acc0[c]));
+          if (has1) {
+            data_out
+                [batch1 * p.out_batch_stride + row * p.out_row_stride + col] =
+                    D_TYPE(FROM_FLOAT_TYPE(acc1[c]));
+          }
+        }
+      }
+    }
+    return;
+  }
+
+  // Slow fallback: reduce one accumulator at a time.
+  for (uint pass = 0u; pass < 2u; ++pass) {
+    if (pass == 1u && !has1) {
+      break;
+    }
+    const uint batch = (pass == 0u) ? batch0 : batch1;
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      const uint col = col0 + c;
+      partial[tid] = (pass == 0u) ? acc0[c] : acc1[c];
+      barrier();
+      for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
+        if (tid < stride) {
+          partial[tid] += partial[tid + stride];
+        }
+        barrier();
+      }
+      if (tid == 0u && col < p.cols) {
+        data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+      }
+      barrier();
+    }
+  }
+}

--- a/mlx/backend/vulkan/kernels/mul_mm_nvfp4_dense.comp
+++ b/mlx/backend/vulkan/kernels/mul_mm_nvfp4_dense.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_16bit_storage : require
@@ -20,12 +21,9 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// Dense NVFP4 matmul (transpose weights) with shared X tiles for prefill.
-#define BM 16
-#define BN 16
-#define BK 32
-
-layout(local_size_x = BN, local_size_y = BM, local_size_z = 1) in;
+// Dense NVFP4 prefill matmul (transpose weights): shared X+W tiles with
+// register blocking. Mirrors mul_mm_affine_bf16_tiled4.
+layout(local_size_x = 8, local_size_y = 8, local_size_z = 1) in;
 
 layout(binding = 0) readonly buffer W {
   uint data_w[];
@@ -52,69 +50,132 @@ layout(push_constant) uniform parameter {
   uint num_groups;
 } p;
 
-shared float As[BM][BK];
+#ifndef MLX_BM
+#define MLX_BM 32
+#endif
+#ifndef MLX_BN
+#define MLX_BN 16
+#endif
+#ifndef MLX_BK
+#define MLX_BK 32
+#endif
+#ifndef MLX_TM
+#define MLX_TM 4
+#endif
+#ifndef MLX_TN
+#define MLX_TN 2
+#endif
+
+const uint BM = MLX_BM;
+const uint BN = MLX_BN;
+const uint BK = MLX_BK;
+const uint TM = MLX_TM;
+const uint TN = MLX_TN;
+
+shared float xs[BM][BK];
+shared float ws[BN][BK];
 
 void main() {
-  const uint col0 = gl_WorkGroupID.x * BN;
-  const uint row0 = gl_WorkGroupID.y * BM;
-  const uint tx = gl_LocalInvocationID.x;
-  const uint ty = gl_LocalInvocationID.y;
-  const uint col = col0 + tx;
-  const uint row = row0 + ty;
-  const uint tid = ty * BN + tx;
-  const uint wg = BM * BN;
+  const uint lx = gl_LocalInvocationID.x;
+  const uint ly = gl_LocalInvocationID.y;
+  const uint row0 = gl_WorkGroupID.y * BM + ly * TM;
+  const uint col0 = gl_WorkGroupID.x * BN + lx * TN;
+  const uint linear = ly * gl_WorkGroupSize.x + lx;
+  const uint thread_count = gl_WorkGroupSize.x * gl_WorkGroupSize.y;
 
-  const uint w_row_base = col * p.packed_row_words;
-  const uint scale_row_base = col * p.scale_row_stride;
-  const bool in_bounds = row < p.rows && col < p.cols;
+  float acc[TM][TN];
+  [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+    [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+      acc[mr][nc] = 0.0f;
+    }
+  }
 
-  float acc = 0.0f;
-  for (uint k0 = 0u; k0 < p.K; k0 += BK) {
-    for (uint i = tid; i < BM * BK; i += wg) {
+  for (uint kb = 0u; kb < p.K; kb += BK) {
+    for (uint i = linear; i < BM * BK; i += thread_count) {
       const uint r = i / BK;
       const uint kk = i - r * BK;
-      const uint gr = row0 + r;
-      const uint gk = k0 + kk;
-      float v = 0.0f;
-      if (gr < p.rows && gk < p.K) {
-        v = TO_FLOAT_TYPE(data_x[gr * p.x_row_stride + gk]);
+      const uint src_row = gl_WorkGroupID.y * BM + r;
+      const uint src_k = kb + kk;
+      xs[r][kk] = (src_row < p.rows && src_k < p.K)
+          ? TO_FLOAT_TYPE(data_x[src_row * p.x_row_stride + src_k])
+          : 0.0f;
+    }
+
+    // NVFP4: 8 nibbles / uint32; group_size 16 so each pack uses one scale.
+    for (uint i = linear; i < BN * (BK / 8u); i += thread_count) {
+      const uint c = i / (BK / 8u);
+      const uint packed_k = i - c * (BK / 8u);
+      const uint src_col = gl_WorkGroupID.x * BN + c;
+      const uint src_k = kb + packed_k * 8u;
+      const uint kk = packed_k * 8u;
+      if (src_col < p.cols && src_k + 7u < p.K) {
+        const uint packed = data_w[src_col * p.packed_row_words + (src_k >> 3u)];
+        const float scale = nvfp4_fp8_e4m3_to_fp32(
+            data_scales[src_col * p.scale_row_stride + (src_k >> 4u)]);
+        [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+          ws[c][kk + n] = nvfp4_decode_nibble(packed, n, scale);
+        }
+      } else {
+        [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+          float v = 0.0f;
+          const uint k = src_k + n;
+          if (src_col < p.cols && k < p.K) {
+            const uint packed =
+                data_w[src_col * p.packed_row_words + (k >> 3u)];
+            const float scale = nvfp4_fp8_e4m3_to_fp32(
+                data_scales[src_col * p.scale_row_stride + (k >> 4u)]);
+            v = nvfp4_decode_nibble(packed, k & 7u, scale);
+          }
+          ws[c][kk + n] = v;
+        }
       }
-      As[r][kk] = v;
     }
     barrier();
 
-    if (in_bounds) {
-      const uint k_end = min(k0 + BK, p.K);
-      if ((p.group_size == 16u) && ((k0 & 7u) == 0u)) {
-        for (uint kk = 0u; kk < BK && (k0 + kk) < k_end; kk += 8u) {
-          const uint k = k0 + kk;
-          const uint packed = data_w[w_row_base + (k >> 3u)];
-          const float scale =
-              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-          acc = fma(As[ty][kk + 0u], nvfp4_decode_nibble(packed, 0u, scale), acc);
-          acc = fma(As[ty][kk + 1u], nvfp4_decode_nibble(packed, 1u, scale), acc);
-          acc = fma(As[ty][kk + 2u], nvfp4_decode_nibble(packed, 2u, scale), acc);
-          acc = fma(As[ty][kk + 3u], nvfp4_decode_nibble(packed, 3u, scale), acc);
-          acc = fma(As[ty][kk + 4u], nvfp4_decode_nibble(packed, 4u, scale), acc);
-          acc = fma(As[ty][kk + 5u], nvfp4_decode_nibble(packed, 5u, scale), acc);
-          acc = fma(As[ty][kk + 6u], nvfp4_decode_nibble(packed, 6u, scale), acc);
-          acc = fma(As[ty][kk + 7u], nvfp4_decode_nibble(packed, 7u, scale), acc);
-        }
-      } else {
-        for (uint kk = 0u; kk < BK && (k0 + kk) < k_end; ++kk) {
-          const uint k = k0 + kk;
-          const uint packed = data_w[w_row_base + (k >> 3u)];
-          const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
-          const float scale =
-              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-          acc = fma(As[ty][kk], nvfp4_lut(q) * scale, acc);
+    for (uint kk = 0u; kk < BK; ++kk) {
+#if MLX_TN == 2
+      const float w0 = ws[lx * TN + 0u][kk];
+      const float w1 = ws[lx * TN + 1u][kk];
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        acc[mr][0] = fma(x, w0, acc[mr][0]);
+        acc[mr][1] = fma(x, w1, acc[mr][1]);
+      }
+#elif MLX_TN == 4
+      const float w0 = ws[lx * TN + 0u][kk];
+      const float w1 = ws[lx * TN + 1u][kk];
+      const float w2 = ws[lx * TN + 2u][kk];
+      const float w3 = ws[lx * TN + 3u][kk];
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        acc[mr][0] = fma(x, w0, acc[mr][0]);
+        acc[mr][1] = fma(x, w1, acc[mr][1]);
+        acc[mr][2] = fma(x, w2, acc[mr][2]);
+        acc[mr][3] = fma(x, w3, acc[mr][3]);
+      }
+#else
+      [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+        const float x = xs[ly * TM + mr][kk];
+        [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+          acc[mr][nc] = fma(x, ws[lx * TN + nc][kk], acc[mr][nc]);
         }
       }
+#endif
     }
     barrier();
   }
 
-  if (in_bounds) {
-    data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(acc));
+  [[unroll]] for (uint mr = 0u; mr < TM; ++mr) {
+    const uint row = row0 + mr;
+    if (row >= p.rows) {
+      continue;
+    }
+    [[unroll]] for (uint nc = 0u; nc < TN; ++nc) {
+      const uint col = col0 + nc;
+      if (col < p.cols) {
+        data_out[row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(acc[mr][nc]));
+      }
+    }
   }
 }

--- a/mlx/backend/vulkan/kernels/mul_mm_nvfp4_dense.comp
+++ b/mlx/backend/vulkan/kernels/mul_mm_nvfp4_dense.comp
@@ -20,7 +20,7 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// Fused NVFP4 gather matmul (transpose weights) with shared X tiles.
+// Dense NVFP4 matmul (transpose weights) with shared X tiles for prefill.
 #define BM 16
 #define BN 16
 #define BK 32
@@ -36,13 +36,7 @@ layout(binding = 1) readonly buffer SCALES {
 layout(binding = 2) readonly buffer X {
   B_TYPE data_x[];
 };
-layout(binding = 3) readonly buffer LHS_INDICES {
-  uint data_lhs_indices[];
-};
-layout(binding = 4) readonly buffer RHS_INDICES {
-  uint data_rhs_indices[];
-};
-layout(binding = 5) writeonly buffer OUT {
+layout(binding = 3) writeonly buffer OUT {
   D_TYPE data_out[];
 };
 
@@ -51,13 +45,9 @@ layout(push_constant) uniform parameter {
   uint cols;
   uint K;
   uint packed_row_words;
-  uint x_batch_stride;
   uint x_row_stride;
-  uint out_batch_stride;
   uint out_row_stride;
-  uint scale_matrix_stride;
   uint scale_row_stride;
-  uint w_matrix_stride_words;
   uint group_size;
   uint num_groups;
 } p;
@@ -67,7 +57,6 @@ shared float As[BM][BK];
 void main() {
   const uint col0 = gl_WorkGroupID.x * BN;
   const uint row0 = gl_WorkGroupID.y * BM;
-  const uint batch = gl_WorkGroupID.z;
   const uint tx = gl_LocalInvocationID.x;
   const uint ty = gl_LocalInvocationID.y;
   const uint col = col0 + tx;
@@ -75,14 +64,8 @@ void main() {
   const uint tid = ty * BN + tx;
   const uint wg = BM * BN;
 
-  const uint lhs_batch = data_lhs_indices[batch];
-  const uint rhs_batch = data_rhs_indices[batch];
-  const uint x_batch_base = lhs_batch * p.x_batch_stride;
-  const uint w_matrix_base = rhs_batch * p.w_matrix_stride_words;
-  const uint scale_matrix_base = rhs_batch * p.scale_matrix_stride;
-
-  const uint w_row_base = w_matrix_base + col * p.packed_row_words;
-  const uint scale_row_base = scale_matrix_base + col * p.scale_row_stride;
+  const uint w_row_base = col * p.packed_row_words;
+  const uint scale_row_base = col * p.scale_row_stride;
   const bool in_bounds = row < p.rows && col < p.cols;
 
   float acc = 0.0f;
@@ -94,8 +77,7 @@ void main() {
       const uint gk = k0 + kk;
       float v = 0.0f;
       if (gr < p.rows && gk < p.K) {
-        v = TO_FLOAT_TYPE(
-            data_x[x_batch_base + gr * p.x_row_stride + gk]);
+        v = TO_FLOAT_TYPE(data_x[gr * p.x_row_stride + gk]);
       }
       As[r][kk] = v;
     }
@@ -133,7 +115,6 @@ void main() {
   }
 
   if (in_bounds) {
-    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
-        D_TYPE(FROM_FLOAT_TYPE(acc));
+    data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(acc));
   }
 }

--- a/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
@@ -22,7 +22,7 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// NVFP4 gather matvec for MoE decode: one workgroup per (batch, row, col).
+// Dense NVFP4 matvec (transpose weights): one workgroup per (row, col).
 #define BLOCK_SIZE 64
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
@@ -36,13 +36,7 @@ layout(binding = 1) readonly buffer SCALES {
 layout(binding = 2) readonly buffer X {
   B_TYPE data_x[];
 };
-layout(binding = 3) readonly buffer LHS_INDICES {
-  uint data_lhs_indices[];
-};
-layout(binding = 4) readonly buffer RHS_INDICES {
-  uint data_rhs_indices[];
-};
-layout(binding = 5) writeonly buffer OUT {
+layout(binding = 3) writeonly buffer OUT {
   D_TYPE data_out[];
 };
 
@@ -51,13 +45,9 @@ layout(push_constant) uniform parameter {
   uint cols;
   uint K;
   uint packed_row_words;
-  uint x_batch_stride;
   uint x_row_stride;
-  uint out_batch_stride;
   uint out_row_stride;
-  uint scale_matrix_stride;
   uint scale_row_stride;
-  uint w_matrix_stride_words;
   uint group_size;
   uint num_groups;
 } p;
@@ -67,20 +57,15 @@ shared float partial[BLOCK_SIZE];
 void main() {
   const uint col = gl_WorkGroupID.x;
   const uint row = gl_WorkGroupID.y;
-  const uint batch = gl_WorkGroupID.z;
   const uint tid = gl_LocalInvocationID.x;
 
   if (row >= p.rows || col >= p.cols) {
     return;
   }
 
-  const uint lhs_batch = data_lhs_indices[batch];
-  const uint rhs_batch = data_rhs_indices[batch];
-  const uint w_row_base =
-      rhs_batch * p.w_matrix_stride_words + col * p.packed_row_words;
-  const uint scale_row_base =
-      rhs_batch * p.scale_matrix_stride + col * p.scale_row_stride;
-  const uint x_row_base = lhs_batch * p.x_batch_stride + row * p.x_row_stride;
+  const uint w_row_base = col * p.packed_row_words;
+  const uint scale_row_base = col * p.scale_row_stride;
+  const uint x_row_base = row * p.x_row_stride;
 
   float acc = 0.0f;
   if ((p.K & 7u) == 0u && p.group_size == 16u) {
@@ -137,8 +122,7 @@ void main() {
   if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
     acc = subgroupAdd(acc);
     if (tid == 0u) {
-      data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
-          D_TYPE(FROM_FLOAT_TYPE(acc));
+      data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(acc));
     }
     return;
   }
@@ -152,7 +136,7 @@ void main() {
     barrier();
   }
   if (tid == 0u) {
-    data_out[batch * p.out_batch_stride + row * p.out_row_stride + col] =
+    data_out[row * p.out_row_stride + col] =
         D_TYPE(FROM_FLOAT_TYPE(partial[0]));
   }
 }

--- a/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
@@ -74,7 +74,56 @@ void main() {
     acc[c] = 0.0f;
   }
 
-  if ((p.K & 7u) == 0u && p.group_size == 16u) {
+  if ((p.K & 15u) == 0u && p.group_size == 16u) {
+    const uint pairs = p.K >> 4u;
+    const bool full_n = (col0 + MLX_BN) <= p.cols;
+    for (uint g = tid; g < pairs; g += BLOCK_SIZE) {
+      const uint k = g << 4u;
+      const uint pidx = g << 1u;
+      float xv[16];
+      [[unroll]] for (uint n = 0u; n < 16u; ++n) {
+        xv[n] = TO_FLOAT_TYPE(data_x[x_row_base + k + n]);
+      }
+      if (full_n) {
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          const uint w_row_base = col * p.packed_row_words;
+          const uint scale_row_base = col * p.scale_row_stride;
+          const uint packed0 = data_w[w_row_base + pidx];
+          const uint packed1 = data_w[w_row_base + pidx + 1u];
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(xv[n], nvfp4_decode_nibble(packed0, n, scale), acc[c]);
+          }
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(
+                xv[n + 8u], nvfp4_decode_nibble(packed1, n, scale), acc[c]);
+          }
+        }
+      } else {
+        [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+          const uint col = col0 + c;
+          if (col < p.cols) {
+            const uint w_row_base = col * p.packed_row_words;
+            const uint scale_row_base = col * p.scale_row_stride;
+            const uint packed0 = data_w[w_row_base + pidx];
+            const uint packed1 = data_w[w_row_base + pidx + 1u];
+            const float scale =
+                nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + g]);
+            [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+              acc[c] =
+                  fma(xv[n], nvfp4_decode_nibble(packed0, n, scale), acc[c]);
+            }
+            [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+              acc[c] = fma(
+                  xv[n + 8u], nvfp4_decode_nibble(packed1, n, scale), acc[c]);
+            }
+          }
+        }
+      }
+    }
+  } else if ((p.K & 7u) == 0u && p.group_size == 16u) {
     const uint packs = p.K >> 3u;
     for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
       const uint k = pidx << 3u;

--- a/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
+++ b/mlx/backend/vulkan/kernels/mul_mv_nvfp4.comp
@@ -1,5 +1,6 @@
 #version 450
 
+#extension GL_EXT_control_flow_attributes : enable
 #extension GL_EXT_shader_8bit_storage : require
 #extension GL_EXT_shader_explicit_arithmetic_types_int8 : require
 #extension GL_EXT_shader_16bit_storage : require
@@ -22,8 +23,11 @@
 #define FROM_FLOAT_TYPE
 #endif
 
-// Dense NVFP4 matvec (transpose weights): one workgroup per (row, col).
+// Dense NVFP4 matvec: one workgroup per (row, col_tile), BN cols share X.
 #define BLOCK_SIZE 64
+#ifndef MLX_BN
+#define MLX_BN 8
+#endif
 
 layout(local_size_x = BLOCK_SIZE, local_size_y = 1, local_size_z = 1) in;
 
@@ -52,91 +56,99 @@ layout(push_constant) uniform parameter {
   uint num_groups;
 } p;
 
-shared float partial[BLOCK_SIZE];
+shared float partial[MLX_BN][BLOCK_SIZE];
 
 void main() {
-  const uint col = gl_WorkGroupID.x;
+  const uint col0 = gl_WorkGroupID.x * MLX_BN;
   const uint row = gl_WorkGroupID.y;
   const uint tid = gl_LocalInvocationID.x;
 
-  if (row >= p.rows || col >= p.cols) {
+  if (row >= p.rows || col0 >= p.cols) {
     return;
   }
 
-  const uint w_row_base = col * p.packed_row_words;
-  const uint scale_row_base = col * p.scale_row_stride;
   const uint x_row_base = row * p.x_row_stride;
 
-  float acc = 0.0f;
+  float acc[MLX_BN];
+  [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+    acc[c] = 0.0f;
+  }
+
   if ((p.K & 7u) == 0u && p.group_size == 16u) {
     const uint packs = p.K >> 3u;
     for (uint pidx = tid; pidx < packs; pidx += BLOCK_SIZE) {
       const uint k = pidx << 3u;
-      const uint packed = data_w[w_row_base + pidx];
-      const float scale =
-          nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k]),
-          nvfp4_decode_nibble(packed, 0u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 1u]),
-          nvfp4_decode_nibble(packed, 1u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 2u]),
-          nvfp4_decode_nibble(packed, 2u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 3u]),
-          nvfp4_decode_nibble(packed, 3u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 4u]),
-          nvfp4_decode_nibble(packed, 4u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 5u]),
-          nvfp4_decode_nibble(packed, 5u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 6u]),
-          nvfp4_decode_nibble(packed, 6u, scale),
-          acc);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k + 7u]),
-          nvfp4_decode_nibble(packed, 7u, scale),
-          acc);
+      float xv[8];
+      [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+        xv[n] = TO_FLOAT_TYPE(data_x[x_row_base + k + n]);
+      }
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          const uint w_row_base = col * p.packed_row_words;
+          const uint scale_row_base = col * p.scale_row_stride;
+          const uint packed = data_w[w_row_base + pidx];
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+          [[unroll]] for (uint n = 0u; n < 8u; ++n) {
+            acc[c] = fma(xv[n], nvfp4_decode_nibble(packed, n, scale), acc[c]);
+          }
+        }
+      }
     }
   } else {
     for (uint k = tid; k < p.K; k += BLOCK_SIZE) {
-      const uint packed = data_w[w_row_base + (k >> 3u)];
-      const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
-      const float scale =
-          nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
-      acc = fma(
-          TO_FLOAT_TYPE(data_x[x_row_base + k]), nvfp4_lut(q) * scale, acc);
+      const float xv = TO_FLOAT_TYPE(data_x[x_row_base + k]);
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          const uint w_row_base = col * p.packed_row_words;
+          const uint scale_row_base = col * p.scale_row_stride;
+          const uint packed = data_w[w_row_base + (k >> 3u)];
+          const uint q = (packed >> ((k & 7u) * 4u)) & 0xFu;
+          const float scale =
+              nvfp4_fp8_e4m3_to_fp32(data_scales[scale_row_base + (k >> 4u)]);
+          acc[c] = fma(xv, nvfp4_lut(q) * scale, acc[c]);
+        }
+      }
     }
   }
 
   if (gl_SubgroupSize == BLOCK_SIZE && gl_NumSubgroups == 1u) {
-    acc = subgroupAdd(acc);
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      acc[c] = subgroupAdd(acc[c]);
+    }
     if (tid == 0u) {
-      data_out[row * p.out_row_stride + col] = D_TYPE(FROM_FLOAT_TYPE(acc));
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        const uint col = col0 + c;
+        if (col < p.cols) {
+          data_out[row * p.out_row_stride + col] =
+              D_TYPE(FROM_FLOAT_TYPE(acc[c]));
+        }
+      }
     }
     return;
   }
 
-  partial[tid] = acc;
+  [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+    partial[c][tid] = acc[c];
+  }
   barrier();
   for (uint stride = BLOCK_SIZE >> 1u; stride > 0u; stride >>= 1u) {
     if (tid < stride) {
-      partial[tid] += partial[tid + stride];
+      [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+        partial[c][tid] += partial[c][tid + stride];
+      }
     }
     barrier();
   }
   if (tid == 0u) {
-    data_out[row * p.out_row_stride + col] =
-        D_TYPE(FROM_FLOAT_TYPE(partial[0]));
+    [[unroll]] for (uint c = 0u; c < MLX_BN; ++c) {
+      const uint col = col0 + c;
+      if (col < p.cols) {
+        data_out[row * p.out_row_stride + col] =
+            D_TYPE(FROM_FLOAT_TYPE(partial[c][0]));
+      }
+    }
   }
 }

--- a/mlx/backend/vulkan/kernels/nvfp4_common.glsl
+++ b/mlx/backend/vulkan/kernels/nvfp4_common.glsl
@@ -1,0 +1,22 @@
+// Shared NVFP4 decode helpers for gather/dense matmul shaders.
+#ifndef MLX_NVFP4_COMMON_GLSL
+#define MLX_NVFP4_COMMON_GLSL
+
+float nvfp4_fp8_e4m3_to_fp32(uint8_t x) {
+  uint v = (uint(x) & 127u) << 7;
+  float val = unpackHalf2x16(v).x * 256.0;
+  return (x & uint8_t(128u)) != 0u ? -val : val;
+}
+
+float nvfp4_lut(uint q) {
+  const float lut[16] = float[16](
+      +0.0, +0.5, +1.0, +1.5, +2.0, +3.0, +4.0, +6.0, -0.0, -0.5, -1.0, -1.5,
+      -2.0, -3.0, -4.0, -6.0);
+  return lut[q];
+}
+
+float nvfp4_decode_nibble(uint packed, uint lane, float scale) {
+  return nvfp4_lut((packed >> (lane * 4u)) & 0xFu) * scale;
+}
+
+#endif

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2354,6 +2354,38 @@ void process_shaders() {
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
        {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
        {"MLX_BN", "16"}});
+  string_to_spv(
+      "gather_mv_nvfp4_rhs_f32_bm2_n16",
+      "gather_mv_nvfp4_rhs.comp",
+      {{"B_TYPE", "float"},
+       {"D_TYPE", "float"},
+       {"MLX_BM", "2"},
+       {"MLX_BN", "16"}});
+  string_to_spv(
+      "gather_mv_nvfp4_rhs_f32_bm2_n8",
+      "gather_mv_nvfp4_rhs.comp",
+      {{"B_TYPE", "float"},
+       {"D_TYPE", "float"},
+       {"MLX_BM", "2"},
+       {"MLX_BN", "8"}});
+  string_to_spv(
+      "gather_mv_nvfp4_rhs_bf16_bf16_bm2_n16",
+      "gather_mv_nvfp4_rhs.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BM", "2"},
+       {"MLX_BN", "16"}});
+  string_to_spv(
+      "gather_mv_nvfp4_rhs_bf16_bf16_bm2_n8",
+      "gather_mv_nvfp4_rhs.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BM", "2"},
+       {"MLX_BN", "8"}});
 
   string_to_spv(
       "fused_affine_matmul_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2229,6 +2229,7 @@ void process_shaders() {
   string_to_spv("quantize_nvfp4_f32", "quantize_nvfp4.comp", {});
   string_to_spv("mul_mm_nvfp4_f32", "mul_mm_nvfp4.comp", {});
   string_to_spv("gather_mm_nvfp4_f32", "gather_mm_nvfp4.comp", {});
+  string_to_spv("gather_mv_nvfp4_f32", "gather_mv_nvfp4.comp", {});
 
   string_to_spv(
       "fused_affine_matmul_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2228,6 +2228,7 @@ void process_shaders() {
   string_to_spv("dequant_nvfp4_f32", "dequant_nvfp4.comp", {});
   string_to_spv("quantize_nvfp4_f32", "quantize_nvfp4.comp", {});
   string_to_spv("mul_mm_nvfp4_f32", "mul_mm_nvfp4.comp", {});
+  string_to_spv("gather_mm_nvfp4_f32", "gather_mm_nvfp4.comp", {});
 
   string_to_spv(
       "fused_affine_matmul_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2244,6 +2244,13 @@ void process_shaders() {
       "mul_mm_nvfp4_dense.comp",
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
   string_to_spv(
+      "mul_mm_nvfp4_dense_f32_n32",
+      "mul_mm_nvfp4_dense.comp",
+      {{"B_TYPE", "float"},
+       {"D_TYPE", "float"},
+       {"MLX_BN", "32"},
+       {"MLX_TN", "4"}});
+  string_to_spv(
       "mul_mm_nvfp4_dense_bf16_bf16",
       "mul_mm_nvfp4_dense.comp",
       {{"B_TYPE", "uint16_t"},
@@ -2251,9 +2258,25 @@ void process_shaders() {
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
        {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
   string_to_spv(
+      "mul_mm_nvfp4_dense_bf16_bf16_n32",
+      "mul_mm_nvfp4_dense.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "32"},
+       {"MLX_TN", "4"}});
+  string_to_spv(
       "gather_mm_nvfp4_f32",
       "gather_mm_nvfp4.comp",
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "gather_mm_nvfp4_f32_n32",
+      "gather_mm_nvfp4.comp",
+      {{"B_TYPE", "float"},
+       {"D_TYPE", "float"},
+       {"MLX_BN", "32"},
+       {"MLX_TN", "4"}});
   string_to_spv(
       "gather_mm_nvfp4_bf16_bf16",
       "gather_mm_nvfp4.comp",
@@ -2261,6 +2284,15 @@ void process_shaders() {
        {"D_TYPE", "uint16_t"},
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
        {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "gather_mm_nvfp4_bf16_bf16_n32",
+      "gather_mm_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "32"},
+       {"MLX_TN", "4"}});
   string_to_spv(
       "gather_mv_nvfp4_f32",
       "gather_mv_nvfp4.comp",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2228,8 +2228,50 @@ void process_shaders() {
   string_to_spv("dequant_nvfp4_f32", "dequant_nvfp4.comp", {});
   string_to_spv("quantize_nvfp4_f32", "quantize_nvfp4.comp", {});
   string_to_spv("mul_mm_nvfp4_f32", "mul_mm_nvfp4.comp", {});
-  string_to_spv("gather_mm_nvfp4_f32", "gather_mm_nvfp4.comp", {});
-  string_to_spv("gather_mv_nvfp4_f32", "gather_mv_nvfp4.comp", {});
+  string_to_spv(
+      "mul_mv_nvfp4_f32",
+      "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "mul_mv_nvfp4_bf16_bf16",
+      "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "mul_mm_nvfp4_dense_f32",
+      "mul_mm_nvfp4_dense.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "mul_mm_nvfp4_dense_bf16_bf16",
+      "mul_mm_nvfp4_dense.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "gather_mm_nvfp4_f32",
+      "gather_mm_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "gather_mm_nvfp4_bf16_bf16",
+      "gather_mm_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+  string_to_spv(
+      "gather_mv_nvfp4_f32",
+      "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+  string_to_spv(
+      "gather_mv_nvfp4_bf16_bf16",
+      "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
 
   string_to_spv(
       "fused_affine_matmul_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2231,14 +2231,27 @@ void process_shaders() {
   string_to_spv(
       "mul_mv_nvfp4_f32",
       "mul_mv_nvfp4.comp",
-      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "8"}});
+  string_to_spv(
+      "mul_mv_nvfp4_f32_n16",
+      "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "16"}});
   string_to_spv(
       "mul_mv_nvfp4_bf16_bf16",
       "mul_mv_nvfp4.comp",
       {{"B_TYPE", "uint16_t"},
        {"D_TYPE", "uint16_t"},
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
-       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "8"}});
+  string_to_spv(
+      "mul_mv_nvfp4_bf16_bf16_n16",
+      "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "16"}});
   string_to_spv(
       "mul_mm_nvfp4_dense_f32",
       "mul_mm_nvfp4_dense.comp",
@@ -2296,14 +2309,27 @@ void process_shaders() {
   string_to_spv(
       "gather_mv_nvfp4_f32",
       "gather_mv_nvfp4.comp",
-      {{"B_TYPE", "float"}, {"D_TYPE", "float"}});
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "8"}});
+  string_to_spv(
+      "gather_mv_nvfp4_f32_n16",
+      "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "16"}});
   string_to_spv(
       "gather_mv_nvfp4_bf16_bf16",
       "gather_mv_nvfp4.comp",
       {{"B_TYPE", "uint16_t"},
        {"D_TYPE", "uint16_t"},
        {"TO_FLOAT_TYPE", "bf16_to_fp32"},
-       {"FROM_FLOAT_TYPE", "fp32_to_bf16"}});
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "8"}});
+  string_to_spv(
+      "gather_mv_nvfp4_bf16_bf16_n16",
+      "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "16"}});
 
   string_to_spv(
       "fused_affine_matmul_f32_f32",

--- a/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
+++ b/mlx/backend/vulkan/kernels/vulkan-shaders-gen.cpp
@@ -2231,6 +2231,10 @@ void process_shaders() {
   string_to_spv(
       "mul_mv_nvfp4_f32",
       "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "1"}});
+  string_to_spv(
+      "mul_mv_nvfp4_f32_n8",
+      "mul_mv_nvfp4.comp",
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "8"}});
   string_to_spv(
       "mul_mv_nvfp4_f32_n16",
@@ -2238,6 +2242,14 @@ void process_shaders() {
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "16"}});
   string_to_spv(
       "mul_mv_nvfp4_bf16_bf16",
+      "mul_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "1"}});
+  string_to_spv(
+      "mul_mv_nvfp4_bf16_bf16_n8",
       "mul_mv_nvfp4.comp",
       {{"B_TYPE", "uint16_t"},
        {"D_TYPE", "uint16_t"},
@@ -2309,6 +2321,10 @@ void process_shaders() {
   string_to_spv(
       "gather_mv_nvfp4_f32",
       "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "1"}});
+  string_to_spv(
+      "gather_mv_nvfp4_f32_n8",
+      "gather_mv_nvfp4.comp",
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "8"}});
   string_to_spv(
       "gather_mv_nvfp4_f32_n16",
@@ -2316,6 +2332,14 @@ void process_shaders() {
       {{"B_TYPE", "float"}, {"D_TYPE", "float"}, {"MLX_BN", "16"}});
   string_to_spv(
       "gather_mv_nvfp4_bf16_bf16",
+      "gather_mv_nvfp4.comp",
+      {{"B_TYPE", "uint16_t"},
+       {"D_TYPE", "uint16_t"},
+       {"TO_FLOAT_TYPE", "bf16_to_fp32"},
+       {"FROM_FLOAT_TYPE", "fp32_to_bf16"},
+       {"MLX_BN", "1"}});
+  string_to_spv(
+      "gather_mv_nvfp4_bf16_bf16_n8",
       "gather_mv_nvfp4.comp",
       {{"B_TYPE", "uint16_t"},
        {"D_TYPE", "uint16_t"},

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -208,12 +208,15 @@ bool fused_nvfp4_dense_qmm_enabled() {
 
 std::optional<vulkan::StaticShaderId> nvfp4_dense_matvec_shader_id(
     Dtype x_dtype,
-    Dtype out_dtype) {
+    Dtype out_dtype,
+    bool wide_n) {
   if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16;
+    return wide_n ? vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16_n16
+                  : vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16;
   }
   if (x_dtype == float32 && out_dtype == float32) {
-    return vulkan::StaticShaderId::mul_mv_nvfp4_f32;
+    return wide_n ? vulkan::StaticShaderId::mul_mv_nvfp4_f32_n16
+                  : vulkan::StaticShaderId::mul_mv_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -251,12 +254,15 @@ std::optional<vulkan::StaticShaderId> gather_nvfp4_matmul_shader_id(
 
 std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_shader_id(
     Dtype x_dtype,
-    Dtype out_dtype) {
+    Dtype out_dtype,
+    bool wide_n) {
   if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16;
+    return wide_n ? vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16_n16
+                  : vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16;
   }
   if (x_dtype == float32 && out_dtype == float32) {
-    return vulkan::StaticShaderId::gather_mv_nvfp4_f32;
+    return wide_n ? vulkan::StaticShaderId::gather_mv_nvfp4_f32_n16
+                  : vulkan::StaticShaderId::gather_mv_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -2159,10 +2165,7 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     }
     const Dtype out_compute_dtype =
         (compute_dtype == bfloat16) ? bfloat16 : float32;
-    auto matvec_id =
-        nvfp4_dense_matvec_shader_id(compute_dtype, out_compute_dtype);
-    if (matvec_id.has_value() && scales_nv.ndim() == 2 &&
-        is_row_contiguous_zero_offset(x_work) &&
+    if (scales_nv.ndim() == 2 && is_row_contiguous_zero_offset(x_work) &&
         is_row_contiguous_zero_offset(w) &&
         is_row_contiguous_zero_offset(scales_nv)) {
       const uint32_t rows = static_cast<uint32_t>(x_work.shape(-2));
@@ -2170,10 +2173,13 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
       const uint32_t num_groups = static_cast<uint32_t>(scales_nv.shape(-1));
       const bool use_matvec = rows <= 8 || decode_lhs || rows == 1;
-      const bool large_n = !use_matvec && cols >= 1024u;
+      const bool wide_n = cols >= 1024u;
+      const bool large_n = !use_matvec && wide_n;
+      auto matvec_id = nvfp4_dense_matvec_shader_id(
+          compute_dtype, out_compute_dtype, wide_n);
       auto matmul_id = nvfp4_dense_matmul_shader_id(
           compute_dtype, out_compute_dtype, large_n);
-      if (matmul_id.has_value() &&
+      if (matvec_id.has_value() && matmul_id.has_value() &&
           cols == static_cast<uint32_t>(out.shape(-1)) &&
           static_cast<uint32_t>(w.shape(-1) * 8) == k &&
           num_groups ==
@@ -2203,11 +2209,13 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           push_constants.num_groups = num_groups;
 
           const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
-          const uint32_t bn = large_n ? 32u : 16u;
+          const uint32_t mv_bn = wide_n ? 16u : 8u;
+          const uint32_t mm_bn = large_n ? 32u : 16u;
           const std::array<uint32_t, 3> grid = use_matvec
-              ? std::array<uint32_t, 3>{cols, rows, 1u}
+              ? std::array<uint32_t, 3>{
+                    (cols + mv_bn - 1u) / mv_bn, rows, 1u}
               : std::array<uint32_t, 3>{
-                    (cols + bn - 1u) / bn, (rows + 31u) / 32u, 1u};
+                    (cols + mm_bn - 1u) / mm_bn, (rows + 31u) / 32u, 1u};
           if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
             throw std::runtime_error(
                 "[QuantizedMatmul::eval_gpu] NVFP4 dense dispatch grid exceeds Vulkan limits.");
@@ -2750,15 +2758,16 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
                             : ensure_float32_row_contiguous(x, s);
     const Dtype out_compute_dtype =
         (compute_dtype == bfloat16) ? bfloat16 : float32;
-    auto matvec_id =
-        gather_nvfp4_matvec_shader_id(compute_dtype, out_compute_dtype);
     const uint32_t batches = static_cast<uint32_t>(lhs_indices.size());
     const uint32_t rows = static_cast<uint32_t>(out.shape(-2));
     const uint32_t cols = static_cast<uint32_t>(out.shape(-1));
     const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
     const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
     const bool use_matvec = rows <= 8;
-    const bool large_n = !use_matvec && cols >= 1024u;
+    const bool wide_n = cols >= 1024u;
+    const bool large_n = !use_matvec && wide_n;
+    auto matvec_id = gather_nvfp4_matvec_shader_id(
+        compute_dtype, out_compute_dtype, wide_n);
     auto matmul_id = gather_nvfp4_matmul_shader_id(
         compute_dtype, out_compute_dtype, large_n);
     const bool shapes_ok = matvec_id.has_value() && matmul_id.has_value() &&
@@ -2800,13 +2809,15 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         push_constants.group_size = static_cast<uint32_t>(group_size_);
         push_constants.num_groups = num_groups;
 
-        // Decode (rows<=8): matvec. Prefill: tiled gather_mm BM=32.
+        // Decode/prefill MoE: multi-col matvec (rows<=8). Prefill mm: BM=32.
         const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
-        const uint32_t bn = large_n ? 32u : 16u;
+        const uint32_t mv_bn = wide_n ? 16u : 8u;
+        const uint32_t mm_bn = large_n ? 32u : 16u;
         const std::array<uint32_t, 3> grid = use_matvec
-            ? std::array<uint32_t, 3>{cols, rows, batches}
+            ? std::array<uint32_t, 3>{
+                  (cols + mv_bn - 1u) / mv_bn, rows, batches}
             : std::array<uint32_t, 3>{
-                  (cols + bn - 1u) / bn, (rows + 31u) / 32u, batches};
+                  (cols + mm_bn - 1u) / mm_bn, (rows + 31u) / 32u, batches};
         if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
           throw std::runtime_error(
               "[GatherQMM::eval_gpu] NVFP4 gather dispatch grid exceeds Vulkan workgroup count limits.");

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -2538,6 +2538,84 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     return;
   }
 
+  if (mode_ == QuantizationMode::Nvfp4 && transpose_) {
+    array x_work = ensure_float32_row_contiguous(x, s);
+    const uint32_t batches = static_cast<uint32_t>(lhs_indices.size());
+    const uint32_t rows = static_cast<uint32_t>(out.shape(-2));
+    const uint32_t cols = static_cast<uint32_t>(out.shape(-1));
+    const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
+    const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
+    const bool shapes_ok = group_size_ == 16 && bits_ == 4 &&
+        w.dtype() == uint32 && scales.dtype() == uint8 &&
+        rows == static_cast<uint32_t>(x_work.shape(-2)) &&
+        cols == static_cast<uint32_t>(w.shape(-2)) &&
+        static_cast<uint32_t>(w.shape(-1) * 8) == k &&
+        num_groups ==
+            static_cast<uint32_t>((k + group_size_ - 1) / group_size_) &&
+        is_row_contiguous_zero_offset(x_work) &&
+        is_row_contiguous_zero_offset(w) &&
+        is_row_contiguous_zero_offset(scales) &&
+        is_row_contiguous_zero_offset(lhs_indices) &&
+        is_row_contiguous_zero_offset(rhs_indices);
+    if (shapes_ok) {
+      array out_work(out.shape(), float32, nullptr, {});
+      out_work.set_data(allocator::malloc(out_work.nbytes()));
+      if (out_work.size() != 0) {
+        vulkan::GatherNvfp4MatmulPushConstants push_constants{};
+        push_constants.rows = rows;
+        push_constants.cols = cols;
+        push_constants.K = k;
+        push_constants.packed_row_words =
+            static_cast<uint32_t>(w.strides(-2));
+        push_constants.x_batch_stride =
+            static_cast<uint32_t>(x_work.shape(-2) * x_work.shape(-1));
+        push_constants.x_row_stride =
+            static_cast<uint32_t>(x_work.strides(-2));
+        push_constants.out_batch_stride = rows * cols;
+        push_constants.out_row_stride =
+            static_cast<uint32_t>(out_work.strides(-2));
+        push_constants.scale_matrix_stride =
+            static_cast<uint32_t>(scales.strides(-3));
+        push_constants.scale_row_stride =
+            static_cast<uint32_t>(scales.strides(-2));
+        push_constants.w_matrix_stride_words =
+            static_cast<uint32_t>(w.strides(-3));
+        push_constants.group_size = static_cast<uint32_t>(group_size_);
+        push_constants.num_groups = num_groups;
+
+        const std::array<uint32_t, 3> grid = {
+            (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
+        if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
+          throw std::runtime_error(
+              "[GatherQMM::eval_gpu] NVFP4 gather dispatch grid exceeds Vulkan workgroup count limits.");
+        }
+
+        auto command_buffer = vulkan::begin_command_recording(s.index);
+        vulkan::dispatch_gather_nvfp4_matmul_op(
+            w,
+            scales,
+            x_work,
+            lhs_indices,
+            rhs_indices,
+            out_work,
+            vulkan::StaticShaderId::gather_mm_nvfp4_f32,
+            command_buffer,
+            s,
+            push_constants,
+            grid);
+        vulkan::end_command_recording(s.index);
+      }
+
+      if (out.dtype() == out_work.dtype()) {
+        out.copy_shared_buffer(out_work);
+      } else {
+        out.set_data(allocator::malloc(out.nbytes()));
+        copy_gpu(out_work, out, CopyType::General, s);
+      }
+      return;
+    }
+  }
+
   if (!affine_mode || !transpose_) {
     array w_deq(expanded_quantized_shape(w, bits_), float32, nullptr, {});
     if (affine_mode &&

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -2583,8 +2583,16 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         push_constants.group_size = static_cast<uint32_t>(group_size_);
         push_constants.num_groups = num_groups;
 
-        const std::array<uint32_t, 3> grid = {
-            (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
+        // Decode (rows<=8): one workgroup per output element with K-reduce.
+        // Prefill/larger rows: tiled gather_mm.
+        const bool use_matvec = rows <= 8;
+        const auto shader_id = use_matvec
+            ? vulkan::StaticShaderId::gather_mv_nvfp4_f32
+            : vulkan::StaticShaderId::gather_mm_nvfp4_f32;
+        const std::array<uint32_t, 3> grid = use_matvec
+            ? std::array<uint32_t, 3>{cols, rows, batches}
+            : std::array<uint32_t, 3>{
+                  (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
         if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
           throw std::runtime_error(
               "[GatherQMM::eval_gpu] NVFP4 gather dispatch grid exceeds Vulkan workgroup count limits.");
@@ -2598,7 +2606,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
             lhs_indices,
             rhs_indices,
             out_work,
-            vulkan::StaticShaderId::gather_mm_nvfp4_f32,
+            shader_id,
             command_buffer,
             s,
             push_constants,

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -195,6 +195,65 @@ bool fused_nvfp4_qqmm_enabled() {
   return enabled;
 }
 
+bool fused_nvfp4_dense_qmm_enabled() {
+  static const bool enabled = []() {
+    if (const char* env = std::getenv("MLX_VULKAN_NVFP4_DENSE_QMM");
+        env != nullptr) {
+      return std::string_view(env) != "0";
+    }
+    return true;
+  }();
+  return enabled;
+}
+
+std::optional<vulkan::StaticShaderId> nvfp4_dense_matvec_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return vulkan::StaticShaderId::mul_mv_nvfp4_f32;
+  }
+  return std::nullopt;
+}
+
+std::optional<vulkan::StaticShaderId> nvfp4_dense_matmul_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return vulkan::StaticShaderId::mul_mm_nvfp4_dense_bf16_bf16;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return vulkan::StaticShaderId::mul_mm_nvfp4_dense_f32;
+  }
+  return std::nullopt;
+}
+
+std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return vulkan::StaticShaderId::gather_mv_nvfp4_f32;
+  }
+  return std::nullopt;
+}
+
+std::optional<vulkan::StaticShaderId> gather_nvfp4_matmul_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return vulkan::StaticShaderId::gather_mm_nvfp4_bf16_bf16;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return vulkan::StaticShaderId::gather_mm_nvfp4_f32;
+  }
+  return std::nullopt;
+}
+
 std::optional<vulkan::StaticShaderId> fused_affine_matmul_shader_id(
     Dtype x_dtype) {
   switch (x_dtype) {
@@ -2078,6 +2137,140 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
     }
   }
 
+  // Fused weight-only NVFP4 QuantizedMatmul (dense Q/K/V/O + shared expert).
+  if (mode_ == QuantizationMode::Nvfp4 && fused_nvfp4_dense_qmm_enabled() &&
+      transpose_ && group_size_ == 16 && bits_ == 4 && x_mat.ndim() == 2 &&
+      w.ndim() == 2 && w.dtype() == uint32 && inputs[2].dtype() == uint8) {
+    array scales_nv = ensure_row_contiguous_zero_offset(inputs[2], s);
+    array x_work = ensure_row_contiguous_zero_offset(x_mat, s);
+    Dtype compute_dtype = float32;
+    if (x_work.dtype() == bfloat16 && out.dtype() == bfloat16) {
+      compute_dtype = bfloat16;
+    } else if (x_work.dtype() != float32) {
+      x_work = ensure_float32_row_contiguous(x_work, s);
+      compute_dtype = float32;
+    }
+    const Dtype out_compute_dtype =
+        (compute_dtype == bfloat16) ? bfloat16 : float32;
+    auto matvec_id =
+        nvfp4_dense_matvec_shader_id(compute_dtype, out_compute_dtype);
+    auto matmul_id =
+        nvfp4_dense_matmul_shader_id(compute_dtype, out_compute_dtype);
+    if (matvec_id.has_value() && matmul_id.has_value() &&
+        scales_nv.ndim() == 2 && is_row_contiguous_zero_offset(x_work) &&
+        is_row_contiguous_zero_offset(w) &&
+        is_row_contiguous_zero_offset(scales_nv)) {
+      const uint32_t rows = static_cast<uint32_t>(x_work.shape(-2));
+      const uint32_t cols = static_cast<uint32_t>(w.shape(-2));
+      const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
+      const uint32_t num_groups = static_cast<uint32_t>(scales_nv.shape(-1));
+      if (cols == static_cast<uint32_t>(out.shape(-1)) &&
+          static_cast<uint32_t>(w.shape(-1) * 8) == k &&
+          num_groups ==
+              static_cast<uint32_t>((k + group_size_ - 1) / group_size_)) {
+        array out_work(
+            (vector_lhs || flatten_lhs_batches)
+                ? Shape{static_cast<int>(rows), out.shape(-1)}
+                : out.shape(),
+            out_compute_dtype,
+            nullptr,
+            {});
+        out_work.set_data(allocator::malloc(out_work.nbytes()));
+        const bool use_matvec = rows <= 8 || decode_lhs || rows == 1;
+        if (out_work.size() != 0) {
+          vulkan::Nvfp4DenseMatmulPushConstants push_constants{};
+          push_constants.rows = rows;
+          push_constants.cols = cols;
+          push_constants.K = k;
+          push_constants.packed_row_words =
+              static_cast<uint32_t>(w.strides(-2));
+          push_constants.x_row_stride =
+              static_cast<uint32_t>(x_work.strides(-2));
+          push_constants.out_row_stride =
+              static_cast<uint32_t>(out_work.strides(-2));
+          push_constants.scale_row_stride =
+              static_cast<uint32_t>(scales_nv.strides(-2));
+          push_constants.group_size = static_cast<uint32_t>(group_size_);
+          push_constants.num_groups = num_groups;
+
+          const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
+          const std::array<uint32_t, 3> grid = use_matvec
+              ? std::array<uint32_t, 3>{cols, rows, 1u}
+              : std::array<uint32_t, 3>{
+                    (cols + 15u) / 16u, (rows + 15u) / 16u, 1u};
+          if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
+            throw std::runtime_error(
+                "[QuantizedMatmul::eval_gpu] NVFP4 dense dispatch grid exceeds Vulkan limits.");
+          }
+
+          auto command_buffer = vulkan::begin_command_recording(s.index);
+          vulkan::dispatch_nvfp4_dense_matmul_op(
+              w,
+              scales_nv,
+              x_work,
+              out_work,
+              shader_id,
+              command_buffer,
+              s,
+              push_constants,
+              grid);
+          vulkan::end_command_recording(s.index);
+        }
+
+        if (out_compute_dtype == bfloat16) {
+          finalize_bf16_output(out_work);
+        } else if (vector_lhs || flatten_lhs_batches) {
+          array::Flags flags = out.flags();
+          flags.contiguous = true;
+          flags.row_contiguous = true;
+          if (vector_lhs) {
+            flags.col_contiguous = true;
+          } else {
+            auto max_dim =
+                std::max_element(out.shape().begin(), out.shape().end());
+            flags.col_contiguous =
+                out.size() <= 1 || out.size() == *max_dim;
+          }
+          if (out.dtype() == out_work.dtype()) {
+            out.copy_shared_buffer(
+                out_work,
+                make_contiguous_strides(out.shape()),
+                flags,
+                out.size());
+            if (!detail::in_tracing() && !detail::retain_graph()) {
+              out.detach();
+            }
+            out.set_status(array::Status::evaluated);
+          } else {
+            array out_view(out.shape(), out_work.dtype(), nullptr, {});
+            out_view.copy_shared_buffer(
+                out_work,
+                make_contiguous_strides(out.shape()),
+                flags,
+                out.size());
+            out.set_data(allocator::malloc(out.nbytes()));
+            copy_gpu(out_view, out, CopyType::GeneralGeneral, s);
+            if (!detail::in_tracing() && !detail::retain_graph()) {
+              out.detach();
+            }
+            out.set_status(array::Status::evaluated);
+          }
+        } else if (out.dtype() == out_work.dtype()) {
+          out.copy_shared_buffer(out_work);
+          out.set_status(array::Status::evaluated);
+        } else {
+          out.set_data(allocator::malloc(out.nbytes()));
+          copy_gpu(out_work, out, CopyType::General, s);
+          out.set_status(array::Status::evaluated);
+        }
+        trace_qmm(
+            use_matvec ? "fused_nvfp4_matvec" : "fused_nvfp4_matmul",
+            compute_dtype == bfloat16 ? "bf16=1" : "f32=1");
+        return;
+      }
+    }
+  }
+
   array scales = mode_ == QuantizationMode::Affine
       ? ensure_float32_row_contiguous(inputs[2], s)
       : inputs[2];
@@ -2466,7 +2659,9 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   const bool native_bf16 = affine_mode && x.dtype() == bfloat16 &&
       out.dtype() == bfloat16 && inputs[2].dtype() == bfloat16 &&
       inputs[3].dtype() == bfloat16;
-  if (x.dtype() == bfloat16 && !native_bf16) {
+  const bool native_nvfp4_bf16 = mode_ == QuantizationMode::Nvfp4 &&
+      x.dtype() == bfloat16 && out.dtype() == bfloat16;
+  if (x.dtype() == bfloat16 && !native_bf16 && !native_nvfp4_bf16) {
     x = ensure_float32_row_contiguous(x, s);
   }
   array w = ensure_row_contiguous_zero_offset(inputs[1], s);
@@ -2539,14 +2734,24 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
   }
 
   if (mode_ == QuantizationMode::Nvfp4 && transpose_) {
-    array x_work = ensure_float32_row_contiguous(x, s);
+    const bool use_bf16 = x.dtype() == bfloat16 && out.dtype() == bfloat16;
+    const Dtype compute_dtype = use_bf16 ? bfloat16 : float32;
+    array x_work = use_bf16 ? ensure_row_contiguous_zero_offset(x, s)
+                            : ensure_float32_row_contiguous(x, s);
+    const Dtype out_compute_dtype =
+        (compute_dtype == bfloat16) ? bfloat16 : float32;
+    auto matvec_id =
+        gather_nvfp4_matvec_shader_id(compute_dtype, out_compute_dtype);
+    auto matmul_id =
+        gather_nvfp4_matmul_shader_id(compute_dtype, out_compute_dtype);
     const uint32_t batches = static_cast<uint32_t>(lhs_indices.size());
     const uint32_t rows = static_cast<uint32_t>(out.shape(-2));
     const uint32_t cols = static_cast<uint32_t>(out.shape(-1));
     const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
     const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
-    const bool shapes_ok = group_size_ == 16 && bits_ == 4 &&
-        w.dtype() == uint32 && scales.dtype() == uint8 &&
+    const bool shapes_ok = matvec_id.has_value() && matmul_id.has_value() &&
+        group_size_ == 16 && bits_ == 4 && w.dtype() == uint32 &&
+        scales.dtype() == uint8 &&
         rows == static_cast<uint32_t>(x_work.shape(-2)) &&
         cols == static_cast<uint32_t>(w.shape(-2)) &&
         static_cast<uint32_t>(w.shape(-1) * 8) == k &&
@@ -2558,7 +2763,7 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         is_row_contiguous_zero_offset(lhs_indices) &&
         is_row_contiguous_zero_offset(rhs_indices);
     if (shapes_ok) {
-      array out_work(out.shape(), float32, nullptr, {});
+      array out_work(out.shape(), out_compute_dtype, nullptr, {});
       out_work.set_data(allocator::malloc(out_work.nbytes()));
       if (out_work.size() != 0) {
         vulkan::GatherNvfp4MatmulPushConstants push_constants{};
@@ -2584,11 +2789,9 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         push_constants.num_groups = num_groups;
 
         // Decode (rows<=8): one workgroup per output element with K-reduce.
-        // Prefill/larger rows: tiled gather_mm.
+        // Prefill/larger rows: tiled gather_mm with shared X.
         const bool use_matvec = rows <= 8;
-        const auto shader_id = use_matvec
-            ? vulkan::StaticShaderId::gather_mv_nvfp4_f32
-            : vulkan::StaticShaderId::gather_mm_nvfp4_f32;
+        const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
         const std::array<uint32_t, 3> grid = use_matvec
             ? std::array<uint32_t, 3>{cols, rows, batches}
             : std::array<uint32_t, 3>{

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -298,6 +298,22 @@ std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_shader_id(
   return std::nullopt;
 }
 
+std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_rhs_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype,
+    uint32_t bn) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return bn >= 16u
+        ? vulkan::StaticShaderId::gather_mv_nvfp4_rhs_bf16_bf16_bm2_n16
+        : vulkan::StaticShaderId::gather_mv_nvfp4_rhs_bf16_bf16_bm2_n8;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return bn >= 16u ? vulkan::StaticShaderId::gather_mv_nvfp4_rhs_f32_bm2_n16
+                     : vulkan::StaticShaderId::gather_mv_nvfp4_rhs_f32_bm2_n8;
+  }
+  return std::nullopt;
+}
+
 std::optional<vulkan::StaticShaderId> fused_affine_matmul_shader_id(
     Dtype x_dtype) {
   switch (x_dtype) {
@@ -2800,13 +2816,27 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
             uint64_t{rows} * uint64_t{batches},
             uint64_t{std::numeric_limits<uint32_t>::max()}));
     const uint32_t mv_bn = nvfp4_matvec_bn(cols, mv_work_items);
+    const auto x_batch_count =
+        x_work.size() / (x_work.shape(-2) * x_work.shape(-1));
+    const auto expert_count = w.size() / (w.shape(-2) * w.shape(-1));
+    // Sorted MoE prefill: tile 2 batches so consecutive same-expert tokens
+    // reuse dequantized W (BM=2 keeps register pressure low).
+    constexpr uint32_t kRhsBm = 2u;
+    const bool use_sorted_rhs = use_matvec && rows == 1 && batches >= 16 &&
+        right_sorted_ && x_batch_count == batches && expert_count > 0 &&
+        batches / expert_count >= 4 && mv_bn >= 8u;
     auto matvec_id =
         gather_nvfp4_matvec_shader_id(compute_dtype, out_compute_dtype, mv_bn);
+    auto matvec_rhs_id = use_sorted_rhs
+        ? gather_nvfp4_matvec_rhs_shader_id(
+              compute_dtype, out_compute_dtype, mv_bn)
+        : std::optional<vulkan::StaticShaderId>{};
     auto matmul_id = gather_nvfp4_matmul_shader_id(
         compute_dtype, out_compute_dtype, large_n);
-    const bool shapes_ok = matvec_id.has_value() && matmul_id.has_value() &&
-        group_size_ == 16 && bits_ == 4 && w.dtype() == uint32 &&
-        scales.dtype() == uint8 &&
+    const bool shapes_ok =
+        (matvec_rhs_id.has_value() || matvec_id.has_value()) &&
+        matmul_id.has_value() && group_size_ == 16 && bits_ == 4 &&
+        w.dtype() == uint32 && scales.dtype() == uint8 &&
         rows == static_cast<uint32_t>(x_work.shape(-2)) &&
         cols == static_cast<uint32_t>(w.shape(-2)) &&
         static_cast<uint32_t>(w.shape(-1) * 8) == k &&
@@ -2842,12 +2872,19 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
             static_cast<uint32_t>(w.strides(-3));
         push_constants.group_size = static_cast<uint32_t>(group_size_);
         push_constants.num_groups = num_groups;
+        push_constants.batches = batches;
 
-        // Decode: BN=1 keeps enough workgroups. Prefill MoE: multi-col.
-        // Prefill mm: BM=32 tiled gather.
-        const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
+        // Sorted MoE prefill: BM=2 W-reuse matvec. Else multi-col / tiled mm.
+        const bool use_rhs = matvec_rhs_id.has_value();
+        const auto shader_id = use_rhs ? *matvec_rhs_id
+            : (use_matvec ? *matvec_id : *matmul_id);
         const uint32_t mm_bn = large_n ? 32u : 16u;
-        const std::array<uint32_t, 3> grid = use_matvec
+        const std::array<uint32_t, 3> grid = use_rhs
+            ? std::array<uint32_t, 3>{
+                  (cols + mv_bn - 1u) / mv_bn,
+                  rows,
+                  (batches + kRhsBm - 1u) / kRhsBm}
+            : use_matvec
             ? std::array<uint32_t, 3>{
                   (cols + mv_bn - 1u) / mv_bn, rows, batches}
             : std::array<uint32_t, 3>{

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -220,12 +220,31 @@ std::optional<vulkan::StaticShaderId> nvfp4_dense_matvec_shader_id(
 
 std::optional<vulkan::StaticShaderId> nvfp4_dense_matmul_shader_id(
     Dtype x_dtype,
-    Dtype out_dtype) {
+    Dtype out_dtype,
+    bool large_n) {
   if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return vulkan::StaticShaderId::mul_mm_nvfp4_dense_bf16_bf16;
+    return large_n
+        ? vulkan::StaticShaderId::mul_mm_nvfp4_dense_bf16_bf16_n32
+        : vulkan::StaticShaderId::mul_mm_nvfp4_dense_bf16_bf16;
   }
   if (x_dtype == float32 && out_dtype == float32) {
-    return vulkan::StaticShaderId::mul_mm_nvfp4_dense_f32;
+    return large_n ? vulkan::StaticShaderId::mul_mm_nvfp4_dense_f32_n32
+                   : vulkan::StaticShaderId::mul_mm_nvfp4_dense_f32;
+  }
+  return std::nullopt;
+}
+
+std::optional<vulkan::StaticShaderId> gather_nvfp4_matmul_shader_id(
+    Dtype x_dtype,
+    Dtype out_dtype,
+    bool large_n) {
+  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
+    return large_n ? vulkan::StaticShaderId::gather_mm_nvfp4_bf16_bf16_n32
+                   : vulkan::StaticShaderId::gather_mm_nvfp4_bf16_bf16;
+  }
+  if (x_dtype == float32 && out_dtype == float32) {
+    return large_n ? vulkan::StaticShaderId::gather_mm_nvfp4_f32_n32
+                   : vulkan::StaticShaderId::gather_mm_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -238,18 +257,6 @@ std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_shader_id(
   }
   if (x_dtype == float32 && out_dtype == float32) {
     return vulkan::StaticShaderId::gather_mv_nvfp4_f32;
-  }
-  return std::nullopt;
-}
-
-std::optional<vulkan::StaticShaderId> gather_nvfp4_matmul_shader_id(
-    Dtype x_dtype,
-    Dtype out_dtype) {
-  if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return vulkan::StaticShaderId::gather_mm_nvfp4_bf16_bf16;
-  }
-  if (x_dtype == float32 && out_dtype == float32) {
-    return vulkan::StaticShaderId::gather_mm_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -2154,17 +2161,20 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
         (compute_dtype == bfloat16) ? bfloat16 : float32;
     auto matvec_id =
         nvfp4_dense_matvec_shader_id(compute_dtype, out_compute_dtype);
-    auto matmul_id =
-        nvfp4_dense_matmul_shader_id(compute_dtype, out_compute_dtype);
-    if (matvec_id.has_value() && matmul_id.has_value() &&
-        scales_nv.ndim() == 2 && is_row_contiguous_zero_offset(x_work) &&
+    if (matvec_id.has_value() && scales_nv.ndim() == 2 &&
+        is_row_contiguous_zero_offset(x_work) &&
         is_row_contiguous_zero_offset(w) &&
         is_row_contiguous_zero_offset(scales_nv)) {
       const uint32_t rows = static_cast<uint32_t>(x_work.shape(-2));
       const uint32_t cols = static_cast<uint32_t>(w.shape(-2));
       const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
       const uint32_t num_groups = static_cast<uint32_t>(scales_nv.shape(-1));
-      if (cols == static_cast<uint32_t>(out.shape(-1)) &&
+      const bool use_matvec = rows <= 8 || decode_lhs || rows == 1;
+      const bool large_n = !use_matvec && cols >= 1024u;
+      auto matmul_id = nvfp4_dense_matmul_shader_id(
+          compute_dtype, out_compute_dtype, large_n);
+      if (matmul_id.has_value() &&
+          cols == static_cast<uint32_t>(out.shape(-1)) &&
           static_cast<uint32_t>(w.shape(-1) * 8) == k &&
           num_groups ==
               static_cast<uint32_t>((k + group_size_ - 1) / group_size_)) {
@@ -2176,7 +2186,6 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
             nullptr,
             {});
         out_work.set_data(allocator::malloc(out_work.nbytes()));
-        const bool use_matvec = rows <= 8 || decode_lhs || rows == 1;
         if (out_work.size() != 0) {
           vulkan::Nvfp4DenseMatmulPushConstants push_constants{};
           push_constants.rows = rows;
@@ -2194,10 +2203,11 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           push_constants.num_groups = num_groups;
 
           const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
+          const uint32_t bn = large_n ? 32u : 16u;
           const std::array<uint32_t, 3> grid = use_matvec
               ? std::array<uint32_t, 3>{cols, rows, 1u}
               : std::array<uint32_t, 3>{
-                    (cols + 15u) / 16u, (rows + 15u) / 16u, 1u};
+                    (cols + bn - 1u) / bn, (rows + 31u) / 32u, 1u};
           if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
             throw std::runtime_error(
                 "[QuantizedMatmul::eval_gpu] NVFP4 dense dispatch grid exceeds Vulkan limits.");
@@ -2742,13 +2752,15 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         (compute_dtype == bfloat16) ? bfloat16 : float32;
     auto matvec_id =
         gather_nvfp4_matvec_shader_id(compute_dtype, out_compute_dtype);
-    auto matmul_id =
-        gather_nvfp4_matmul_shader_id(compute_dtype, out_compute_dtype);
     const uint32_t batches = static_cast<uint32_t>(lhs_indices.size());
     const uint32_t rows = static_cast<uint32_t>(out.shape(-2));
     const uint32_t cols = static_cast<uint32_t>(out.shape(-1));
     const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
     const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
+    const bool use_matvec = rows <= 8;
+    const bool large_n = !use_matvec && cols >= 1024u;
+    auto matmul_id = gather_nvfp4_matmul_shader_id(
+        compute_dtype, out_compute_dtype, large_n);
     const bool shapes_ok = matvec_id.has_value() && matmul_id.has_value() &&
         group_size_ == 16 && bits_ == 4 && w.dtype() == uint32 &&
         scales.dtype() == uint8 &&
@@ -2788,14 +2800,13 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         push_constants.group_size = static_cast<uint32_t>(group_size_);
         push_constants.num_groups = num_groups;
 
-        // Decode (rows<=8): one workgroup per output element with K-reduce.
-        // Prefill/larger rows: tiled gather_mm with shared X.
-        const bool use_matvec = rows <= 8;
+        // Decode (rows<=8): matvec. Prefill: tiled gather_mm BM=32.
         const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
+        const uint32_t bn = large_n ? 32u : 16u;
         const std::array<uint32_t, 3> grid = use_matvec
             ? std::array<uint32_t, 3>{cols, rows, batches}
             : std::array<uint32_t, 3>{
-                  (cols + 15u) / 16u, (rows + 15u) / 16u, batches};
+                  (cols + bn - 1u) / bn, (rows + 31u) / 32u, batches};
         if (!dispatch_grid_within_limits(grid[0], grid[1], grid[2])) {
           throw std::runtime_error(
               "[GatherQMM::eval_gpu] NVFP4 gather dispatch grid exceeds Vulkan workgroup count limits.");

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -2816,9 +2816,14 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
             uint64_t{rows} * uint64_t{batches},
             uint64_t{std::numeric_limits<uint32_t>::max()}));
     const uint32_t mv_bn = nvfp4_matvec_bn(cols, mv_work_items);
+    // Guard zero matrix dims before batch/expert divides; empty gathers skip
+    // dispatch via out_work.size() != 0 below.
+    const auto x_matrix_elems = x_work.shape(-2) * x_work.shape(-1);
+    const auto w_matrix_elems = w.shape(-2) * w.shape(-1);
     const auto x_batch_count =
-        x_work.size() / (x_work.shape(-2) * x_work.shape(-1));
-    const auto expert_count = w.size() / (w.shape(-2) * w.shape(-1));
+        x_matrix_elems == 0 ? 0 : x_work.size() / x_matrix_elems;
+    const auto expert_count =
+        w_matrix_elems == 0 ? 0 : w.size() / w_matrix_elems;
     // Sorted MoE prefill: tile 2 batches so consecutive same-expert tokens
     // reuse dequantized W (BM=2 keeps register pressure low).
     constexpr uint32_t kRhsBm = 2u;

--- a/mlx/backend/vulkan/quantized.cpp
+++ b/mlx/backend/vulkan/quantized.cpp
@@ -206,17 +206,38 @@ bool fused_nvfp4_dense_qmm_enabled() {
   return enabled;
 }
 
+// Matvec column tile: 1 for decode (keep enough workgroups), 8/16 for
+// large-batch MoE prefill where X reuse dominates.
+uint32_t nvfp4_matvec_bn(uint32_t cols, uint32_t work_items) {
+  // work_items = rows * batches (gather) or rows (dense).
+  constexpr uint32_t kMultiColMinWorkItems = 256u;
+  if (work_items < kMultiColMinWorkItems) {
+    return 1u;
+  }
+  return cols >= 1024u ? 16u : 8u;
+}
+
 std::optional<vulkan::StaticShaderId> nvfp4_dense_matvec_shader_id(
     Dtype x_dtype,
     Dtype out_dtype,
-    bool wide_n) {
+    uint32_t bn) {
   if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return wide_n ? vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16_n16
-                  : vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16;
+    if (bn >= 16u) {
+      return vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16_n16;
+    }
+    if (bn >= 8u) {
+      return vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16_n8;
+    }
+    return vulkan::StaticShaderId::mul_mv_nvfp4_bf16_bf16;
   }
   if (x_dtype == float32 && out_dtype == float32) {
-    return wide_n ? vulkan::StaticShaderId::mul_mv_nvfp4_f32_n16
-                  : vulkan::StaticShaderId::mul_mv_nvfp4_f32;
+    if (bn >= 16u) {
+      return vulkan::StaticShaderId::mul_mv_nvfp4_f32_n16;
+    }
+    if (bn >= 8u) {
+      return vulkan::StaticShaderId::mul_mv_nvfp4_f32_n8;
+    }
+    return vulkan::StaticShaderId::mul_mv_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -255,14 +276,24 @@ std::optional<vulkan::StaticShaderId> gather_nvfp4_matmul_shader_id(
 std::optional<vulkan::StaticShaderId> gather_nvfp4_matvec_shader_id(
     Dtype x_dtype,
     Dtype out_dtype,
-    bool wide_n) {
+    uint32_t bn) {
   if (x_dtype == bfloat16 && out_dtype == bfloat16) {
-    return wide_n ? vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16_n16
-                  : vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16;
+    if (bn >= 16u) {
+      return vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16_n16;
+    }
+    if (bn >= 8u) {
+      return vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16_n8;
+    }
+    return vulkan::StaticShaderId::gather_mv_nvfp4_bf16_bf16;
   }
   if (x_dtype == float32 && out_dtype == float32) {
-    return wide_n ? vulkan::StaticShaderId::gather_mv_nvfp4_f32_n16
-                  : vulkan::StaticShaderId::gather_mv_nvfp4_f32;
+    if (bn >= 16u) {
+      return vulkan::StaticShaderId::gather_mv_nvfp4_f32_n16;
+    }
+    if (bn >= 8u) {
+      return vulkan::StaticShaderId::gather_mv_nvfp4_f32_n8;
+    }
+    return vulkan::StaticShaderId::gather_mv_nvfp4_f32;
   }
   return std::nullopt;
 }
@@ -2173,10 +2204,10 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
       const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
       const uint32_t num_groups = static_cast<uint32_t>(scales_nv.shape(-1));
       const bool use_matvec = rows <= 8 || decode_lhs || rows == 1;
-      const bool wide_n = cols >= 1024u;
-      const bool large_n = !use_matvec && wide_n;
-      auto matvec_id = nvfp4_dense_matvec_shader_id(
-          compute_dtype, out_compute_dtype, wide_n);
+      const bool large_n = !use_matvec && cols >= 1024u;
+      const uint32_t mv_bn = nvfp4_matvec_bn(cols, rows);
+      auto matvec_id =
+          nvfp4_dense_matvec_shader_id(compute_dtype, out_compute_dtype, mv_bn);
       auto matmul_id = nvfp4_dense_matmul_shader_id(
           compute_dtype, out_compute_dtype, large_n);
       if (matvec_id.has_value() && matmul_id.has_value() &&
@@ -2209,7 +2240,6 @@ void QuantizedMatmul::eval_gpu(const std::vector<array>& inputs, array& out) {
           push_constants.num_groups = num_groups;
 
           const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
-          const uint32_t mv_bn = wide_n ? 16u : 8u;
           const uint32_t mm_bn = large_n ? 32u : 16u;
           const std::array<uint32_t, 3> grid = use_matvec
               ? std::array<uint32_t, 3>{
@@ -2764,10 +2794,14 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
     const uint32_t k = static_cast<uint32_t>(x_work.shape(-1));
     const uint32_t num_groups = static_cast<uint32_t>(scales.shape(-1));
     const bool use_matvec = rows <= 8;
-    const bool wide_n = cols >= 1024u;
-    const bool large_n = !use_matvec && wide_n;
-    auto matvec_id = gather_nvfp4_matvec_shader_id(
-        compute_dtype, out_compute_dtype, wide_n);
+    const bool large_n = !use_matvec && cols >= 1024u;
+    const uint32_t mv_work_items =
+        static_cast<uint32_t>(std::min<uint64_t>(
+            uint64_t{rows} * uint64_t{batches},
+            uint64_t{std::numeric_limits<uint32_t>::max()}));
+    const uint32_t mv_bn = nvfp4_matvec_bn(cols, mv_work_items);
+    auto matvec_id =
+        gather_nvfp4_matvec_shader_id(compute_dtype, out_compute_dtype, mv_bn);
     auto matmul_id = gather_nvfp4_matmul_shader_id(
         compute_dtype, out_compute_dtype, large_n);
     const bool shapes_ok = matvec_id.has_value() && matmul_id.has_value() &&
@@ -2809,9 +2843,9 @@ void GatherQMM::eval_gpu(const std::vector<array>& inputs, array& out) {
         push_constants.group_size = static_cast<uint32_t>(group_size_);
         push_constants.num_groups = num_groups;
 
-        // Decode/prefill MoE: multi-col matvec (rows<=8). Prefill mm: BM=32.
+        // Decode: BN=1 keeps enough workgroups. Prefill MoE: multi-col.
+        // Prefill mm: BM=32 tiled gather.
         const auto shader_id = use_matvec ? *matvec_id : *matmul_id;
-        const uint32_t mv_bn = wide_n ? 16u : 8u;
         const uint32_t mm_bn = large_n ? 32u : 16u;
         const std::array<uint32_t, 3> grid = use_matvec
             ? std::array<uint32_t, 3>{


### PR DESCRIPTION
## Summary

This PR adds NVFP4 (FP4 with per-block scaling) support to the MLX Vulkan backend, enabling low-precision inference for MoE models and dense workloads.

### Commits

- `7f13bcb0d` Fuse NVFP4 GatherQMM and spill UMA allocs to host heap
- `4d097072d` Add NVFP4 gather matvec for MoE decode
- `965bc22f9` Add dense NVFP4 matvec/mm with bf16 activations
- `247199ac0` Speed up NVFP4 prefill with register-blocked tiles
- `a49476589` Multi-column NVFP4 matvec for MoE prefill
- `1e9f56b6a` Use BN=1 NVFP4 matvec for small-batch decode
- `fb87d525b` Speed up NVFP4 matvec with pack-16 K stepping
- `a8e04f09e` Reuse NVFP4 weights across sorted MoE pairs

### Benchmark Results

#### bf16 (Qwen3-0.6B-bf16)

| Metric | Value |
|--------|-------|
| Prompt TPS | 4200.503 |
| Generation TPS | 67.661 |
| Peak Memory (GB) | 2.262 |

#### 8bit (Qwen3-0.6B-8bit)

| Metric | Value |
|--------|-------|
| Prompt TPS | 4215.483 |
| Generation TPS | 118.662 |
| Peak Memory (GB) | 2.001 |