### PR TITLE
fix(vulkan): recognize Mesa honeykrisp Apple GPUs via device-name fallback

### DIFF
--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -82,8 +82,12 @@ device_info(int device_index) {
         vendor_name = "Qualcomm";
         break;
       default:
-        vendor_name =
-            "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        if (device_name.find("Apple") != std::string::npos) {
+          vendor_name = "Apple";
+        } else {
+          vendor_name =
+              "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        }
         break;
     }
 

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -218,6 +218,10 @@ GpuArchitecture classify_gpu_architecture(
     case 0x5143u:
       return GpuArchitecture::Qualcomm;
     default:
+      if (device_name_contains(device_name, "Apple")) {
+        // Mesa honeykrisp reports a non-PCI vendorID on Apple Silicon.
+        return GpuArchitecture::Apple;
+      }
       return GpuArchitecture::Unknown;
   }
 }


### PR DESCRIPTION
# fix(vulkan): recognize Mesa honeykrisp Apple GPUs via device-name fallback

## Problem

Mesa's **honeykrisp** driver (the open-source Vulkan driver for Apple Silicon on Asahi Linux) reports its own driver vendor ID (`0x10005` = 65541) instead of Apple's PCI vendor ID (`0x106B`) — the standard Mesa convention:

```
$ vulkaninfo --summary
GPU id = 0 (Apple M1 Pro (G13S C0))
```
```python
>>> mx.device_info()["vendor_name"]
'Unknown (65541)'
```

Consequences in this backend:

1. `classify_gpu_architecture()` falls through to `GpuArchitecture::Unknown`, so **every Apple-specific code path is silently bypassed** — most importantly the `GpuArchitecture::Apple` arm of the matmul tile-configuration selection in `matmul.cpp`.
2. `device_info()` reports `vendor_name: Unknown (65541)` instead of `Apple`.
3. All future Apple-tuned heuristics (workgroup sizing, flash-attention configs, conv shmem padding) would be unreachable on exactly the hardware they target.

Measured impact of the misclassification on this machine: **Qwen3-0.6B-bf16 generation ran at 22.2 tok/s before the fix, 37.6 tok/s after (+69%)** — solely from activating the existing `GpuArchitecture::Apple` matmul tile config.

## Change

Two minimal fallbacks keyed on the device name (honeykrisp always exposes names like `"Apple M1 Pro (G13S C0)"`):

- `vulkan.cpp` / `classify_gpu_architecture()`: in the `default:` switch arm, return `GpuArchitecture::Apple` when the device name contains `"Apple"`. The explicit `case 0x106Bu:` is kept for drivers that do report the PCI ID.
- `device_info.cpp`: same name-based fallback for the human-readable `vendor_name`.

No behavior change for AMD/NVIDIA/Intel/Qualcomm or for any driver that reports a standard vendorID; the fallback only fires where classification previously degraded to `Unknown`.

## Hardware validation environment

First-class Apple Silicon data point for this backend:

| | |
|---|---|
| SoC | Apple M1 Pro (t6000, j316s), 10 CPU cores, 32 GB unified memory |
| OS | Asahi Linux — Fedora 44, kernel 7.1.5-400.asahi.fc44.aarch64 |
| Vulkan driver | Mesa honeykrisp 26.1.5 (`asahi_icd.aarch64.json`), loader 1.4.341 |
| Exposed | Vulkan 1.3 conformant · timeline semaphores ✓ · bufferDeviceAddress ✓ · shaderInt8 ✓ · subgroupSizeControl ✓ · shaderFloatControls2 ✓ · `VK_KHR_shader_integer_dot_product` ✓ · `VK_EXT_pipeline_robustness` ✓ · subgroup size 32, clustered subgroups ✓ · unified memory detected (`is_unified_memory = true`), 16.6 GB GPU-visible heap |
| **Not exposed** | **`VK_KHR_cooperative_matrix` ✗** · **`VK_NV_cooperative_matrix2` ✗** · `VK_KHR_shader_bfloat16` ✗ |

Notes:
- The bf16 runtime capability probe correctly detects the missing bfloat16 extension and falls back (`MLX_VULKAN_DEBUG_CAPS=1`: `extension_present=0 ... runtime_probe_supported=1`). All bf16 model tests still pass via the fallback storage/conversion paths.
- With no cooperative matrix on this driver, matmul dispatches scalar kernels (`matmul_direct_{f16,bf16}_aligned_f16acc`; verified via `MLX_VULKAN_MATMUL_DEBUG=1`). This is the dominant limiter on prefill throughput today and frames the follow-up work below.

Build environment: Fedora-packaged glslc/shaderc 2026.1 (SPIR-V 1.0 target); the GLSL feature-tests that pass at configure time test the *shader compiler*, not the device: `GL_EXT_integer_dot_product` and `GL_EXT_bfloat16` compile fine, while coopmat shaders are never selected at runtime on this device.

## Results

### Misclassification impact (short-context generate, Qwen3-0.6B-bf16)

| | generation TPS | peak memory |
|---|---:|---:|
| before fix (`Unknown` arch) | 22.211 | 1.226 GB |
| after fix (`Apple` arch) | **37.649 (+69%)** | 1.225 GB |

### Full benchmark, `./dev.sh benchmark`, M1 Pro / honeykrisp (5 trials, avg)

| Model | Bits | Prompt TPS | Generation TPS | Peak memory (GB) |
| --- | --- | ---: | ---: | ---: |
| mlx-community/Qwen3-0.6B-bf16 | bf16 | 285.934 | 24.395 | 2.092 |
| mlx-community/Qwen3-0.6B-8bit | 8bit | 285.182 | 30.235 | 1.628 |

Generation smoke test produces fully coherent output (Qwen3-0.6B-bf16 and -8bit).

### Reference: CI Strix Halo (AMD Radeon 8060S) from `benchmarks/results.csv`

| Model | Bits | Prompt TPS | Generation TPS | Peak memory (GB) |
| --- | --- | ---: | ---: | ---: |
| mlx-community/Qwen3-0.6B-bf16 | bf16 | 4126.137 | 67.986 | 2.262 |
| mlx-community/Qwen3-0.6B-8bit | 8bit | 4172.886 | 121.145 | 2.001 |

The prompt-TPS delta vs Strix Halo has a clear structural cause: RDNA3 exposes `VK_KHR_cooperative_matrix`, so Strix runs the coopmat GEMM family, while honeykrisp does not expose it and every GEMM takes the scalar `mul_mm` path. Closing that gap on Apple Silicon requires either hand-tuned scalar kernels for AGX or upstream honeykrisp gaining cooperative-matrix support; neither is attempted in this PR.

## Verification steps

On an Asahi Linux machine with honeykrisp:

```bash
git submodule update --init mlx mlx-lm
./dev.sh init-venv && ./dev.sh build
./dev.sh run python -c "import mlx.core as mx; print(mx.device_info()['vendor_name'])"
# -> Apple   (previously 'Unknown (65541)')
./dev.sh generate          # coherent output
./dev.sh benchmark bf16    # numbers above
./dev.sh benchmark 8bit
```

On non-Apple platforms nothing changes: the fallback only triggers when the vendorID is unrecognized *and* the device name contains `Apple`.

## Notes for reviewers

- honeykrisp reports `subgroup_min_size`/`subgroup_max_size` as 0 despite advertising `subgroupSizeControl`; the generic workgroup-size default (`min(32, subgroup_size)`) happens to be correct for Apple's fixed 32-lane subgroups, so no change is needed there yet.
- Follow-up work now unblocked by correct classification, in rough impact order:
  1. Scalar `mul_mm` tuning for AGX (tile shapes / specialization constants in the `GpuArchitecture::Apple` arm) — biggest lever while coopmat is absent.
  2. Flash-attention tuning arms for Apple in `fast.cpp` (currently Intel/AMD/NVIDIA-only branches).
  3. Exploit `VK_KHR_shader_integer_dot_product` (present on honeykrisp) for quantized GEMV/GEMM decode paths.
  4. Conv shmem-padding config for Apple in `conv.cpp`.
