### PR TITLE
perf(vulkan): tune scalar mul_mm tiles for Apple AGX (BK=4, TM=4)

### DIFF
--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -82,8 +82,12 @@ device_info(int device_index) {
         vendor_name = "Qualcomm";
         break;
       default:
-        vendor_name =
-            "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        if (device_name.find("Apple") != std::string::npos) {
+          vendor_name = "Apple";
+        } else {
+          vendor_name =
+              "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        }
         break;
     }
 

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -346,6 +346,13 @@ constexpr std::array<uint32_t, 11> kSafeMatmulSpec =
 constexpr std::array<uint32_t, 11> kLane64MatmulSpec =
     {64, 32, 32, 16, 32, 32, 2, 2, 2, 1, 64};
 
+// Apple AGX (M-series via Mesa honeykrisp): scalar mul_mm prefers a shallow
+// K slab (BK=4) with a 4-row thread tile for occupancy. Measured on M1 Pro
+// Qwen3-0.6B prefill shapes: 1117 GFLOPS avg vs 627 for kSafeMatmulSpec
+// (+78%). BK<=2 is numerically broken in the scalar shader (rel err ~400).
+constexpr std::array<uint32_t, 11> kAppleMatmulSpec =
+    {32, 32, 32, 4, 32, 32, 2, 4, 2, 1, 32};
+
 // Cooperative-matrix warptiles (TM/TN/TK must match 16x16x16 subgroup mats).
 // On Strix Halo / RDNA3.5 the llama.cpp "large" 128x128/256-thread tile is
 // ~10x slower than this medium tile for dense F16 GEMMs; keep one known-good
@@ -626,7 +633,6 @@ MatmulProfile matmul_profile_for_device() {
             {kSafeMatmulSpec, 4096}}},
       };
     case vulkan::GpuArchitecture::Intel:
-    case vulkan::GpuArchitecture::Apple:
     case vulkan::GpuArchitecture::Qualcomm:
       return {
           32,
@@ -636,6 +642,16 @@ MatmulProfile matmul_profile_for_device() {
           {{{kSafeMatmulSpec, 512},
             {kSafeMatmulSpec, 1024},
             {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::Apple:
+      return {
+          32,
+          {{{kAppleMatmulSpec, 768},
+            {kAppleMatmulSpec, 1536},
+            {kAppleMatmulSpec, 3072}}},
+          {{{kAppleMatmulSpec, 512},
+            {kAppleMatmulSpec, 1024},
+            {kAppleMatmulSpec, 2048}}},
       };
     case vulkan::GpuArchitecture::AmdCdna:
     case vulkan::GpuArchitecture::Unknown:

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -218,6 +218,10 @@ GpuArchitecture classify_gpu_architecture(
     case 0x5143u:
       return GpuArchitecture::Qualcomm;
     default:
+      if (device_name_contains(device_name, "Apple")) {
+        // Mesa honeykrisp reports a non-PCI vendorID on Apple Silicon.
+        return GpuArchitecture::Apple;
+      }
       return GpuArchitecture::Unknown;
   }
 }


### PR DESCRIPTION
# perf(vulkan): tune scalar mul_mm tiles for Apple AGX (BK=4, TM=4)

**Stacked on #69** — that PR makes `GpuArchitecture::Apple` classification work on Mesa honeykrisp (vendorID `0x10005` ≠ PCI `0x106B`), which is a prerequisite for this arm to ever execute. Tracking issue: goniz/mlx-vulkan#70.

## Why

honeykrisp exposes **no cooperative matrix** (`VK_KHR_cooperative_matrix` / `VK_NV_cooperative_matrix2` absent; verified per-device in `vulkaninfo` and at runtime via capability instrumentation). Every GEMM on Apple Silicon therefore runs the scalar `mul_mm` path — previously with the generic `kSafeMatmulSpec` (`BK=16, TM/TN=2`) shared with Intel/Qualcomm.

## What changed

New `kAppleMatmulSpec` used by the `GpuArchitecture::Apple` arm of `matmul_profile_for_device()`:

```
{BLOCK=32, BM=32, BN=32, BK=4, WM=32, WN=32, WMITER=2, TM=4, TN=2, TK=1, WARP=32}
```

Rationale: AGX favors shallow K slabs (higher occupancy from smaller shared-memory stages) and a 4-row thread tile. fp32-accum family thresholds are unchanged from the generic profile.

## How it was measured

No-rebuild sweep via `MLX_VULKAN_MATMUL_SPEC`, 21 configurations, each gated on numerics (max rel err vs f32 reference < 0.02) over four Qwen3-0.6B prefill shapes (M=4096; K×N = 1024×2048, 1024×1024, 1024×3072, 3072×1024), 7 timed reps each:

| config | avg GFLOPS | numerics |
|---|---:|---|
| baseline `{16,32,32,...}` | 630 | OK |
| BK=32 | 333 | OK |
| BK=8 | 1001 | OK |
| **BK=4, TM=4** | **1117** | **OK** |
| BK=4, TM=4, TN=4 | 1109 | OK |
| BK=2 | 1677 | **BAD (rel err ~400)** |
| BM=64 variants | 548–706 | **BAD (rel err ~1)** |

Two shader-correctness boundaries surfaced by the sweep (worth separate follow-up): the scalar shader produces wrong results for **BK ≤ 2** and for **BM=64 / BLOCK_SIZE ≠ 32** combos. Evidence recorded in goniz/mlx-vulkan#70; not touched here.

## End-to-end results (M1 Pro, Asahi Fedora 44, mesa honeykrisp 26.1.5)

### This PR's effect — `./dev.sh benchmark` (5-trial avg)

| Model | Bits | Prompt TPS before → after | Generation TPS before → after | Peak mem |
| --- | --- | ---: | ---: | ---: |
| Qwen3-0.6B-bf16 | bf16 | 285.9 → **372.2 (+30%)** | 24.4 → 24.2 | 2.09 → 2.06 GB |
| Qwen3-0.6B-8bit | 8bit | 285.2 → **370.6 (+30%)** | 30.2 → 30.5 | 1.63 GB |

Generation is flat by design: decode is memory-bandwidth-bound through the matvec path, untouched by these tiles. Coherent-output smoke test passes for both quants.

### Cumulative vs Strix Halo CI reference (same benchmark harness)

| Model | Bits | Prompt TPS | Generation TPS |
| --- | --- | ---: | ---: |
| M1 Pro (this branch) | bf16 | 372.2 | 24.2 |
| Strix Halo 8060S | bf16 | 4126.1 | 68.0 |

Prefill remains coopmat-limited on this driver; the remaining levers are listed in goniz/mlx-vulkan#70 (fast-attn arms, integer-dot-product quantized decode, conv shmem config).

## Verification steps

```bash
git submodule update --init mlx mlx-lm   # with #69 applied to mlx
./dev.sh init-venv && ./dev.sh build
./dev.sh run python -c "
import mlx.core as mx
mx.set_default_device(mx.gpu)
a = mx.random.normal((4096,1024)).astype(mx.bfloat16)
b = mx.random.normal((2048,1024)).astype(mx.bfloat16)
import time
mx.eval(a@b.T)
t=time.perf_counter(); o=a@b.T; mx.eval(o); mx.synchronize()
print(f'{2*4096*2048*1024/(time.perf_counter()-t)/1e9:.0f} GFLOPS')"
# ~1150+ GFLOPS with this PR, ~650 without
./dev.sh generate && ./dev.sh benchmark bf16 && ./dev.sh benchmark 8bit
```

Non-Apple platforms are unaffected: only the `GpuArchitecture::Apple` case changed.
