### PR TITLE
fix(vulkan): tighten matmul/FA env envelope checks

### DIFF
--- a/mlx/backend/vulkan/fast.cpp
+++ b/mlx/backend/vulkan/fast.cpp
@@ -821,23 +821,33 @@ FlashAttentionTuningParams get_flash_attention_tuning_params_scalar(
     // The scalar kernel silently corrupts output outside its validated
     // envelope (goniz/mlx-vulkan#70): block_rows must be a multiple of 4,
     // workgroup_size must equal subgroup_size * 4, and non-power-of-two
-    // d_split values are both wrong-shaped and slow. Reject anything else.
+    // d_split values are both wrong-shaped and slow. Also require the
+    // same block_cols % (wg/ds/rs) divisibility the host dispatch gate
+    // uses, so a bad override rejects loudly instead of quietly skipping
+    // the Vulkan FA path.
     const uint32_t subgroup_x4 =
         std::max(vulkan::VulkanContext::get().subgroup_size(), 32u) * 4u;
     const bool power_of_two_ds = vals[4] != 0u &&
         (vals[4] & (vals[4] - 1u)) == 0u;
+    const uint32_t cols_per_iter =
+        (idx == 5 && vals[2] != 0u && vals[4] != 0u) ? (vals[3] / vals[4] / vals[2])
+                                                     : 0u;
+    const bool tile_ok =
+        cols_per_iter != 0u && (vals[1] % cols_per_iter) == 0u;
     const bool in_validated_envelope = idx == 5 && vals[0] % 4u == 0u &&
         vals[0] >= 4u && (vals[1] == 16u || vals[1] == 32u ||
                           vals[1] == 64u) &&
         (vals[2] == 1u || vals[2] == 2u || vals[2] == 4u) &&
-        vals[3] == subgroup_x4 && power_of_two_ds && vals[4] <= 8u;
+        vals[3] == subgroup_x4 && power_of_two_ds && vals[4] <= 8u &&
+        tile_ok;
     if (!in_validated_envelope) {
       std::cerr << "[vulkan::fast] MLX_VULKAN_FLASH_ATTN_PARAMS rejected: '"
                 << env << "' is outside the numerically validated envelope "
                            "(block_rows%4==0 and >=4; block_cols in "
                            "{16,32,64}; row_split in {1,2,4}; "
                            "workgroup_size==" << subgroup_x4 <<
-                    "; d_split a power of two <= 8). See "
+                    "; d_split a power of two <= 8; "
+                    "block_cols % (wg/d_split/row_split) == 0). See "
                     "goniz/mlx-vulkan#70.\n";
       return std::nullopt;
     }

--- a/mlx/backend/vulkan/kernels.cpp
+++ b/mlx/backend/vulkan/kernels.cpp
@@ -131,11 +131,13 @@ std::vector<uint32_t> matmul_specialization_constants(
     // measured set corrupt output (e.g. BM=64 under-covered by one warp,
     // WM/WN > subgroup size). Restrict the env override to shapes that
     // were numerically verified; extend the list only with fresh numerics
-    // gate results.
+    // gate results. BK must be an explicit measured member — not just
+    // any multiple of 4 in [4, 32].
+    const bool bk_ok = parsed[3] == 4u || parsed[3] == 8u ||
+        parsed[3] == 16u || parsed[3] == 32u;
     const bool in_validated_envelope =
         parsed[10] == 32u && parsed[0] == 32u && parsed[1] == 32u &&
-        parsed[2] == 32u && parsed[3] >= 4u && parsed[3] <= 32u &&
-        parsed[3] % 4u == 0u && parsed[4] == 32u && parsed[5] == 32u &&
+        parsed[2] == 32u && bk_ok && parsed[4] == 32u && parsed[5] == 32u &&
         parsed[6] == 2u && (parsed[7] == 2u || parsed[7] == 4u) &&
         (parsed[8] == 2u || parsed[8] == 4u) && parsed[9] == 1u;
     if (!in_validated_envelope) {


### PR DESCRIPTION
## Summary
- Follow-up to #73: require matmul env `BK` to be an explicit measured member of `{4,8,16,32}` instead of any multiple of 4 in `[4,32]` (so untested `BK=12/20/24/28` are rejected).
- Reject `MLX_VULKAN_FLASH_ATTN_PARAMS` overrides that fail the host `block_cols % (wg/d_split/row_split) == 0` divisibility gate, matching dispatch, so bad combos fail loudly instead of quietly skipping the Vulkan FA path.

## Test plan
- [x] `./dev.sh build`
- [x] `./dev.sh benchmark bf16`
- [x] `./dev.sh benchmark 8bit`

## Benchmarks (Strix Halo / this host)

| Quant | Prompt TPS | Gen TPS | Peak mem |
| --- | ---: | ---: | ---: |
| bf16 | 4260.773 | 66.965 | 2.262 GB |
| 8bit | 4236.018 | 117.603 | 2.005 GB |

Default (no env override) paths are unchanged; only debug env validation is tighter.

Made with [Cursor](https://cursor.com)