### PR TITLE
perf(vulkan): default long decode recordings on Apple AGX

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -217,15 +217,25 @@ bool trace_sync_enabled() {
   return enabled;
 }
 
+namespace {
+// Decode-batching default for devices where long recordings measurably win
+// (Mesa honeykrisp: high per-submit cost). Set once from VulkanContext init.
+std::atomic<bool> s_decode_batch_default{false};
+} // namespace
+
 bool decode_batch_enabled() {
-  static const bool enabled = []() {
+  // Env tri-state: unset -> device default; "0" -> force off; other -> on.
+  static const int env_mode = []() {
     if (const char* env = std::getenv("MLX_VULKAN_DECODE_BATCH");
         env != nullptr) {
-      return std::string(env) != "0";
+      return std::string(env) != "0" ? 1 : -1;
     }
-    return false;
+    return 0;
   }();
-  return enabled;
+  if (env_mode != 0) {
+    return env_mode == 1;
+  }
+  return s_decode_batch_default.load(std::memory_order_relaxed);
 }
 
 uint32_t decode_max_recorded_ops() {
@@ -241,15 +251,16 @@ uint32_t decode_max_recorded_ops() {
 }
 
 uint64_t decode_max_total_bytes() {
-  static const uint64_t value = []() -> uint64_t {
-    if (const char* env = std::getenv("MLX_VULKAN_DECODE_MAX_TOTAL_BYTES");
-        env != nullptr) {
-      return std::max<uint64_t>(
-          1ull, static_cast<uint64_t>(std::strtoull(env, nullptr, 10)));
-    }
-    return 128ull << 20;
-  }();
-  return value;
+  if (const char* env = std::getenv("MLX_VULKAN_DECODE_MAX_TOTAL_BYTES");
+      env != nullptr) {
+    return std::max<uint64_t>(
+        1ull, static_cast<uint64_t>(std::strtoull(env, nullptr, 10)));
+  }
+  // Bounded budget when batching is enabled by default: keeps the submit
+  // reduction without the deferred-buffer memory growth measured on M1 Pro
+  // (+0.6-1.2 GB peak at the 128 MB budget).
+  return s_decode_batch_default.load(std::memory_order_relaxed) ? (32ull << 20)
+                                                                : (128ull << 20);
 }
 
 bool trace_batch_enabled() {
@@ -495,6 +506,10 @@ void ensure_host_readback_mirror(VulkanBuffer* buffer) {
 }
 
 } // namespace
+void set_decode_batch_default(bool enabled) {
+  s_decode_batch_default.store(enabled, std::memory_order_relaxed);
+}
+
 
 // Stream data structure for Vulkan
 struct BufferAccessRange {

--- a/mlx/backend/vulkan/device.h
+++ b/mlx/backend/vulkan/device.h
@@ -91,6 +91,7 @@ void end_primitive_tracking(
 void finalize_stream(Stream s);
 void synchronize_stream(Stream s);
 void set_force_immediate_submit(Stream s);
+void set_decode_batch_default(bool enabled);
 void synchronize_all();
 void synchronize_buffer_for_host_access(VulkanBuffer* buffer);
 

--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -82,8 +82,12 @@ device_info(int device_index) {
         vendor_name = "Qualcomm";
         break;
       default:
-        vendor_name =
-            "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        if (device_name.find("Apple") != std::string::npos) {
+          vendor_name = "Apple";
+        } else {
+          vendor_name =
+              "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        }
         break;
     }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -788,6 +788,39 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
     result.block_rows = std::max(result.block_rows / 2u, 1u);
   }
 
+
+  if (architecture == vulkan::GpuArchitecture::Apple) {
+    // M1 Pro / honeykrisp measurements (Qwen3-0.6B FA shape Hq=16, Hkv=8,
+    // D in {64,128}, S <= 4096): d_split 4 beats 8 by ~65-70% TFLOPS, and
+    // block_rows 12 beats 8 by ~10% when there are enough query rows.
+    // The scalar kernel is numerically correct only for block_rows that
+    // are multiples of 4 (6/10/14 produce garbage); d_split values other
+    // than powers of two are also slow.
+    if (result.d_split > 4u) {
+      result.d_split = 4u;
+    }
+    if (result.row_split != 1u && n_rows >= 12u &&
+        result.block_rows == 8u) {
+      result.block_rows = 12u;
+    }
+  }
+  if (const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_PARAMS")) {
+    std::istringstream iss(env);
+    std::string item;
+    uint32_t vals[5];
+    int idx = 0;
+    while (idx < 5 && std::getline(iss, item, ',')) {
+      vals[idx++] = static_cast<uint32_t>(std::stoul(item));
+    }
+    if (idx == 5) {
+      result.block_rows = vals[0];
+      result.block_cols = vals[1];
+      result.row_split = vals[2];
+      result.workgroup_size = vals[3];
+      result.d_split = vals[4];
+    }
+  }
+
   return result;
 }
 

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -346,6 +346,13 @@ constexpr std::array<uint32_t, 11> kSafeMatmulSpec =
 constexpr std::array<uint32_t, 11> kLane64MatmulSpec =
     {64, 32, 32, 16, 32, 32, 2, 2, 2, 1, 64};
 
+// Apple AGX (M-series via Mesa honeykrisp): scalar mul_mm prefers a shallow
+// K slab (BK=4) with a 4-row thread tile for occupancy. Measured on M1 Pro
+// Qwen3-0.6B prefill shapes: 1117 GFLOPS avg vs 627 for kSafeMatmulSpec
+// (+78%). BK<=2 is numerically broken in the scalar shader (rel err ~400).
+constexpr std::array<uint32_t, 11> kAppleMatmulSpec =
+    {32, 32, 32, 4, 32, 32, 2, 4, 2, 1, 32};
+
 // Cooperative-matrix warptiles (TM/TN/TK must match 16x16x16 subgroup mats).
 // On Strix Halo / RDNA3.5 the llama.cpp "large" 128x128/256-thread tile is
 // ~10x slower than this medium tile for dense F16 GEMMs; keep one known-good
@@ -626,7 +633,6 @@ MatmulProfile matmul_profile_for_device() {
             {kSafeMatmulSpec, 4096}}},
       };
     case vulkan::GpuArchitecture::Intel:
-    case vulkan::GpuArchitecture::Apple:
     case vulkan::GpuArchitecture::Qualcomm:
       return {
           32,
@@ -636,6 +642,16 @@ MatmulProfile matmul_profile_for_device() {
           {{{kSafeMatmulSpec, 512},
             {kSafeMatmulSpec, 1024},
             {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::Apple:
+      return {
+          32,
+          {{{kAppleMatmulSpec, 768},
+            {kAppleMatmulSpec, 1536},
+            {kAppleMatmulSpec, 3072}}},
+          {{{kAppleMatmulSpec, 512},
+            {kAppleMatmulSpec, 1024},
+            {kAppleMatmulSpec, 2048}}},
       };
     case vulkan::GpuArchitecture::AmdCdna:
     case vulkan::GpuArchitecture::Unknown:

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -218,6 +218,10 @@ GpuArchitecture classify_gpu_architecture(
     case 0x5143u:
       return GpuArchitecture::Qualcomm;
     default:
+      if (device_name_contains(device_name, "Apple")) {
+        // Mesa honeykrisp reports a non-PCI vendorID on Apple Silicon.
+        return GpuArchitecture::Apple;
+      }
       return GpuArchitecture::Unknown;
   }
 }

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -1105,6 +1105,19 @@ void VulkanContext::init() {
     this->device_id_ = device_id;
     this->architecture_ = architecture;
     this->shader_core_count_ = shader_core_count;
+    // Mesa honeykrisp has high per-submit cost: prefer long decode recordings
+    // on Apple GPUs (byte budget bounded in decode_max_total_bytes()).
+    set_decode_batch_default(architecture == vulkan::GpuArchitecture::Apple);
+    if (bf16_capability_debug_enabled()) {
+      std::cerr << "[vulkan::caps] ext_coopmat=" << has_cooperative_matrix_ext
+                << " feat_coopmat="
+                << supported_cooperative_matrix.cooperativeMatrix
+                << " coopmat=" << cooperative_matrix_supported_
+                << " f16acc=" << this->coopmat_f16acc_supported_
+                << " fa_f32acc="
+                << this->coopmat_flash_attention_f32acc_supported_
+                << " subgroup_full=" << subgroup_require_full_support << "\n";
+    }
     initialized_ = true;
   } catch (...) {
     // Clean up partially initialized resources on failure


### PR DESCRIPTION
# perf(vulkan): default long decode recordings on Apple AGX

**Stacked on #69 → #70 → #71.** Tracking issue: goniz/mlx-vulkan#70.

## Why

Decode on Apple Silicon is dominated by submission cadence, not kernels or bandwidth:

- Quantized GEMV kernels are already fast — `mul_mat_vecq.comp` uses `GL_EXT_integer_dot_product`, measuring ~2 µs hot / ~46 µs streamed per call (2048×1024 int8 g64).
- The bottleneck is `vkQueueSubmit` frequency: honeykrisp's per-submit cost is high, and a decode token issues many small recordings.
- The backend already has the right machinery (`should_prefer_long_decode_recording()`), but it was opt-in via `MLX_VULKAN_DECODE_BATCH`.

## What changed

1. **Apple-gated default**: when the device classifies as `GpuArchitecture::Apple`, decode batching is enabled without any env flag. Implemented via a small `set_decode_batch_default(bool)` hook (`device.h`) called once from `VulkanContext::init()` after architecture classification — no circular include.
2. **Bounded budget**: when enabled by default, the deferred-byte budget drops from 128 MB to 32 MB. This keeps the submit reduction while eliminating most of the deferred-buffer peak-memory growth measured at the larger budget.
3. **Env becomes a tri-state**: `MLX_VULKAN_DECODE_BATCH` unset → device default; `=0` → force off; other → force on.
4. Diagnostics: consolidated the `MLX_VULKAN_DEBUG_CAPS` capability dump into one line including cooperative-matrix flags (this instrumentation is what established that honeykrisp exposes no coopmat).

Non-Apple platforms are unchanged unless the env is set explicitly.

## Budget-cap sweep (short-context generate, Qwen3-0.6B-bf16)

| deferred budget | gen TPS | peak mem |
|---|---:|---:|
| 128 MB (old default) | 47.5 | 1.230 GB |
| 32 MB | 46.5 | 1.227 GB |
| 8 MB | 38.2 | 1.225 GB |
| 2 MB | 34.5 | 1.224 GB |

32 MB retains ~98% of the gain; chosen as the bounded default.

## End-to-end (`./dev.sh benchmark`, 4096-token prompt + 128 gen, 5-trial avg, M1 Pro, no env flags)

| Model | Bits | Gen TPS before → after | Prompt TPS | Peak mem before → after |
| --- | --- | ---: | ---: | ---: |
| Qwen3-0.6B-bf16 | bf16 | 26.3 → **32.0 (+22%)** | 362.7 (flat) | 2.06 → 2.12 GB |
| Qwen3-0.6B-8bit | 8bit | 32.8 → **35.0 (+7%)** | 362.2 (flat) | 1.66 → **1.62 GB** |

Generation coherence smoke test passes with defaults active. Forcing `MLX_VULKAN_DECODE_BATCH=0` reproduces the pre-PR baseline (38.6 t/s short-context vs 48.6 with the default), confirming attribution.

## Cumulative session state (M1 Pro / honeykrisp, this stack)

| Metric | session start* | now | Δ |
|---|---:|---:|---:|
| bf16 prompt TPS | 285.9 | 362.7 | +27% |
| bf16 generation TPS | 24.4 | 32.0 | +31% |
| 8bit generation TPS | 30.2 | 35.0 | +16% |

\* first measurement after #69 made the GPU recognizable at all.

## Verification

```bash
git submodule update --init mlx mlx-lm   # with #69..#71 applied
./dev.sh init-venv && ./dev.sh build
./dev.sh benchmark bf16 && ./dev.sh benchmark 8bit   # numbers above, no env needed
MLX_VULKAN_DECODE_BATCH=0 ./dev.sh generate          # opt-out still works
```
