### PR TITLE
perf(vulkan): tune scalar flash-attention params for Apple AGX

### DIFF
--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -82,8 +82,12 @@ device_info(int device_index) {
         vendor_name = "Qualcomm";
         break;
       default:
-        vendor_name =
-            "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        if (device_name.find("Apple") != std::string::npos) {
+          vendor_name = "Apple";
+        } else {
+          vendor_name =
+              "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        }
         break;
     }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -788,6 +788,39 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
     result.block_rows = std::max(result.block_rows / 2u, 1u);
   }
 
+
+  if (architecture == vulkan::GpuArchitecture::Apple) {
+    // M1 Pro / honeykrisp measurements (Qwen3-0.6B FA shape Hq=16, Hkv=8,
+    // D in {64,128}, S <= 4096): d_split 4 beats 8 by ~65-70% TFLOPS, and
+    // block_rows 12 beats 8 by ~10% when there are enough query rows.
+    // The scalar kernel is numerically correct only for block_rows that
+    // are multiples of 4 (6/10/14 produce garbage); d_split values other
+    // than powers of two are also slow.
+    if (result.d_split > 4u) {
+      result.d_split = 4u;
+    }
+    if (result.row_split != 1u && n_rows >= 12u &&
+        result.block_rows == 8u) {
+      result.block_rows = 12u;
+    }
+  }
+  if (const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_PARAMS")) {
+    std::istringstream iss(env);
+    std::string item;
+    uint32_t vals[5];
+    int idx = 0;
+    while (idx < 5 && std::getline(iss, item, ',')) {
+      vals[idx++] = static_cast<uint32_t>(std::stoul(item));
+    }
+    if (idx == 5) {
+      result.block_rows = vals[0];
+      result.block_cols = vals[1];
+      result.row_split = vals[2];
+      result.workgroup_size = vals[3];
+      result.d_split = vals[4];
+    }
+  }
+
   return result;
 }
 

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -346,6 +346,13 @@ constexpr std::array<uint32_t, 11> kSafeMatmulSpec =
 constexpr std::array<uint32_t, 11> kLane64MatmulSpec =
     {64, 32, 32, 16, 32, 32, 2, 2, 2, 1, 64};
 
+// Apple AGX (M-series via Mesa honeykrisp): scalar mul_mm prefers a shallow
+// K slab (BK=4) with a 4-row thread tile for occupancy. Measured on M1 Pro
+// Qwen3-0.6B prefill shapes: 1117 GFLOPS avg vs 627 for kSafeMatmulSpec
+// (+78%). BK<=2 is numerically broken in the scalar shader (rel err ~400).
+constexpr std::array<uint32_t, 11> kAppleMatmulSpec =
+    {32, 32, 32, 4, 32, 32, 2, 4, 2, 1, 32};
+
 // Cooperative-matrix warptiles (TM/TN/TK must match 16x16x16 subgroup mats).
 // On Strix Halo / RDNA3.5 the llama.cpp "large" 128x128/256-thread tile is
 // ~10x slower than this medium tile for dense F16 GEMMs; keep one known-good
@@ -626,7 +633,6 @@ MatmulProfile matmul_profile_for_device() {
             {kSafeMatmulSpec, 4096}}},
       };
     case vulkan::GpuArchitecture::Intel:
-    case vulkan::GpuArchitecture::Apple:
     case vulkan::GpuArchitecture::Qualcomm:
       return {
           32,
@@ -636,6 +642,16 @@ MatmulProfile matmul_profile_for_device() {
           {{{kSafeMatmulSpec, 512},
             {kSafeMatmulSpec, 1024},
             {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::Apple:
+      return {
+          32,
+          {{{kAppleMatmulSpec, 768},
+            {kAppleMatmulSpec, 1536},
+            {kAppleMatmulSpec, 3072}}},
+          {{{kAppleMatmulSpec, 512},
+            {kAppleMatmulSpec, 1024},
+            {kAppleMatmulSpec, 2048}}},
       };
     case vulkan::GpuArchitecture::AmdCdna:
     case vulkan::GpuArchitecture::Unknown:

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -218,6 +218,10 @@ GpuArchitecture classify_gpu_architecture(
     case 0x5143u:
       return GpuArchitecture::Qualcomm;
     default:
+      if (device_name_contains(device_name, "Apple")) {
+        // Mesa honeykrisp reports a non-PCI vendorID on Apple Silicon.
+        return GpuArchitecture::Apple;
+      }
       return GpuArchitecture::Unknown;
   }
 }


### PR DESCRIPTION
# perf(vulkan): tune scalar flash-attention params for Apple AGX

**Stacked on #69 (Apple device classification) and #70 (AGX matmul tiles).** Tracking issue: goniz/mlx-vulkan#70.

## Why

honeykrisp exposes no cooperative matrix, so SDPA on Apple Silicon runs the scalar flash-attention path with generic heuristics. Profiling showed attention is the dominant prefill cost on this hardware: a single Qwen3-0.6B layer's FA at S=4096 takes ~365 ms while all its GEMMs together take ~22 ms — attention is ~90% of prefill time. After the matmul tuning in #70, this is the next bottleneck.

## What changed

`get_flash_attention_tuning_params_scalar()` gains an Apple arm:

1. `d_split` clamped to ≤ 4 (generic formula picks 8 for D ∈ {64, 128}).
2. `block_rows` 8 → 12 when `row_split != 1 && n_rows >= 12`.

Also adds `MLX_VULKAN_FLASH_ATTN_PARAMS=br,bc,rs,wg,ds`, a no-rebuild debug override mirroring `MLX_VULKAN_MATMUL_SPEC`, which is what enabled the sweep below.

## Sweep evidence

M1 Pro, Hq=16 / Hkv=8 (Qwen3-0.6B), bf16, 7 reps, gated on max rel err vs composed f32 reference < 0.05.

### S = 4096, D = 128

| br | bc | rs | wg | ds | TFLOPS | numerics |
|---:|---:|---:|---:|---:|---:|---|
| 8 | 32 | 4 | 128 | 8 | 0.20 | OK (baseline) |
| 8 | 32 | 4 | 128 | **4** | **0.34** | OK |
| 8 | 32 | 1 | 128 | 8 | 0.26 | OK |
| 8 | 32 | 1 | 128 | 4 | 0.10 | OK (bad interaction) |
| 12 | 32 | 4 | 128 | 4 | **0.37** | OK |
| 10 / 14 | 32 | 4 | 128 | 4 | 0.40–0.43 | **BAD (rel err ~2·10⁷)** |
| 6 | 32 | 4 | 128 | 4 | 0.34 | **BAD** |
| any | any | any | **64 or 256** | any | — | **BAD** |

Correctness boundaries discovered (worth separate follow-up fixes): scalar FA kernel produces garbage for `block_rows % 4 != 0`, and only `workgroup_size == subgroup_size * 4` is correct on this driver. `d_split` non-powers-of-two are legal but slow (0.10T).

### D = 64 cross-check

Same ordering holds: ds=8→4 gives 0.20 → 0.33 TFLOPS; br=12 tops out at 0.35.

## End-to-end (`./dev.sh benchmark`, 5-trial avg, M1 Pro)

| Model | Bits | Prompt TPS | Generation TPS | Peak mem |
| --- | --- | ---: | ---: | ---: |
| Qwen3-0.6B-bf16 | bf16 | 363.1 / 366.5ᵇ | **26.2 / 26.4** (+8–9% vs 24.2) | 2.06 GB |
| Qwen3-0.6B-8bit | 8bit | 361.8 | **32.8** (+8% vs 30.5) | 1.66 GB |

ᵇ two independent runs; prompt reads ~2% below the #70 run (372.2) — borderline against cross-run variance, reported as-is. Generation improvement reproduces across both runs and both quants. Coherent-output smoke test passes.

Microbenchmark without env override after baking: 0.30–0.32 TFLOPS at S∈{1024,4096}, D∈{64,128} (baseline 0.18–0.20).

## Verification

```bash
git submodule update --init mlx mlx-lm   # with #69 + #70 applied
./dev.sh init-venv && ./dev.sh build
./dev.sh run python -c "
import mlx.core as mx, time
mx.set_default_device(mx.gpu)
q = mx.random.normal((1,16,4096,128)).astype(mx.bfloat16)
k = mx.random.normal((1,8,4096,128)).astype(mx.bfloat16)
v = mx.random.normal((1,8,4096,128)).astype(mx.bfloat16)
mx.eval(mx.fast.scaled_dot_product_attention(q,k,v,scale=128**-0.5))
t=time.perf_counter()
o = mx.fast.scaled_dot_product_attention(q,k,v,scale=128**-0.5)
mx.eval(o); mx.synchronize()
print(f'{2*16*4096*4096*128/(time.perf_counter()-t)/1e12:.2f} TFLOPS')"
# ~0.3 with this PR, ~0.2 without
./dev.sh generate && ./dev.sh benchmark bf16 && ./dev.sh benchmark 8bit
```

Non-Apple platforms unaffected: only the Apple arm of the scalar heuristic changed.
