### PR TITLE
fix(vulkan): reject tuning specs outside numerically validated envelopes

### DIFF
--- a/mlx/backend/vulkan/device.cpp
+++ b/mlx/backend/vulkan/device.cpp
@@ -217,15 +217,25 @@ bool trace_sync_enabled() {
   return enabled;
 }
 
+namespace {
+// Decode-batching default for devices where long recordings measurably win
+// (Mesa honeykrisp: high per-submit cost). Set once from VulkanContext init.
+std::atomic<bool> s_decode_batch_default{false};
+} // namespace
+
 bool decode_batch_enabled() {
-  static const bool enabled = []() {
+  // Env tri-state: unset -> device default; "0" -> force off; other -> on.
+  static const int env_mode = []() {
     if (const char* env = std::getenv("MLX_VULKAN_DECODE_BATCH");
         env != nullptr) {
-      return std::string(env) != "0";
+      return std::string(env) != "0" ? 1 : -1;
     }
-    return false;
+    return 0;
   }();
-  return enabled;
+  if (env_mode != 0) {
+    return env_mode == 1;
+  }
+  return s_decode_batch_default.load(std::memory_order_relaxed);
 }
 
 uint32_t decode_max_recorded_ops() {
@@ -241,15 +251,16 @@ uint32_t decode_max_recorded_ops() {
 }
 
 uint64_t decode_max_total_bytes() {
-  static const uint64_t value = []() -> uint64_t {
-    if (const char* env = std::getenv("MLX_VULKAN_DECODE_MAX_TOTAL_BYTES");
-        env != nullptr) {
-      return std::max<uint64_t>(
-          1ull, static_cast<uint64_t>(std::strtoull(env, nullptr, 10)));
-    }
-    return 128ull << 20;
-  }();
-  return value;
+  if (const char* env = std::getenv("MLX_VULKAN_DECODE_MAX_TOTAL_BYTES");
+      env != nullptr) {
+    return std::max<uint64_t>(
+        1ull, static_cast<uint64_t>(std::strtoull(env, nullptr, 10)));
+  }
+  // Bounded budget when batching is enabled by default: keeps the submit
+  // reduction without the deferred-buffer memory growth measured on M1 Pro
+  // (+0.6-1.2 GB peak at the 128 MB budget).
+  return s_decode_batch_default.load(std::memory_order_relaxed) ? (32ull << 20)
+                                                                : (128ull << 20);
 }
 
 bool trace_batch_enabled() {
@@ -495,6 +506,10 @@ void ensure_host_readback_mirror(VulkanBuffer* buffer) {
 }
 
 } // namespace
+void set_decode_batch_default(bool enabled) {
+  s_decode_batch_default.store(enabled, std::memory_order_relaxed);
+}
+
 
 // Stream data structure for Vulkan
 struct BufferAccessRange {

--- a/mlx/backend/vulkan/device.h
+++ b/mlx/backend/vulkan/device.h
@@ -91,6 +91,7 @@ void end_primitive_tracking(
 void finalize_stream(Stream s);
 void synchronize_stream(Stream s);
 void set_force_immediate_submit(Stream s);
+void set_decode_batch_default(bool enabled);
 void synchronize_all();
 void synchronize_buffer_for_host_access(VulkanBuffer* buffer);
 

--- a/mlx/backend/vulkan/device_info.cpp
+++ b/mlx/backend/vulkan/device_info.cpp
@@ -82,8 +82,12 @@ device_info(int device_index) {
         vendor_name = "Qualcomm";
         break;
       default:
-        vendor_name =
-            "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        if (device_name.find("Apple") != std::string::npos) {
+          vendor_name = "Apple";
+        } else {
+          vendor_name =
+              "Unknown (0x" + std::to_string(device_props.vendorID) + ")";
+        }
         break;
     }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -788,6 +788,39 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
     result.block_rows = std::max(result.block_rows / 2u, 1u);
   }
 
+
+  if (architecture == vulkan::GpuArchitecture::Apple) {
+    // M1 Pro / honeykrisp measurements (Qwen3-0.6B FA shape Hq=16, Hkv=8,
+    // D in {64,128}, S <= 4096): d_split 4 beats 8 by ~65-70% TFLOPS, and
+    // block_rows 12 beats 8 by ~10% when there are enough query rows.
+    // The scalar kernel is numerically correct only for block_rows that
+    // are multiples of 4 (6/10/14 produce garbage); d_split values other
+    // than powers of two are also slow.
+    if (result.d_split > 4u) {
+      result.d_split = 4u;
+    }
+    if (result.row_split != 1u && n_rows >= 12u &&
+        result.block_rows == 8u) {
+      result.block_rows = 12u;
+    }
+  }
+  if (const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_PARAMS")) {
+    std::istringstream iss(env);
+    std::string item;
+    uint32_t vals[5];
+    int idx = 0;
+    while (idx < 5 && std::getline(iss, item, ',')) {
+      vals[idx++] = static_cast<uint32_t>(std::stoul(item));
+    }
+    if (idx == 5) {
+      result.block_rows = vals[0];
+      result.block_cols = vals[1];
+      result.row_split = vals[2];
+      result.workgroup_size = vals[3];
+      result.d_split = vals[4];
+    }
+  }
+
   return result;
 }
 

--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -804,21 +804,51 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
       result.block_rows = 12u;
     }
   }
-  if (const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_PARAMS")) {
+  static const std::optional<std::array<uint32_t, 5>> fa_env_params = []()
+      -> std::optional<std::array<uint32_t, 5>> {
+    const char* env = std::getenv("MLX_VULKAN_FLASH_ATTN_PARAMS");
+    if (env == nullptr) {
+      return std::nullopt;
+    }
     std::istringstream iss(env);
     std::string item;
-    uint32_t vals[5];
+    std::array<uint32_t, 5> vals{};
     int idx = 0;
     while (idx < 5 && std::getline(iss, item, ',')) {
       vals[idx++] = static_cast<uint32_t>(std::stoul(item));
     }
-    if (idx == 5) {
-      result.block_rows = vals[0];
-      result.block_cols = vals[1];
-      result.row_split = vals[2];
-      result.workgroup_size = vals[3];
-      result.d_split = vals[4];
+
+    // The scalar kernel silently corrupts output outside its validated
+    // envelope (goniz/mlx-vulkan#70): block_rows must be a multiple of 4,
+    // workgroup_size must equal subgroup_size * 4, and non-power-of-two
+    // d_split values are both wrong-shaped and slow. Reject anything else.
+    const uint32_t subgroup_x4 =
+        std::max(vulkan::VulkanContext::get().subgroup_size(), 32u) * 4u;
+    const bool power_of_two_ds = vals[4] != 0u &&
+        (vals[4] & (vals[4] - 1u)) == 0u;
+    const bool in_validated_envelope = idx == 5 && vals[0] % 4u == 0u &&
+        vals[0] >= 4u && (vals[1] == 16u || vals[1] == 32u ||
+                          vals[1] == 64u) &&
+        (vals[2] == 1u || vals[2] == 2u || vals[2] == 4u) &&
+        vals[3] == subgroup_x4 && power_of_two_ds && vals[4] <= 8u;
+    if (!in_validated_envelope) {
+      std::cerr << "[vulkan::fast] MLX_VULKAN_FLASH_ATTN_PARAMS rejected: '"
+                << env << "' is outside the numerically validated envelope "
+                           "(block_rows%4==0 and >=4; block_cols in "
+                           "{16,32,64}; row_split in {1,2,4}; "
+                           "workgroup_size==" << subgroup_x4 <<
+                    "; d_split a power of two <= 8). See "
+                    "goniz/mlx-vulkan#70.\n";
+      return std::nullopt;
     }
+    return vals;
+  }();
+  if (fa_env_params.has_value()) {
+    result.block_rows = (*fa_env_params)[0];
+    result.block_cols = (*fa_env_params)[1];
+    result.row_split = (*fa_env_params)[2];
+    result.workgroup_size = (*fa_env_params)[3];
+    result.d_split = (*fa_env_params)[4];
   }
 
   return result;

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -124,6 +124,29 @@ std::vector<uint32_t> matmul_specialization_constants(
     if (parsed.size() != kDefaultSpec.size()) {
       return std::vector<uint32_t>{};
     }
+
+    // The scalar kernel produces silently wrong results outside its
+    // validated tiling envelope (see goniz/mlx-vulkan#70): BK < 4 breaks
+    // load-address divisors, and warp/workgroup/tile ratios outside the
+    // measured set corrupt output (e.g. BM=64 under-covered by one warp,
+    // WM/WN > subgroup size). Restrict the env override to shapes that
+    // were numerically verified; extend the list only with fresh numerics
+    // gate results.
+    const bool in_validated_envelope =
+        parsed[10] == 32u && parsed[0] == 32u && parsed[1] == 32u &&
+        parsed[2] == 32u && parsed[3] >= 4u && parsed[3] <= 32u &&
+        parsed[3] % 4u == 0u && parsed[4] == 32u && parsed[5] == 32u &&
+        parsed[6] == 2u && (parsed[7] == 2u || parsed[7] == 4u) &&
+        (parsed[8] == 2u || parsed[8] == 4u) && parsed[9] == 1u;
+    if (!in_validated_envelope) {
+      std::cerr
+          << "[vulkan::kernels] MLX_VULKAN_MATMUL_SPEC rejected: shape "
+             "outside the numerically validated envelope "
+             "(BLOCK,BM,BN must be 32; WM,WN must be 32; WMITER must be 2; "
+             "TK must be 1; WARP must be 32; BK in {4,8,16,32}; "
+             "TM,TN in {2,4}). See goniz/mlx-vulkan#70.\n";
+      return std::vector<uint32_t>{};
+    }
     return parsed;
   }();
   if (!kEnvSpec.empty()) {

--- a/mlx/backend/vulkan/matmul.cpp
+++ b/mlx/backend/vulkan/matmul.cpp
@@ -346,6 +346,13 @@ constexpr std::array<uint32_t, 11> kSafeMatmulSpec =
 constexpr std::array<uint32_t, 11> kLane64MatmulSpec =
     {64, 32, 32, 16, 32, 32, 2, 2, 2, 1, 64};
 
+// Apple AGX (M-series via Mesa honeykrisp): scalar mul_mm prefers a shallow
+// K slab (BK=4) with a 4-row thread tile for occupancy. Measured on M1 Pro
+// Qwen3-0.6B prefill shapes: 1117 GFLOPS avg vs 627 for kSafeMatmulSpec
+// (+78%). BK<=2 is numerically broken in the scalar shader (rel err ~400).
+constexpr std::array<uint32_t, 11> kAppleMatmulSpec =
+    {32, 32, 32, 4, 32, 32, 2, 4, 2, 1, 32};
+
 // Cooperative-matrix warptiles (TM/TN/TK must match 16x16x16 subgroup mats).
 // On Strix Halo / RDNA3.5 the llama.cpp "large" 128x128/256-thread tile is
 // ~10x slower than this medium tile for dense F16 GEMMs; keep one known-good
@@ -626,7 +633,6 @@ MatmulProfile matmul_profile_for_device() {
             {kSafeMatmulSpec, 4096}}},
       };
     case vulkan::GpuArchitecture::Intel:
-    case vulkan::GpuArchitecture::Apple:
     case vulkan::GpuArchitecture::Qualcomm:
       return {
           32,
@@ -636,6 +642,16 @@ MatmulProfile matmul_profile_for_device() {
           {{{kSafeMatmulSpec, 512},
             {kSafeMatmulSpec, 1024},
             {kSafeMatmulSpec, 2048}}},
+      };
+    case vulkan::GpuArchitecture::Apple:
+      return {
+          32,
+          {{{kAppleMatmulSpec, 768},
+            {kAppleMatmulSpec, 1536},
+            {kAppleMatmulSpec, 3072}}},
+          {{{kAppleMatmulSpec, 512},
+            {kAppleMatmulSpec, 1024},
+            {kAppleMatmulSpec, 2048}}},
       };
     case vulkan::GpuArchitecture::AmdCdna:
     case vulkan::GpuArchitecture::Unknown:

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -218,6 +218,10 @@ GpuArchitecture classify_gpu_architecture(
     case 0x5143u:
       return GpuArchitecture::Qualcomm;
     default:
+      if (device_name_contains(device_name, "Apple")) {
+        // Mesa honeykrisp reports a non-PCI vendorID on Apple Silicon.
+        return GpuArchitecture::Apple;
+      }
       return GpuArchitecture::Unknown;
   }
 }

--- a/mlx/backend/vulkan/vulkan.cpp
+++ b/mlx/backend/vulkan/vulkan.cpp
@@ -1105,6 +1105,19 @@ void VulkanContext::init() {
     this->device_id_ = device_id;
     this->architecture_ = architecture;
     this->shader_core_count_ = shader_core_count;
+    // Mesa honeykrisp has high per-submit cost: prefer long decode recordings
+    // on Apple GPUs (byte budget bounded in decode_max_total_bytes()).
+    set_decode_batch_default(architecture == vulkan::GpuArchitecture::Apple);
+    if (bf16_capability_debug_enabled()) {
+      std::cerr << "[vulkan::caps] ext_coopmat=" << has_cooperative_matrix_ext
+                << " feat_coopmat="
+                << supported_cooperative_matrix.cooperativeMatrix
+                << " coopmat=" << cooperative_matrix_supported_
+                << " f16acc=" << this->coopmat_f16acc_supported_
+                << " fa_f32acc="
+                << this->coopmat_flash_attention_f32acc_supported_
+                << " subgroup_full=" << subgroup_require_full_support << "\n";
+    }
     initialized_ = true;
   } catch (...) {
     // Clean up partially initialized resources on failure


### PR DESCRIPTION
# fix(vulkan): reject tuning specs outside numerically validated envelopes

**Stacked on #69 → #70 → #71 → #72.** Tracking issue: goniz/mlx-vulkan#70.

## Problem

The scalar `mul_mm` and flash-attention kernels produce **silently wrong results** for tiling shapes outside the envelope their load/coverage math assumes. During the tuning work in #70/#71, every out-of-envelope candidate was caught only because each sweep was gated on numerics against an f32 reference:

| kernel | corrupting shape | observed error |
|---|---|---|
| scalar matmul | `BK <= 2` (bf16) | rel err ~400 |
| scalar matmul | `BM=64` with single-warp M coverage | rel err ~1 |
| scalar matmul | `WM`/`WN` > subgroup size (`64×64` warp tile @ 32 lanes) | rel err ~1.7·10⁸ |
| scalar FA | `block_rows % 4 != 0` (6/10/14) | rel err ~2·10⁷ |
| scalar FA | `workgroup_size != subgroup_size * 4` (64/256) | rel err ~0.5–0.95 |

Root cause analysis posted at [#70 comment](https://github.com/goniz/mlx-vulkan/issues/70#issuecomment-5388444560): F16/F32 hardcode `BK 32` ignoring spec constant 3; bf16/quant consume it, but the load-coverage math (`mul_mm.comp:210–216`) degenerates for small BK and the warp-grid mapping under-covers tiles when `BM/WM` exceeds the available warps.

Without guards, any user experiment via `MLX_VULKAN_MATMUL_SPEC` / `MLX_VULKAN_FLASH_ATTN_PARAMS` — or any future tuning attempt — can silently return wrong numbers.

## What changed

Both env knobs now validate against the **measured-and-numerics-verified envelope** before dispatching:

- `MLX_VULKAN_MATMUL_SPEC`: rejects shapes outside `{BLOCK,BM,BN}=32, WM=WN=32, WMITER=2, TK=1, WARP=subgroup(32), BK∈{4,8,16,32}, TM,TN∈{2,4}` with a one-time diagnostic pointing at #70; falls back to the device profile.
- `MLX_VULKAN_FLASH_ATTN_PARAMS`: requires `block_rows % 4 == 0 && ≥ 4`, `block_cols ∈ {16,32,64}`, `row_split ∈ {1,2,4}`, `workgroup_size == subgroup*4`, `d_split` power-of-two ≤ 8; same rejection behavior. Parsing is cached (one diagnostic per process, not per dispatch).

Device profiles are untouched — their shapes are curated per architecture arm (#70, #71). The envelopes are intentionally conservative; extend them only with fresh numerics-gate results (methodology: compare against composed f32 reference, max rel err < 0.02).

## Verification (M1 Pro / honeykrisp)

```bash
./dev.sh build
# rejected + correct fallback:
MLX_VULKAN_MATMUL_SPEC="32,32,32,2,32,32,2,2,2,1,32" ./dev.sh run python <gemm bench>
# -> [vulkan::kernels] MLX_VULKAN_MATMUL_SPEC rejected: ... ; numerics OK
# valid spec still applies:
MLX_VULKAN_MATMUL_SPEC="32,32,32,4,32,32,2,4,2,1,32" ...   # 1114 GFLOPS OK
# FA: block_rows=6 rejected once, defaults used; block_rows=12 passes (0.35 TFLOPS)
```

## Scope note

This PR makes bad configs **loud**, not fast. Actually supporting small-BK/large-tile shapes correctly requires reworking the load-addressing and warp-coverage math (day-scale; est. +50% GEMM ≈ +5% end-to-end prompt given attention dominance) — tracked in #70 with the analysis above.
